### PR TITLE
Remove wrong restrictions on maxFragmentCombinedOutputResources value

### DIFF
--- a/correspondence/index.bs
+++ b/correspondence/index.bs
@@ -102,11 +102,11 @@ User agents are not required to use these formulas and may expose whatever they 
                 [Root Signature Limits](https://docs.microsoft.com/en-us/windows/win32/direct3d12/root-signature-limits)
     </thead>
     <tr>
-        <th><p class=issue>need a max buffer size limit
+        <th>`maxBufferSize`
         <td>[#1371](https://github.com/gpuweb/gpuweb/issues/1371)
         <td>`maxMemoryAllocationSize`
         <td>`MTLDevice.maxBufferLength`
-        <td><p class=issue>*No documented limit?*
+        <td>*No documented limit.* Implementations could use a constant, or determine this based on the amount of VRAM on the system as D3D11 FL11's [soft resource size limit](https://learn.microsoft.com/en-us/windows/win32/direct3d11/overviews-direct3d-11-resources-limits) does.
     <tr>
         <th>`maxTextureDimension1D`
         <td>[#1327](https://github.com/gpuweb/gpuweb/issues/1327)
@@ -116,7 +116,7 @@ User agents are not required to use these formulas and may expose whatever they 
     <tr>
         <th>`maxTextureDimension2D`
         <td>[#1327](https://github.com/gpuweb/gpuweb/issues/1327)
-        <td>`min(maxImageDimension2D, maxImageDimensionCube)`
+        <td>`min(maxImageDimension2D, maxImageDimensionCube, maxFramebufferWidth, maxFramebufferHeight, maxViewportDimensions[0], maxViewportDimensions[1], viewportBoundsRange[0], -viewportBoundsRange[1])`
         <td>min(`Maximum 2D texture width and height`, `Maximum cube map texture width and height`)
         <td>16384 = `min(D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION, D3D12_REQ_TEXTURECUBE_DIMENSION)`
     <tr>
@@ -167,7 +167,7 @@ User agents are not required to use these formulas and may expose whatever they 
         <th>`maxStorageTexturesPerShaderStage`
         <td>[#409](https://github.com/gpuweb/gpuweb/issues/409)
         <td>`maxPerStageDescriptorStorageImages`
-        <td rowspan=2>*Strategy-dependent.* Allocate `Maximum number of Unordered Access Views in all descriptor tables across all stages` across these two limits.
+        <td rowspan=2>*Strategy-dependent.* Allocate `Maximum number of Unordered Access Views in all descriptor tables across all stages` (guaranteed to be 64) across stages across these two limits. For example, 32 for each shader stage, split as 16 textures and 16 buffers per shader stage.
     <tr>
         <th>`maxStorageBuffersPerShaderStage`
         <td>[#409](https://github.com/gpuweb/gpuweb/issues/409)
@@ -184,17 +184,21 @@ User agents are not required to use these formulas and may expose whatever they 
         <td>`maxVertexInputBindings`
         <td>[16](https://docs.microsoft.com/en-ca/windows/win32/api/d3d12/ns-d3d12-d3d12_input_element_desc)
     <tr>
+        <th>`maxFragmentCombinedOutputResources`
+        <td>[#3829](https://github.com/gpuweb/gpuweb/pull/3829), [#1343](https://github.com/gpuweb/gpuweb/issues/1343)
+        <td>`maxFragmentCombinedOutputResources`
+        <td colspan=2>*No separate limit.* Use `maxColorAttachments + maxStorageBuffersPerShaderStage + maxStorageTexturesPerShaderStage`.
+    <tr>
         <th>`maxUniformBufferBindingSize`
         <td>[#803](https://github.com/gpuweb/gpuweb/issues/803)
         <td>`maxUniformBufferRange`
-        <td>*No documented limit.* Use `maxBufferSize`.
+        <td>*No documented limit.* Use `maxBufferSize` or choose a constant.
         <td>65536 = `D3D12_REQ_CONSTANT_BUFFER_ELEMENT_COUNT * sizeof(float4)`
     <tr>
         <th>`maxStorageBufferBindingSize`
         <td>[#1163](https://github.com/gpuweb/gpuweb/issues/1163)
         <td>`maxStorageBufferRange`
-        <td>*No documented limit.* Use `maxBufferSize`.
-        <td><p class=issue>*No documented limit.* Use 4 GiB, or 2 GiB if that's problematic?
+        <td colspan=2>*No documented limit.* Use `maxBufferSize` or choose a constant.
     <tr>
         <th>`minUniformBufferOffsetAlignment`
         <td>[#1863](https://github.com/gpuweb/gpuweb/issues/1863)
@@ -234,7 +238,7 @@ User agents are not required to use these formulas and may expose whatever they 
     <tr>
         <th>`maxColorAttachments`
         <td>[#2820](https://github.com/gpuweb/gpuweb/issues/2820)
-        <td>`min(maxColorAttachments, maxFragmentOutputAttachments)`
+        <td>`min(maxColorAttachments, maxFragmentOutputAttachments, maxFragmentCombinedOutputResources)`
         <td>`Maximum number of color render targets per render
     pass descriptor`
         <td>8 = `D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT`

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1632,8 +1632,6 @@ applications should generally request the "worst" limits that work for their con
         and color attachments in a {{GPURenderPipelineDescriptor}}.
 
         The [=supported limit=] for an [=adapter=] must be
-        &ge; {{supported limits/maxStorageBuffersPerShaderStage}},
-        &ge; {{supported limits/maxStorageTexturesPerShaderStage}}, and
         &ge; {{supported limits/maxColorAttachments}}.
 
     <tr><td><dfn>maxUniformBufferBindingSize</dfn>


### PR DESCRIPTION
maxFragmentCombinedOutputResources only applies to fragment shaders, while maxStorage{Buffers,Textures}PerShaderStage apply to compute/vertex shaders as well. So we shouldn't have restrictions between those limits as exposed by adapters.

This also simplifies how implementations determine which values to expose for the three related limits (max storage buffers, max storage textures, max color attachments). This wasn't reflected in the correspondence doc, but prior to adding this limit it would have been necessary to statically choose an allocation of those three limits such that their sum was < `maxFragmentCombinedOutputResources`.

Also update some other parts of the correspondence doc.

Thanks @austinEng for finding this issue (and PTAL)

Related issues: #3829, #1343, #3916, #1371