### PR TITLE
[editorial] Clearly distinguish texel copy footprints vs memory costs

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4704,8 +4704,13 @@ The <dfn dfn>texel block width</dfn> and <dfn dfn>texel block height</dfn> speci
     and the [=texel block height=] is the number of texel rows in one [=texel block=]. See [[#texture-format-caps]] for an exhaustive list
     of values for every texture format.
 
-The <dfn dfn>texel block size</dfn> of a {{GPUTextureFormat}} is the number of bytes to store one [=texel block=].
-The [=texel block size=] of each {{GPUTextureFormat}} is constant except for {{GPUTextureFormat/"stencil8"}}, {{GPUTextureFormat/"depth24plus"}}, and {{GPUTextureFormat/"depth24plus-stencil8"}}.
+The <dfn dfn>texel block copy footprint</dfn> of an [=aspect=] of a {{GPUTextureFormat}} is the number of
+bytes one texel block occupies during an [=image copy=], if applicable.
+
+Note:
+The <dfn dfn>texel block memory cost</dfn> of a {{GPUTextureFormat}} is the number of
+bytes needed to store one [=texel block=]. It is not fully defined for all formats.
+**This value is informative and non-normative.**
 
 <script type=idl>
 enum GPUTextureFormat {
@@ -9495,8 +9500,8 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                             - Set |aspectSpecificFormat| to the [=aspect-specific format=] according to [[#depth-formats]].
                         - [=validating texture copy range=](|destination|, |copySize|) return `true`.
                         - If |dstTexture|.{{GPUTexture/format}} is not a [=depth-or-stencil format=]:
-                            - |source|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                                |dstTexture|.{{GPUTexture/format}}.
+                            - |source|.{{GPUImageDataLayout/offset}} is a multiple of the
+                                [=texel block copy footprint=] of |dstTexture|.{{GPUTexture/format}}.
                         - If |dstTexture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
                             - |source|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                         - [$validating linear texture data$](|source|,
@@ -9563,8 +9568,8 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                             {{GPUBufferUsage/COPY_DST}}.
                         - [=validating texture copy range=](|source|, |copySize|) returns `true`.
                         - If |srcTexture|.{{GPUTexture/format}} is not a [=depth-or-stencil format=]:
-                            - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                                |srcTexture|.{{GPUTexture/format}}.
+                            - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the
+                                [=texel block copy footprint=] of |srcTexture|.{{GPUTexture/format}}.
                         - If |srcTexture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                         - [$validating linear texture data$](|destination|,
@@ -14768,6 +14773,14 @@ The {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/STORAGE_BINDING}
 specify support for {{GPUTextureUsage/RENDER_ATTACHMENT|GPUTextureUsage.RENDER_ATTACHMENT}}
 and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage respectively.
 
+The <dfn dfn>render target pixel byte cost</dfn>
+and <dfn dfn>render target component alignment</dfn>
+are used to validate the {{supported limits/maxColorAttachmentBytesPerSample}} limit.
+
+Note:
+The [=texel block memory cost=] of each of these formats is the same as its
+[=texel block copy footprint=].
+
 <table class=data>
     <thead class=stickyheader>
         <tr>
@@ -14778,11 +14791,10 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
             <th><span class=vertical>multisampling</span>
             <th><span class=vertical>resolve</span>
             <th><span class=vertical>{{GPUTextureUsage/STORAGE_BINDING}}</span>
-            <th>[=Texel block size=] (Bytes)
-            <th><dfn dfn>Render target pixel byte cost</dfn> (Bytes)
-            <th><dfn dfn>Render target component alignment</dfn> (Bytes)
+            <th>[=Texel block copy footprint=] (Bytes)
+            <th>[=Render target pixel byte cost=] (Bytes)
     </thead>
-    <tr><th>8-bit per component
+    <tr><th colspan=10>8 bits per component (1-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14791,9 +14803,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>
-        <td>1
-        <td>1
-        <td>1
+        <td colspan=2>1
     <tr>
         <td>{{GPUTextureFormat/r8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14802,9 +14812,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td><!-- Vulkan -->
-        <td>1
-        <td>&ndash; <!-- no render target -->
-        <td>&ndash; <!-- no render target -->
+        <td colspan=1>1
+        <td colspan=1>&ndash; <!-- no render target -->
     <tr>
         <td>{{GPUTextureFormat/r8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14813,9 +14822,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
-        <td>1
-        <td>1
-        <td>1
+        <td colspan=2>1
     <tr>
         <td>{{GPUTextureFormat/r8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -14824,9 +14831,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
-        <td>1
-        <td>1
-        <td>1
+        <td colspan=2>1
     <tr>
         <td>{{GPUTextureFormat/rg8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14835,9 +14840,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Vulkan -->
-        <td>2
-        <td>2
-        <td>1
+        <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/rg8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14846,9 +14849,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td><!-- Vulkan -->
-        <td>2
-        <td>&ndash; <!-- no render target -->
-        <td>&ndash; <!-- no render target -->
+        <td colspan=1>2
+        <td colspan=1>&ndash; <!-- no render target -->
     <tr>
         <td>{{GPUTextureFormat/rg8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14857,9 +14859,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
-        <td>2
-        <td>2
-        <td>1
+        <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/rg8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -14868,9 +14868,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
-        <td>2
-        <td>2
-        <td>1
+        <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14879,9 +14877,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-        <td>4
-        <td>8
-        <td>1
+        <td colspan=1>4
+        <td colspan=1>8
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14890,9 +14887,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>
-        <td>4
-        <td>8
-        <td>1
+        <td colspan=1>4
+        <td colspan=1>8
     <tr>
         <td>{{GPUTextureFormat/rgba8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14901,9 +14897,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td>&checkmark;
-        <td>4
-        <td>&ndash; <!-- no render target --> <!-- If we add render target support for this in the future, rgba8snorm has to be a special case where the render target pixel byte cost = 8 -->
-        <td>&ndash; <!-- no render target -->
+        <td colspan=1>4
+        <td colspan=1>&ndash; <!-- no render target --> <!-- If we add render target support for this in the future, rgba8snorm has to be a special case where the render target pixel byte cost = 8 -->
     <tr>
         <td>{{GPUTextureFormat/rgba8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14912,9 +14907,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
-        <td>4
-        <td>4
-        <td>1
+        <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/rgba8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -14923,9 +14916,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
-        <td>4
-        <td>4
-        <td>1
+        <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14934,9 +14925,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>If {{GPUFeatureName/"bgra8unorm-storage"}} is enabled
-        <td>4
-        <td>8
-        <td>1
+        <td colspan=1>4
+        <td colspan=1>8
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14945,10 +14935,9 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>
-        <td>4
-        <td>8
-        <td>1
-    <tr><th>16-bit per component
+        <td colspan=1>4
+        <td colspan=1>8
+    <tr><th colspan=10>16 bits per component (2-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14957,9 +14946,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
-        <td>2
-        <td>2
-        <td>2
+        <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/r16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -14968,9 +14955,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
-        <td>2
-        <td>2
-        <td>2
+        <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/r16float}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14979,9 +14964,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>
-        <td>2
-        <td>2
-        <td>2
+        <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/rg16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14990,9 +14973,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
-        <td>4
-        <td>4
-        <td>2
+        <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/rg16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -15001,9 +14982,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
-        <td>4
-        <td>4
-        <td>2
+        <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/rg16float}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -15012,9 +14991,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Vulkan -->
-        <td>4
-        <td>4
-        <td>2
+        <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/rgba16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -15023,9 +15000,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
-        <td>8
-        <td>8
-        <td>2
+        <td colspan=2>8
     <tr>
         <td>{{GPUTextureFormat/rgba16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -15034,9 +15009,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
-        <td>8
-        <td>8
-        <td>2
+        <td colspan=2>8
     <tr>
         <td>{{GPUTextureFormat/rgba16float}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -15045,10 +15018,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-        <td>8
-        <td>8
-        <td>2
-    <tr><th>32-bit per component
+        <td colspan=2>8
+    <tr><th colspan=10>32 bits per component (4-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -15057,9 +15028,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
-        <td>4
-        <td>4
-        <td>4
+        <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/r32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -15068,9 +15037,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
-        <td>4
-        <td>4
-        <td>4
+        <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/r32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -15081,9 +15048,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
-        <td>4
-        <td>4
-        <td>4
+        <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/rg32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -15092,9 +15057,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
-        <td>8
-        <td>8
-        <td>4
+        <td colspan=2>8
     <tr>
         <td>{{GPUTextureFormat/rg32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -15103,9 +15066,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
-        <td>8
-        <td>8
-        <td>4
+        <td colspan=2>8
     <tr>
         <td>{{GPUTextureFormat/rg32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -15116,9 +15077,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
-        <td>8
-        <td>8
-        <td>4
+        <td colspan=2>8
     <tr>
         <td>{{GPUTextureFormat/rgba32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -15127,9 +15086,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
-        <td>16
-        <td>16
-        <td>4
+        <td colspan=2>16
     <tr>
         <td>{{GPUTextureFormat/rgba32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -15138,9 +15095,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
-        <td>16
-        <td>16
-        <td>4
+        <td colspan=2>16
     <tr>
         <td>{{GPUTextureFormat/rgba32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -15151,10 +15106,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
-        <td>16
-        <td>16
-        <td>4
-    <tr><th>mixed component width
+        <td colspan=2>16
+    <tr><th colspan=10>mixed component width, 32 bits per texel (4-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -15163,18 +15116,16 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>
-        <td>4
-        <td>8
-        <td>4
+        <td colspan=1>4
+        <td colspan=1>8
     <tr>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=3>If {{GPUFeatureName/"rg11b10ufloat-renderable"}} is enabled
         <td>
         <td><!-- Vulkan -->
-        <td>4
-        <td>8
-        <td>4
+        <td colspan=1>4
+        <td colspan=1>8
 </table>
 
 ### Depth-stencil formats ### {#depth-formats}
@@ -15195,75 +15146,75 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
     <thead>
         <tr>
             <th>Format
-            <th>Bytes per texel
+            <th class=note>[=Texel block memory cost=] (Bytes)
             <th>Aspect
-            <th>[=Texel block size=] (Bytes)
             <th>{{GPUTextureSampleType}}
             <th>Valid [=image copy=] source
             <th>Valid [=image copy=] destination
+            <th>[=Texel block copy footprint=] (Bytes)
             <th><dfn dfn>Aspect-specific format</dfn>
     </thead>
     <tr>
         <td>{{GPUTextureFormat/stencil8}}
         <td>1 &minus; 4
         <td>stencil
-        <td>1
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
+        <td>1
         <td>{{GPUTextureFormat/stencil8}}
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>2
         <td>depth
-        <td>2
         <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=2>&checkmark;
+        <td>2
         <td>{{GPUTextureFormat/depth16unorm}}
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
         <td>depth
-        <td>&ndash; (<a href="#depthPlus">See prose</a>)
         <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=2>&cross;
+        <td>&ndash;
         <td>{{GPUTextureFormat/depth24plus}}
     <tr>
         <td rowspan=2 style="white-space: nowrap">{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
-        <td>&ndash; (<a href="#depthPlus">See prose</a>)
         <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=2>&cross;
+        <td>&ndash;
         <td>{{GPUTextureFormat/depth24plus}}
     <tr>
         <td>stencil
-        <td>1
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
+        <td>1
         <td>{{GPUTextureFormat/stencil8}}
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
         <td>depth
-        <td>4
         <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=1>&checkmark;
         <td colspan=1>&cross;
+        <td>4
         <td>{{GPUTextureFormat/depth32float}}
     <tr>
         <td rowspan=2 style="white-space: nowrap">{{GPUTextureFormat/depth32float-stencil8}}
         <td rowspan=2>5 &minus; 8
         <td>depth
-        <td>4
         <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=1>&checkmark;
         <td colspan=1>&cross;
+        <td>4
         <td>{{GPUTextureFormat/depth32float}}
     <tr>
         <td>stencil
-        <td>1
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
+        <td>1
         <td>{{GPUTextureFormat/stencil8}}
 </table>
 
@@ -15333,15 +15284,17 @@ type and can be filtered on sampling. None of these formats support multisamplin
 
 A <dfn dfn>compressed format</dfn> is any format with a block size greater than 1&times;1.
 
-The [=texel block size=] (in bytes) of a packed format is equal to the Bytes per block column below.
+Note:
+The [=texel block memory cost=] of each of these formats is the same as its
+[=texel block copy footprint=].
 
 <table class=data>
     <thead class=stickyheader>
         <tr>
             <th>Format
-            <th>Bytes per block
+            <th>[=Texel block copy footprint=] (Bytes)
             <th>{{GPUTextureSampleType}}
-            <th>Block Size
+            <th>Texel block [=texel block width|width=]/[=texel block height|height=]
             <th>[=Feature=]
     </thead>
     <tr>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14794,7 +14794,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
             <th>[=Texel block copy footprint=] (Bytes)
             <th>[=Render target pixel byte cost=] (Bytes)
     </thead>
-    <tr><th colspan=10>8 bits per component (1-byte [=render target component alignment=])
+    <tr><th colspan=9>8 bits per component (1-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14937,7 +14937,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td colspan=1>4
         <td colspan=1>8
-    <tr><th colspan=10>16 bits per component (2-byte [=render target component alignment=])
+    <tr><th colspan=9>16 bits per component (2-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -15019,7 +15019,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td colspan=2>8
-    <tr><th colspan=10>32 bits per component (4-byte [=render target component alignment=])
+    <tr><th colspan=9>32 bits per component (4-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -15107,7 +15107,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td>&checkmark;
         <td colspan=2>16
-    <tr><th colspan=10>mixed component width, 32 bits per texel (4-byte [=render target component alignment=])
+    <tr><th colspan=9>mixed component width, 32 bits per texel (4-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -305,7 +305,7 @@ dictionary GPUImageCopyExternalImage {
             [=Assert=] this is an integer.
         - |heightInBlocks| be |copyExtent|.[=Extent3D/height=] &divide; the [=texel block height=] of |format|.
             [=Assert=] this is an integer.
-        - |bytesInLastRow| be |widthInBlocks| &times; the [=texel block size|size=] of |format|.
+        - |bytesInLastRow| be |widthInBlocks| &times; the [=texel block copy footprint=] of |format|.
     1. Fail if the following input validation requirements are not met:
 
         <div class=validusage>


### PR DESCRIPTION
And reorganize the texture format tables a little bit.

Fixes #3768