### PR TITLE
Simplify timestampWrites API

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12706,6 +12706,7 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
     - |timestampWrites|.`querySet`.{{GPUQuerySet/type}} must be {{GPUQueryType/"timestamp"}}.
     - |timestampWrites|.`beginningOfPassWriteIndex` must be &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
     - |timestampWrites|.`endOfPassWriteIndex` must be &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
+    - No two write indices in |timestampWrites| (`beginningOfPassWriteIndex`, `endOfPassWriteIndex`) may be equal.
 
     <!-- editorial note: any additional timestamp write locations that are compute- or
     render-specific could either be written here conditionally, or written at the call sites

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10685,7 +10685,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     1. If |this|.{{GPURenderPassDescriptor/timestampWrites}} is [=map/exist|provided=]:
         - [$Validate timestampWrites$](|device|, |this|.{{GPURenderPassDescriptor/timestampWrites}})
-        must return true.
+            must return true.
 
     1. No two entries in |this|.{{GPURenderPassDescriptor/timestampWrites}} may have the same
         [{{GPURenderPassTimestampWrite/querySet}}, {{GPURenderPassTimestampWrite/queryIndex}}] pair.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -767,6 +767,10 @@ In this specification, the following syntactic shorthands are used:
 : The `.` ("dot") syntax, common in programming languages.
 ::
     The phrasing "`Foo.Bar`" means "the `Bar` member of the value (or interface) `Foo`."
+    If `Foo` is an [=ordered map=], [=asserts=] that the key `Bar` exists.
+
+    <div class="note editorial">
+    Some phrasing in this spec may currently assume this resolves to `undefined` if `Bar` doesn't exist.
 
     The phrasing "`Foo.Bar` is [=map/exist|provided=]" means
     "the `Bar` member [=map/exists=] in the [=map=] value `Foo`"
@@ -9345,9 +9349,10 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
                 1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
                     <div class=validusage>
-                        - [$Validate timestampWrites$](|this|.{{GPUObjectBase/[[device]]}},
-                            |descriptor|.{{GPUComputePassDescriptor/timestampWrites}})
-                            must return true.
+                        - If |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is [=map/exist|provided=]:
+                            - [$Validate timestampWrites$](|this|.{{GPUObjectBase/[[device]]}},
+                                |descriptor|.{{GPUComputePassDescriptor/timestampWrites}})
+                                must return true.
                     </div>
                 1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
                     1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
@@ -10248,21 +10253,16 @@ GPUComputePassEncoder includes GPUBindingCommandsMixin;
 ### Compute Pass Encoder Creation ### {#compute-pass-encoder-creation}
 
 <script type=idl>
-enum GPUComputePassTimestampLocation {
-    "beginning",
-    "end"
-};
-
-dictionary GPUComputePassTimestampWrite {
+dictionary GPUComputePassTimestampWrites {
     required GPUQuerySet querySet;
-    required GPUSize32 queryIndex;
-    required GPUComputePassTimestampLocation location;
+    GPUSize32 beginningOfPassWriteIndex;
+    GPUSize32 endOfPassWriteIndex;
 };
+</script>
 
-typedef sequence<GPUComputePassTimestampWrite> GPUComputePassTimestampWrites;
-
+<script type=idl>
 dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
-    GPUComputePassTimestampWrites timestampWrites = [];
+    GPUComputePassTimestampWrites timestampWrites;
 };
 </script>
 
@@ -10599,24 +10599,19 @@ When executing encoded render pass commands as part of a {{GPUCommandBuffer}}, a
 ### Render Pass Encoder Creation ### {#render-pass-encoder-creation}
 
 <script type=idl>
-enum GPURenderPassTimestampLocation {
-    "beginning",
-    "end"
-};
-
-dictionary GPURenderPassTimestampWrite {
+dictionary GPURenderPassTimestampWrites {
     required GPUQuerySet querySet;
-    required GPUSize32 queryIndex;
-    required GPURenderPassTimestampLocation location;
+    GPUSize32 beginningOfPassWriteIndex;
+    GPUSize32 endOfPassWriteIndex;
 };
+</script>
 
-typedef sequence<GPURenderPassTimestampWrite> GPURenderPassTimestampWrites;
-
+<script type=idl>
 dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     required sequence<GPURenderPassColorAttachment?> colorAttachments;
     GPURenderPassDepthStencilAttachment depthStencilAttachment;
     GPUQuerySet occlusionQuerySet;
-    GPURenderPassTimestampWrites timestampWrites = [];
+    GPURenderPassTimestampWrites timestampWrites;
     GPUSize64 maxDrawCount = 50000000;
 };
 </script>
@@ -10688,7 +10683,8 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/type}}
             must be {{GPUQueryType/occlusion}}.
 
-    1. [$Validate timestampWrites$](|device|, |this|.{{GPURenderPassDescriptor/timestampWrites}})
+    1. If |this|.{{GPURenderPassDescriptor/timestampWrites}} is [=map/exist|provided=]:
+        - [$Validate timestampWrites$](|device|, |this|.{{GPURenderPassDescriptor/timestampWrites}})
         must return true.
 
     1. No two entries in |this|.{{GPURenderPassDescriptor/timestampWrites}} may have the same
@@ -12705,13 +12701,15 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
 
     Return `true` if the following requirements are met, and `false` if not.
 
-    - If |timestampWrites| is not [=list/is empty|empty=],
-        {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |device|.
-    - No two entries in |timestampWrites| may have the same `location`.
-    - For each |timestampWrite| in |timestampWrites|:
-        - |timestampWrite|.`querySet` must be [$valid to use with$] |device|.
-        - |timestampWrite|.`querySet`.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
-        - |timestampWrite|.`queryIndex` &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
+    - {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |device|.
+    - |timestampWrites|.`querySet` must be [$valid to use with$] |device|.
+    - |timestampWrites|.`querySet`.{{GPUQuerySet/type}} must be {{GPUQueryType/"timestamp"}}.
+    - |timestampWrites|.`beginningOfPassWriteIndex` must be &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
+    - |timestampWrites|.`endOfPassWriteIndex` must be &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
+
+    <!-- editorial note: any additional timestamp write locations that are compute- or
+    render-specific could either be written here conditionally, or written at the call sites
+    in compute/render pass descriptor validation. -->
 </div>
 
 # Canvas Rendering # {#canvas-rendering}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12706,7 +12706,9 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
     - |timestampWrites|.`querySet`.{{GPUQuerySet/type}} must be {{GPUQueryType/"timestamp"}}.
     - |timestampWrites|.`beginningOfPassWriteIndex` must be &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
     - |timestampWrites|.`endOfPassWriteIndex` must be &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
-    - No two write indices in |timestampWrites| (`beginningOfPassWriteIndex`, `endOfPassWriteIndex`) may be equal.
+    - Of the write index members in |timestampWrites| (`beginningOfPassWriteIndex`, `endOfPassWriteIndex`):
+        - At least one must be [=map/exist|provided=].
+        - Of those which are [=map/exist|provided=], no two may be equal.
 
     <!-- editorial note: any additional timestamp write locations that are compute- or
     render-specific could either be written here conditionally, or written at the call sites


### PR DESCRIPTION
Summary:

- ```js
  encoder.beginWhicheverPass({
    // ...
    timestampWrites: {
      querySet: myTimestampQuerySet,
      beginningOfPassWriteIndex: 0,
      endOfPassWriteIndex: 1,
    }
  });
  ```
- Both write indices are optional, but at least one is required.
- They may not write to the same index.
- Revisiting this I find myself wondering what the beginning of a "pass write index" is, but this is probably silly.

Fixes #3808