### PR TITLE
[editorial] Make a new section for Adapter Capability Guarantees

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1433,6 +1433,15 @@ describe WebGPU functionality that differs between different implementations,
 typically due to hardware or system software constraints.
 A [=capability=] is either a [=feature=] or a [=limit=].
 
+The capabilities of an [=adapter=] must conform to [[#adapter-capability-guarantees]].
+
+Only supported capabilities may be requested in {{GPUAdapter/requestDevice()}};
+requesting unsupported capabilities results in failure.
+
+The capabilities of a [=device=] are exactly the ones which were requested in
+{{GPUAdapter/requestDevice()}}. These capabilities are enforced regardless of the
+capabilities of the [=adapter=].
+
 <p tracking-vector>
 For privacy considerations, see [[#privacy-machine-limits]].
 
@@ -1440,9 +1449,6 @@ For privacy considerations, see [[#privacy-machine-limits]].
 
 A <dfn dfn>feature</dfn> is a set of optional WebGPU functionality that is not supported
 on all implementations, typically due to hardware or system software constraints.
-
-Each {{GPUAdapter}} exposes a set of available features.
-Only those features may be requested in {{GPUAdapter/requestDevice()}}.
 
 Functionality that is part of a feature may only be used if the feature was requested at device
 creation (in {{GPUDeviceDescriptor/requiredFeatures}}).
@@ -1466,11 +1472,6 @@ See the [[#feature-index|Feature Index]] for a description of the functionality 
 ### Limits ### {#limits}
 
 Each <dfn dfn>limit</dfn> is a numeric limit on the usage of WebGPU on a device.
-
-A <dfn dfn>supported limits</dfn> object has a value for every defined limit.
-Each [=adapter=] has a set of [=supported limits=], and
-[=devices=] are {{GPUDeviceDescriptor/requiredLimits|created}} with specific [=supported limits=] in place.
-The device limits are enforced regardless of the adapter's limits.
 
 Each limit has a <dfn dfn for=limit>default</dfn> value.
 Every [=adapter=] is guaranteed to support the default value or [=limit/better=].
@@ -1509,6 +1510,8 @@ Setting "better" limits may not necessarily be desirable, as they may have a per
 Because of this, and to improve portability across devices and implementations,
 applications should generally request the "worst" limits that work for their content
 (ideally, the default values).
+
+A <dfn dfn>supported limits</dfn> object has a value for every limit defined by WebGPU:
 
 <table class="data no-colspan-center" dfn-type=attribute dfn-for="supported limits">
     <thead>
@@ -1551,20 +1554,6 @@ applications should generally request the "worst" limits that work for their con
     <tr class=row-continuation><td colspan=4>
         The maximum allowed number of {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}
         values when creating a {{GPUBindGroupLayout}}.
-
-        The [=supported limit=] for an [=adapter=] must be &ge;
-        ([=max bindings per shader stage=] &times; [=max shader stages per pipeline=]) for the same
-        [=adapter=].
-
-        <dfn dfn for=>max bindings per shader stage</dfn> is
-        ({{supported limits/maxSampledTexturesPerShaderStage}} +
-        {{supported limits/maxSamplersPerShaderStage}} +
-        {{supported limits/maxStorageBuffersPerShaderStage}} +
-        {{supported limits/maxStorageTexturesPerShaderStage}} +
-        {{supported limits/maxUniformBuffersPerShaderStage}}).
-
-        <dfn dfn for=>max shader stages per pipeline</dfn> is `2`, because a
-        {{GPURenderPipeline}} supports both a vertex and fragment shader.
 
         Note: 640 "ought to be enough for anybody" who is using the default
         [=exceeds the binding slot limits|binding slot limits=].
@@ -1631,9 +1620,6 @@ applications should generally request the "worst" limits that work for their con
         {{GPUShaderStage/FRAGMENT}}-stage storage textures,
         and color attachments in a {{GPURenderPipelineDescriptor}}.
 
-        The [=supported limit=] for an [=adapter=] must be
-        &ge; {{supported limits/maxColorAttachments}}.
-
     <tr><td><dfn>maxUniformBufferBindingSize</dfn>
         <td>{{GPUSize64}} <td>[=limit class/maximum=] <td>65536 bytes
     <tr class=row-continuation><td colspan=4>
@@ -1660,10 +1646,6 @@ applications should generally request the "worst" limits that work for their con
         |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
         is {{GPUBufferBindingType/"uniform"}}.
 
-        The [=supported limit=] for an [=adapter=] **must not** be &lt; 32 bytes.
-
-        Note: 32 bytes would be the alignment of `vec4<f64>`. See [[WGSL#alignment-and-size]].
-
     <tr><td><dfn>minStorageBufferOffsetAlignment</dfn>
         <td>{{GPUSize32}} <td>[=limit class/alignment=] <td>256 bytes
     <tr class=row-continuation><td colspan=4>
@@ -1673,10 +1655,6 @@ applications should generally request the "worst" limits that work for their con
         |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
         is {{GPUBufferBindingType/"storage"}}
         or {{GPUBufferBindingType/"read-only-storage"}}.
-
-        The [=supported limit=] for an [=adapter=] **must not** be &lt; 32 bytes.
-
-        Note: 32 bytes would be the alignment of `vec4<f64>`. See [[WGSL#alignment-and-size]].
 
     <tr><td><dfn>maxVertexBuffers</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8
@@ -1689,10 +1667,6 @@ applications should generally request the "worst" limits that work for their con
     <tr class=row-continuation><td colspan=4>
         The maximum size of {{GPUBufferDescriptor/size}}
         when creating a {{GPUBuffer}}.
-
-        The [=supported limit=] for an [=adapter=] must be
-        &ge; {{supported limits/maxUniformBufferBindingSize}} and
-        &ge; {{supported limits/maxStorageBufferBindingSize}}.
 
     <tr><td><dfn>maxVertexAttributes</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16
@@ -2282,7 +2256,8 @@ interface GPU {
                 1. Let |adapter| be `null`.
                 1. If the user agent chooses to return an adapter, it should:
                     1. Set |adapter| to a [=valid=] [=adapter=], chosen according to
-                        the rules in [[#adapter-selection]] and the criteria in |options|.
+                        the rules in [[#adapter-selection]] and the criteria in |options|,
+                        adhering to [[#adapter-capability-guarantees]].
 
                         The [=supported limits=] of the adapter must adhere to the requirements
                         defined in [[#limits]].
@@ -2370,6 +2345,39 @@ calling {{GPUAdapter/requestDevice()}}.
         const gpuAdapter = await navigator.gpu.requestAdapter();
     </pre>
 </div>
+
+### Adapter Capability Guarantees ### {#adapter-capability-guarantees}
+
+Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the following guarantees:
+
+- At least one of the following must be true:
+    - {{GPUFeatureName/"texture-compression-bc"}} is supported.
+    - Both {{GPUFeatureName/"texture-compression-etc2"}} and
+        {{GPUFeatureName/"texture-compression-astc"}} are supported.
+- All supported limits must be either the [=limit/default=] value or [=limit/better=].
+- {{supported limits/maxBindingsPerBindGroup}} must be must be &ge;
+    ([=max bindings per shader stage=] &times; [=max shader stages per pipeline=]), where:
+
+    - <dfn dfn for=>max bindings per shader stage</dfn> is
+        ({{supported limits/maxSampledTexturesPerShaderStage}} +
+        {{supported limits/maxSamplersPerShaderStage}} +
+        {{supported limits/maxStorageBuffersPerShaderStage}} +
+        {{supported limits/maxStorageTexturesPerShaderStage}} +
+        {{supported limits/maxUniformBuffersPerShaderStage}}).
+    - <dfn dfn for=>max shader stages per pipeline</dfn> is `2`, because a
+        {{GPURenderPipeline}} supports both a vertex and fragment shader.
+
+    Note: {{supported limits/maxBindingsPerBindGroup}} does not reflect a fundamental limit;
+    implementations should raise it to conform to this requirement, rather than lowering the
+    other limits.
+
+- {{supported limits/maxColorAttachments}} must be &le; {{supported limits/maxFragmentCombinedOutputResources}}.
+- {{supported limits/minUniformBufferOffsetAlignment}} and
+    {{supported limits/minStorageBufferOffsetAlignment}} must both be &ge; 32 bytes.
+
+        Note: 32 bytes would be the alignment of `vec4<f64>`. See [[WGSL#alignment-and-size]].
+- {{supported limits/maxUniformBufferBindingSize}} must be &le; {{supported limits/maxBufferSize}}.
+- {{supported limits/maxStorageBufferBindingSize}} must be &le; {{supported limits/maxBufferSize}}.
 
 ### Adapter Selection ### {#adapter-selection}
 


### PR DESCRIPTION
This section lists the (BC || (ETC2 && ASTC)) guarantee, and subsumes all of the relative guarantees between different limits.

Plus a little editorial cleanup.

Fixes #2083