### PR TITLE
[editorial] Add symmetry restriction about alignment

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8886,6 +8886,15 @@ member's type:
   Where |T| is the type of the |i|'th member of |S|.
 </p>
 
+If a structure member has the [=attribute/align=] attribute applied, the
+value [=shader-creation error|must=] be at least as large as the alignment of
+the member's type:
+
+<p algorithm="member align constraint">
+  [=AlignOfMember=](|S|, |i|) &ge; [=AlignOf=](T)<br>
+  Where |T| is the type of the |i|'th member of |S|.
+</p>
+
 The first structure member always has a zero byte offset from the start of the
 structure:
 <p algorithm="offset of first structure member">


### PR DESCRIPTION
Fixes #3050

* Add a symmetrical restriction (to size) that alignment can only be increased by the attribute