### PR TITLE
[editorial] Always add vertical lines to data tables

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -238,7 +238,8 @@ div.algorithm > div[data-timeline] {
     border-color: #c900f1 !important;
 }
 [data-timeline="const"] {
-    border-color: rgba(186, 186, 186, 30%) !important;
+    /* 186 is perceptual 50% gray, so works for both light and dark modes. */
+    border-color: rgb(186 186 186 / 30%) !important;
 }
 
 /*
@@ -351,9 +352,11 @@ div.algorithm > div[data-timeline] {
 /*
  * Add vertical lines to demarcate multi-column cells.
  */
-table.data td[colspan] {
-    border-left-style: dotted;
-    border-right-style: dotted;
+table.data td,
+table.data th {
+    /* Only one side is needed because there are no outer borders on the tables.
+     * 186 is perceptual 50% gray, so works for both light and dark modes. */
+    border-left: 1px solid rgb(186 186 186 / 30%);
 }
 
 table.data.no-colspan-center td[colspan],
@@ -14819,8 +14822,8 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td><!-- Vulkan -->
-        <td colspan=1>1
-        <td colspan=1>&ndash; <!-- no render target -->
+        <td>1
+        <td>&ndash; <!-- no render target -->
     <tr>
         <td>{{GPUTextureFormat/r8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14856,8 +14859,8 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td><!-- Vulkan -->
-        <td colspan=1>2
-        <td colspan=1>&ndash; <!-- no render target -->
+        <td>2
+        <td>&ndash; <!-- no render target -->
     <tr>
         <td>{{GPUTextureFormat/rg8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14884,8 +14887,8 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-        <td colspan=1>4
-        <td colspan=1>8
+        <td>4
+        <td>8
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14894,8 +14897,8 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td>
-        <td colspan=1>4
-        <td colspan=1>8
+        <td>4
+        <td>8
     <tr>
         <td>{{GPUTextureFormat/rgba8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14904,8 +14907,8 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td>&checkmark;
-        <td colspan=1>4
-        <td colspan=1>&ndash; <!-- no render target --> <!-- If we add render target support for this in the future, rgba8snorm has to be a special case where the render target pixel byte cost = 8 -->
+        <td>4
+        <td>&ndash; <!-- no render target --> <!-- If we add render target support for this in the future, rgba8snorm has to be a special case where the render target pixel byte cost = 8 -->
     <tr>
         <td>{{GPUTextureFormat/rgba8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14932,8 +14935,8 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td>If {{GPUFeatureName/"bgra8unorm-storage"}} is enabled
-        <td colspan=1>4
-        <td colspan=1>8
+        <td>4
+        <td>8
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14942,8 +14945,8 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td>
-        <td colspan=1>4
-        <td colspan=1>8
+        <td>4
+        <td>8
     <tr><th colspan=9>16 bits per component (2-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
@@ -15123,16 +15126,16 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td>
-        <td colspan=1>4
-        <td colspan=1>8
+        <td>4
+        <td>8
     <tr>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=3>If {{GPUFeatureName/"rg11b10ufloat-renderable"}} is enabled
         <td>
         <td><!-- Vulkan -->
-        <td colspan=1>4
-        <td colspan=1>8
+        <td>4
+        <td>8
 </table>
 
 ### Depth-stencil formats ### {#depth-formats}
@@ -15204,8 +15207,8 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
         <td>4
         <td>depth
         <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
-        <td colspan=1>&checkmark;
-        <td colspan=1>&cross;
+        <td>&checkmark;
+        <td>&cross;
         <td>4
         <td>{{GPUTextureFormat/depth32float}}
     <tr>
@@ -15213,8 +15216,8 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
         <td rowspan=2>5 &minus; 8
         <td>depth
         <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
-        <td colspan=1>&checkmark;
-        <td colspan=1>&cross;
+        <td>&checkmark;
+        <td>&cross;
         <td>4
         <td>{{GPUTextureFormat/depth32float}}
     <tr>


### PR DESCRIPTION
This replaces styling that only adds vertical lines on colspans. It makes our tables look a bit utilitarian, but that's what they are. I think it makes them easier to use.