### PR TITLE
[editorial] Justify GPUStorageTextureAccess when it only has one value

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5748,8 +5748,11 @@ dictionary GPUStorageTextureBindingLayout {
 <dl dfn-type=dict-member dfn-for=GPUStorageTextureBindingLayout>
     : <dfn>access</dfn>
     ::
-        Indicates whether texture views bound to this binding will be bound for read-only or
-        write-only access.
+        The access mode for this binding, indicating readability and writability.
+
+        Note:
+        There is currently only one access mode, {{GPUStorageTextureAccess/"write-only"}},
+        but this will expand in the future.
 
     : <dfn>format</dfn>
     ::


### PR DESCRIPTION
Fixes #3418