### PR TITLE
[editorial] Clarify memory locations

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8586,6 +8586,7 @@ Each memory location is 8-bits in size.
 An operation affecting memory interacts with a set of one or more memory locations.
 Memory operations on [=composites=] [=behavioral requirement|will not=]
 access padding memory locations.
+Therefore, the set of memory locations accessed by an operation may not be contiguous.
 
 Two sets of memory locations <dfn noexport>overlap</dfn> if the intersection of
 their sets of memory locations is non-empty.


### PR DESCRIPTION
Fixes #2039

* Clarify that operations on memory may not operate on a contiguous set of memory locations