### PR TITLE
[editorial] Rename variable_statement grammar

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4491,7 +4491,7 @@ such that the redundant loads are eliminated.
 ## Variable and Value Declaration Grammar Summary ## {#var-and-value-decl-grammar}
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>variable_statement</dfn> :
+  <dfn for=syntax>variable_or_value_statement</dfn> :
 
     | [=syntax/variable_decl=]
 
@@ -4518,7 +4518,7 @@ such that the redundant loads are eliminated.
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>global_constant_decl</dfn> :
+  <dfn for=syntax>global_value_decl</dfn> :
 
     | <a for=syntax_kw lt=const>`'const'`</a> [=syntax/optionally_typed_ident=] <a for=syntax_sym lt=equal>`'='`</a> [=syntax/expression=]
 
@@ -6761,7 +6761,7 @@ allows them to naturally use values defined in the loop body.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>for_init</dfn> :
 
-    | [=syntax/variable_statement=]
+    | [=syntax/variable_or_value_statement=]
 
     | [=syntax/variable_updating_statement=]
 
@@ -7125,7 +7125,7 @@ The [=syntax/statement=] rule matches statements that can be used in most places
 
     | [=syntax/func_call_statement=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
-    | [=syntax/variable_statement=] <a for=syntax_sym lt=semicolon>`';'`</a>
+    | [=syntax/variable_or_value_statement=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
     | [=syntax/break_statement=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
@@ -8524,7 +8524,7 @@ A WGSL program is a sequence of optional [=directives=] followed by [=module sco
 
     | [=syntax/global_variable_decl=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
-    | [=syntax/global_constant_decl=] <a for=syntax_sym lt=semicolon>`';'`</a>
+    | [=syntax/global_value_decl=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
     | [=syntax/type_alias_decl=] <a for=syntax_sym lt=semicolon>`';'`</a>
 

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -181,7 +181,7 @@
 
  | [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=] [=recursive descent syntax/argument_expression_list=]
 
- | [=recursive descent syntax/variable_statement=]
+ | [=recursive descent syntax/variable_and_value_statement=]
 
  | [=recursive descent syntax/variable_updating_statement=]
 </div>
@@ -199,15 +199,13 @@
 
  | [=recursive descent syntax/attribute=] * `'fn'` [=recursive descent syntax/ident=] `'('` ( [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] `':'` [=recursive descent syntax/type_specifier=] ( `','` [=recursive descent syntax/param=] )* `','` ? )? `')'` ( `'->'` [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=] )? `'{'` [=recursive descent syntax/statement=] * `'}'`
 
- | [=recursive descent syntax/attribute=] * `'override'` [=recursive descent syntax/optionally_typed_ident=] ( `'='` [=recursive descent syntax/expression=] )? `';'`
-
  | [=recursive descent syntax/attribute=] * `'var'` ( [=syntax_sym/_template_args_start=] [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? [=syntax_sym/_template_args_end=] )? [=recursive descent syntax/optionally_typed_ident=] ( `'='` [=recursive descent syntax/expression=] )? `';'`
+
+ | [=recursive descent syntax/global_value_decl=] `';'`
 
  | `';'`
 
  | `'alias'` [=recursive descent syntax/ident=] `'='` [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=] `';'`
-
- | `'const'` [=recursive descent syntax/optionally_typed_ident=] `'='` [=recursive descent syntax/expression=] `';'`
 
  | `'const_assert'` [=recursive descent syntax/expression=] `';'`
 
@@ -220,6 +218,14 @@
  | `'enable'` [=syntax/ident_pattern_token=] `';'`
 
  | `'requires'` [=syntax/ident_pattern_token=] ( `','` [=recursive descent syntax/software_extension_name=] )* `','` ? `';'`
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for='recursive descent syntax'>global_value_decl</dfn>:
+
+ | [=recursive descent syntax/attribute=] * `'override'` [=recursive descent syntax/optionally_typed_ident=] ( `'='` [=recursive descent syntax/expression=] )?
+
+ | `'const'` [=recursive descent syntax/optionally_typed_ident=] `'='` [=recursive descent syntax/expression=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -345,7 +351,7 @@
 
  | [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=] `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'` `';'`
 
- | [=recursive descent syntax/variable_statement=] `';'`
+ | [=recursive descent syntax/variable_and_value_statement=] `';'`
 
  | [=recursive descent syntax/variable_updating_statement=] `';'`
 
@@ -440,13 +446,7 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>variable_decl</dfn>:
-
- | `'var'` ( [=syntax_sym/_template_args_start=] [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? [=syntax_sym/_template_args_end=] )? [=recursive descent syntax/optionally_typed_ident=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>variable_statement</dfn>:
+  <dfn for='recursive descent syntax'>variable_and_value_statement</dfn>:
 
  | [=recursive descent syntax/variable_decl=]
 
@@ -455,6 +455,12 @@
  | `'const'` [=recursive descent syntax/optionally_typed_ident=] `'='` [=recursive descent syntax/expression=]
 
  | `'let'` [=recursive descent syntax/optionally_typed_ident=] `'='` [=recursive descent syntax/expression=]
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for='recursive descent syntax'>variable_decl</dfn>:
+
+ | `'var'` ( [=syntax_sym/_template_args_start=] [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? [=syntax_sym/_template_args_end=] )? [=recursive descent syntax/optionally_typed_ident=]
 </div>
 
 <div class='syntax' noexport='true'>


### PR DESCRIPTION
* Rename variable_statement to variable_or_value_statement
* Rename global_constant_decl to global_value_decl