### PR TITLE
maxBindGroupsPlusVertexBuffers and unbinding

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1568,7 +1568,7 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
     <tr class=row-continuation><td colspan=4>
         The maximum number of bind group and vertex buffer slots used simultaneously,
         counting any empty slots below the highest index.
-        Validated in {{GPUDevice/createRenderPipeline())}} and [$valid to draw|in draw calls$].
+        Validated in {{GPUDevice/createRenderPipeline()}} and [$valid to draw|in draw calls$].
 
     <tr><td><dfn>maxBindingsPerBindGroup</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>640

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1563,13 +1563,11 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
         when creating a {{GPUPipelineLayout}}.
 
     <tr><td><dfn>maxBindGroupsPlusVertexBuffers</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>12
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>24
     <tr class=row-continuation><td colspan=4>
         The maximum number of bind group and vertex buffer slots used simultaneously,
         counting any empty slots below the highest index.
         Validated in {{GPUDevice/createRenderPipeline())}} and [$valid to draw|in draw calls$].
-
-        Issue: FIXME: Raise this to 24 or something?
 
     <tr><td><dfn>maxBindingsPerBindGroup</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>640
@@ -2374,10 +2372,6 @@ Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the followi
 - {{supported limits/maxColorAttachments}} must be &le; {{supported limits/maxFragmentCombinedOutputResources}}.
 - {{supported limits/maxBindGroups}} must be &le; {{supported limits/maxBindGroupsPlusVertexBuffers}}.
 - {{supported limits/maxVertexBuffers}} must be &le; {{supported limits/maxBindGroupsPlusVertexBuffers}}.
-- {{supported limits/maxBindGroupsPlusVertexBuffers}} must be &le;
-    {{supported limits/maxBindGroups}} + {{supported limits/maxVertexBuffers}}.
-
-    Issue: FIXME: Lift this?
 - {{supported limits/minUniformBufferOffsetAlignment}} and
     {{supported limits/minStorageBufferOffsetAlignment}} must both be &ge; 32 bytes.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1552,6 +1552,13 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
         allowed in {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
         when creating a {{GPUPipelineLayout}}.
 
+    <tr><td><dfn>maxBindGroupsPlusVertexBuffers</dfn>
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>4
+    <tr class=row-continuation><td colspan=4>
+        The highest index of any {{GPUVertexBufferLayout|GPUVertexBufferLayout}} within {{GPUVertexState/buffers}},
+        plus the number of {{GPUBindGroupLayout|GPUBindGroupLayouts}} within {{GPUPipelineLayoutDescriptor/bindGroupLayouts}},
+        when creating a {{GPUPipelineLayout}}.
+
     <tr><td><dfn>maxBindingsPerBindGroup</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>640
     <tr class=row-continuation><td colspan=4>
@@ -1764,6 +1771,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureDimension3D;
     readonly attribute unsigned long maxTextureArrayLayers;
     readonly attribute unsigned long maxBindGroups;
+    readonly attribute unsigned long maxBindGroupsPlusVertexBuffers;
     readonly attribute unsigned long maxBindingsPerBindGroup;
     readonly attribute unsigned long maxDynamicUniformBuffersPerPipelineLayout;
     readonly attribute unsigned long maxDynamicStorageBuffersPerPipelineLayout;
@@ -7660,6 +7668,9 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
                     <div class=validusage>
                         - |layout| is [$valid to use with$] |this|.
                         - [$validating GPURenderPipelineDescriptor$](|descriptor|, |layout|, |this|) succeeds.
+                        - |layout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}.length + |vertexBufferCount| is &le;
+                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}},
+                            where |vertexBufferCount| is the maximum index in |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}} that is not `undefined`
                     </div>
                 1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
                 1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to false.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1553,7 +1553,7 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
         when creating a {{GPUPipelineLayout}}.
 
     <tr><td><dfn>maxBindGroupsPlusVertexBuffers</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>4
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>12
     <tr class=row-continuation><td colspan=4>
         The highest index of any {{GPUVertexBufferLayout|GPUVertexBufferLayout}} within {{GPUVertexState/buffers}},
         plus the number of {{GPUBindGroupLayout|GPUBindGroupLayouts}} within {{GPUPipelineLayoutDescriptor/bindGroupLayouts}},

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1569,6 +1569,8 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
         plus the number of {{GPUBindGroupLayout|GPUBindGroupLayouts}} within {{GPUPipelineLayoutDescriptor/bindGroupLayouts}},
         when creating a {{GPUPipelineLayout}}.
 
+        Issue: FIXME: Raise this to 24 or something?
+
     <tr><td><dfn>maxBindingsPerBindGroup</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>640
     <tr class=row-continuation><td colspan=4>
@@ -2370,6 +2372,12 @@ Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the followi
     other limits.
 
 - {{supported limits/maxColorAttachments}} must be &le; {{supported limits/maxFragmentCombinedOutputResources}}.
+- {{supported limits/maxBindGroups}} must be &le; {{supported limits/maxBindGroupsPlusVertexBuffers}}.
+- {{supported limits/maxVertexBuffers}} must be &le; {{supported limits/maxBindGroupsPlusVertexBuffers}}.
+- {{supported limits/maxBindGroupsPlusVertexBuffers}} must be &le;
+    {{supported limits/maxBindGroups}} + {{supported limits/maxVertexBuffers}}.
+
+    Issue: FIXME: Lift this?
 - {{supported limits/minUniformBufferOffsetAlignment}} and
     {{supported limits/minStorageBufferOffsetAlignment}} must both be &ge; 32 bytes.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7670,7 +7670,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
                         - [$validating GPURenderPipelineDescriptor$](|descriptor|, |layout|, |this|) succeeds.
                         - |layout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}.length + |vertexBufferCount| is &le;
                             |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}},
-                            where |vertexBufferCount| is the maximum index in |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}} that is not `undefined`
+                            where |vertexBufferCount| is the maximum index in |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}} that is not `undefined`.
                     </div>
                 1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
                 1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to false.
@@ -9857,6 +9857,8 @@ interface mixin GPUBindingCommandsMixin {
         Uint32Array dynamicOffsetsData,
         GPUSize64 dynamicOffsetsDataStart,
         GPUSize32 dynamicOffsetsDataLength);
+
+    undefined unsetBindGroup(GPUIndex32 index);
 };
 </script>
 
@@ -9934,6 +9936,14 @@ It must only be included by interfaces which also include those mixins.
                     <div class=validusage>
                         - |bindGroup| must be [$valid to use with$] |this|.
                         - |index| must be &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}.
+                        - If |this| is a {{GPURenderCommandsMixin}}:
+                            - |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
+                                |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}, where:
+
+                                : |bindGroupSpaceUsed| is:
+                                :: max(|index|, the maximum key in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1
+                                : |vertexBufferSpaceUsed| is:
+                                :: (the maximum key in |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1
                         - |dynamicOffsets|.length must be
                             |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
 
@@ -9993,6 +10003,41 @@ It must only be included by interfaces which also include those mixins.
                     [=get a copy of the buffer source|a copy of=] |dynamicOffsetsData|.
                 1. Call |this|.{{GPUBindingCommandsMixin/setBindGroup(index,
                     bindGroup, dynamicOffsets)|setBindGroup}}(|index|, |bindGroup|, |dynamicOffsets|).
+            </div>
+        </div>
+
+    : <dfn>unsetBindGroup(index)</dfn>
+    ::
+        Unsets the current {{GPUBindGroup}} for the given index.
+
+        <div algorithm=GPUBindingCommandsMixin.setBindGroup-unset>
+            <div data-timeline=content>
+                **Called on:** {{GPUBindingCommandsMixin}} |this|.
+
+                **Arguments:**
+
+                <pre class=argumentdef for="GPUBindingCommandsMixin/unsetBindGroup(index)">
+                    |index|: The index to unset the bind group at.
+                </pre>
+
+                **Returns:** {{undefined}}
+
+                [=Content timeline=] steps:
+
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
+                    <div class=validusage>
+                        - |index| &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}.
+                    </div>
+                1. [=map/Remove=] |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|index|].
+                1. [=map/Remove=] |this|.{{GPUBindingCommandsMixin/[[dynamic_offsets]]}}[|index|].
             </div>
         </div>
 </dl>
@@ -11128,6 +11173,7 @@ interface mixin GPURenderCommandsMixin {
 
     undefined setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset = 0, optional GPUSize64 size);
     undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
+    undefined unsetVertexBuffer(GPUIndex32 slot);
 
     undefined draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1,
         optional GPUSize32 firstVertex = 0, optional GPUSize32 firstInstance = 0);
@@ -11317,12 +11363,43 @@ It must only be included by interfaces which also include those mixins.
                         - |buffer| must be [$valid to use with$] |this|.
                         - |buffer|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/VERTEX}}.
                         - |slot| must be &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
+                        - |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
+                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}, where:
+
+                            : |bindGroupSpaceUsed| is
+                            :: (the maximum key in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1
+                            : |vertexBufferSpaceUsed| is
+                            :: max(|slot|, the maximum key in |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1
                         - |offset| must be a multiple of 4.
                         - |offset| + |size| must be &le; |buffer|.{{GPUBuffer/size}}.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Set |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|] to be |buffer|.
                 1. Set |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|] to be |size|.
+            </div>
+        </div>
+
+    : <dfn>unsetVertexBuffer(slot)</dfn>
+    ::
+        Unsets the current vertex buffer for the given slot.
+
+        <div algorithm=GPURenderCommandsMixin.setVertexBuffer-unset>
+            **Called on:** {{GPURenderCommandsMixin}} this.
+
+            **Arguments:**
+
+            <pre class=argumentdef for="GPURenderCommandsMixin/unsetVertexBuffer(slot)">
+                |slot|: The vertex buffer slot to unset.
+            </pre>
+
+            **Returns:** {{undefined}}
+
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
+            <div class=device-timeline>
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [=map/Remove=] |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|].
+                1. [=map/Remove=] |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|].
             </div>
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9965,7 +9965,7 @@ It must only be included by interfaces which also include those mixins.
                     <div class=validusage>
                         - |index| must be &lt;
                             |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}.
-                        - |dynamicOffsets|.length must be |dynamicOffsetCount|.
+                        - |dynamicOffsets|.length must equal |dynamicOffsetCount|.
                     </div>
                 1. If |bindGroup| is `null`:
                     1. [=map/Remove=] |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|index|].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1565,9 +1565,9 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
     <tr><td><dfn>maxBindGroupsPlusVertexBuffers</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>12
     <tr class=row-continuation><td colspan=4>
-        The highest index of any {{GPUVertexBufferLayout|GPUVertexBufferLayout}} within {{GPUVertexState/buffers}},
-        plus the number of {{GPUBindGroupLayout|GPUBindGroupLayouts}} within {{GPUPipelineLayoutDescriptor/bindGroupLayouts}},
-        when creating a {{GPUPipelineLayout}}.
+        The maximum number of bind group and vertex buffer slots used simultaneously,
+        counting any empty slots below the highest index.
+        Validated in {{GPUDevice/createRenderPipeline())}} and [$valid to draw|in draw calls$].
 
         Issue: FIXME: Raise this to 24 or something?
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9949,13 +9949,12 @@ It must only be included by interfaces which also include those mixins.
                         <div class=validusage>
                             - |bindGroup| must be [$valid to use with$] |this|.
                             - If |this| is a {{GPURenderCommandsMixin}}:
-                                - |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
-                                    |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}, where:
-
-                                    : |bindGroupSpaceUsed| is:
-                                    :: max(|index|, the maximum key in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1
-                                    : |vertexBufferSpaceUsed| is:
-                                    :: (the maximum key in |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1
+                                1. Let |bindGroupSpaceUsed| be
+                                    max(|index|, the maximum key in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1.
+                                1. Let |vertexBufferSpaceUsed| be
+                                    (the maximum key in |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1.
+                                1. |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
+                                    |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}.
                             - [$Iterate over each dynamic binding offset|For each dynamic binding$]
                                 (|bufferBinding|, |bufferLayout|, |dynamicOffsetIndex|) in |bindGroup|:
                                 - |bufferBinding|.{{GPUBufferBinding/offset}} + |dynamicOffsets|[|dynamicOffsetIndex|] +
@@ -11350,13 +11349,13 @@ It must only be included by interfaces which also include those mixins.
                         <div class=validusage>
                             - |buffer| must be [$valid to use with$] |this|.
                             - |buffer|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/VERTEX}}.
-                            - |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
-                                |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}, where:
-
-                                : |bindGroupSpaceUsed| is
-                                :: (the maximum key in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1
-                                : |vertexBufferSpaceUsed| is
-                                :: max(|slot|, the maximum key in |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1
+                            -
+                                1. Let |bindGroupSpaceUsed| be
+                                    (the maximum key in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1.
+                                1. Let |vertexBufferSpaceUsed| be
+                                    max(|slot|, the maximum key in |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1.
+                                1. |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
+                                    |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}.
                         </div>
                     1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                     1. Set |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|] to be |buffer|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9977,13 +9977,6 @@ It must only be included by interfaces which also include those mixins.
 
                         <div class=validusage>
                             - |bindGroup| must be [$valid to use with$] |this|.
-                            - If |this| is a {{GPURenderCommandsMixin}}:
-                                1. Let |bindGroupSpaceUsed| be
-                                    max(|index|, the maximum key in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1.
-                                1. Let |vertexBufferSpaceUsed| be
-                                    (the maximum key in |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1.
-                                1. |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
-                                    |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}.
                             - [$Iterate over each dynamic binding offset|For each dynamic binding$]
                                 (|bufferBinding|, |bufferLayout|, |dynamicOffsetIndex|) in |bindGroup|:
                                 - |bufferBinding|.{{GPUBufferBinding/offset}} + |dynamicOffsets|[|dynamicOffsetIndex|] +
@@ -11378,13 +11371,6 @@ It must only be included by interfaces which also include those mixins.
                         <div class=validusage>
                             - |buffer| must be [$valid to use with$] |this|.
                             - |buffer|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/VERTEX}}.
-                            -
-                                1. Let |bindGroupSpaceUsed| be
-                                    (the maximum key in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1.
-                                1. Let |vertexBufferSpaceUsed| be
-                                    max(|slot|, the maximum key in |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1.
-                                1. |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
-                                    |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}.
                         </div>
                     1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                     1. Set |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|] to be |buffer|.
@@ -11677,6 +11663,13 @@ It must only be included by interfaces which also include those mixins.
                 |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.length:
                 - If |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}[|slot|] is not `null`,
                     |encoder|.{{GPURenderCommandsMixin/[[vertex_buffers]]}} must [=map/contain=] |slot|.
+            - Validate {{supported limits/maxBindGroupsPlusVertexBuffers}}:
+                1. Let |bindGroupSpaceUsed| be
+                    (the maximum key in |encoder|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1.
+                1. Let |vertexBufferSpaceUsed| be
+                    (the maximum key in |encoder|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1.
+                1. |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
+                    |encoder|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}.
         </div>
     1. Otherwise return `true`.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9850,15 +9850,13 @@ command encoder can no longer be used.
 
 <script type=idl>
 interface mixin GPUBindingCommandsMixin {
-    undefined setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
+    undefined setBindGroup(GPUIndex32 index, GPUBindGroup? bindGroup,
         optional sequence<GPUBufferDynamicOffset> dynamicOffsets = []);
 
-    undefined setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
+    undefined setBindGroup(GPUIndex32 index, GPUBindGroup? bindGroup,
         Uint32Array dynamicOffsetsData,
         GPUSize64 dynamicOffsetsDataStart,
         GPUSize32 dynamicOffsetsDataLength);
-
-    undefined unsetBindGroup(GPUIndex32 index);
 };
 </script>
 
@@ -9904,7 +9902,7 @@ It must only be included by interfaces which also include those mixins.
                     ::
                         The index to set the bind group at.
 
-                    : <dfn>|bindGroup|</dfn>, of type {{GPUBindGroup}}, non-nullable, required
+                    : <dfn>|bindGroup|</dfn>, of type {{GPUBindGroup}}, nullable, required
                     ::
                         Bind group to use for subsequent render or compute commands.
 
@@ -9931,38 +9929,49 @@ It must only be included by interfaces which also include those mixins.
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. Let |dynamicOffsetCount| be 0 if `bindGroup` is `null`, or
+                    |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}} if not.
                 1. If any of the following requirements are unmet, make |this| [=invalid=] and stop.
 
                     <div class=validusage>
-                        - |bindGroup| must be [$valid to use with$] |this|.
-                        - |index| must be &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}.
-                        - If |this| is a {{GPURenderCommandsMixin}}:
-                            - |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
-                                |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}, where:
-
-                                : |bindGroupSpaceUsed| is:
-                                :: max(|index|, the maximum key in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1
-                                : |vertexBufferSpaceUsed| is:
-                                :: (the maximum key in |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1
-                        - |dynamicOffsets|.length must be
-                            |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
-
-                        - [$Iterate over each dynamic binding offset|For each dynamic binding$]
-                            (|bufferBinding|, |bufferLayout|, |dynamicOffsetIndex|) in |bindGroup|:
-                            - |bufferBinding|.{{GPUBufferBinding/offset}} + |dynamicOffsets|[|dynamicOffsetIndex|] +
-                                |bufferLayout|.{{GPUBufferBindingLayout/minBindingSize}} must be &le;
-                                |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/size}}.
-                            - If |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"uniform"}}:
-
-                                - |dynamicOffset| must be a multiple of {{supported limits/minUniformBufferOffsetAlignment}}.
-
-                            - If |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"storage"}}
-                                or {{GPUBufferBindingType/"read-only-storage"}}:
-
-                                - |dynamicOffset| must be a multiple of {{supported limits/minStorageBufferOffsetAlignment}}.
+                        - |index| must be &lt;
+                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}.
+                        - |dynamicOffsets|.length must be |dynamicOffsetCount|.
                     </div>
-                1. Set |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|index|] to be |bindGroup|.
-                1. Set |this|.{{GPUBindingCommandsMixin/[[dynamic_offsets]]}}[|index|] to be a copy of |dynamicOffsets|.
+                1. If |bindGroup| is `null`:
+                    1. [=map/Remove=] |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|index|].
+                    1. [=map/Remove=] |this|.{{GPUBindingCommandsMixin/[[dynamic_offsets]]}}[|index|].
+
+                    Otherwise:
+
+                    1. If any of the following requirements are unmet, make |this| [=invalid=] and stop.
+
+                        <div class=validusage>
+                            - |bindGroup| must be [$valid to use with$] |this|.
+                            - If |this| is a {{GPURenderCommandsMixin}}:
+                                - |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
+                                    |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}, where:
+
+                                    : |bindGroupSpaceUsed| is:
+                                    :: max(|index|, the maximum key in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1
+                                    : |vertexBufferSpaceUsed| is:
+                                    :: (the maximum key in |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1
+                            - [$Iterate over each dynamic binding offset|For each dynamic binding$]
+                                (|bufferBinding|, |bufferLayout|, |dynamicOffsetIndex|) in |bindGroup|:
+                                - |bufferBinding|.{{GPUBufferBinding/offset}} + |dynamicOffsets|[|dynamicOffsetIndex|] +
+                                    |bufferLayout|.{{GPUBufferBindingLayout/minBindingSize}} must be &le;
+                                    |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/size}}.
+                                - If |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"uniform"}}:
+
+                                    - |dynamicOffset| must be a multiple of {{supported limits/minUniformBufferOffsetAlignment}}.
+
+                                - If |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"storage"}}
+                                    or {{GPUBufferBindingType/"read-only-storage"}}:
+
+                                    - |dynamicOffset| must be a multiple of {{supported limits/minStorageBufferOffsetAlignment}}.
+                        </div>
+                    1. Set |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|index|] to be |bindGroup|.
+                    1. Set |this|.{{GPUBindingCommandsMixin/[[dynamic_offsets]]}}[|index|] to be a copy of |dynamicOffsets|.
             </div>
         </div>
 
@@ -10003,41 +10012,6 @@ It must only be included by interfaces which also include those mixins.
                     [=get a copy of the buffer source|a copy of=] |dynamicOffsetsData|.
                 1. Call |this|.{{GPUBindingCommandsMixin/setBindGroup(index,
                     bindGroup, dynamicOffsets)|setBindGroup}}(|index|, |bindGroup|, |dynamicOffsets|).
-            </div>
-        </div>
-
-    : <dfn>unsetBindGroup(index)</dfn>
-    ::
-        Unsets the current {{GPUBindGroup}} for the given index.
-
-        <div algorithm=GPUBindingCommandsMixin.setBindGroup-unset>
-            <div data-timeline=content>
-                **Called on:** {{GPUBindingCommandsMixin}} |this|.
-
-                **Arguments:**
-
-                <pre class=argumentdef for="GPUBindingCommandsMixin/unsetBindGroup(index)">
-                    |index|: The index to unset the bind group at.
-                </pre>
-
-                **Returns:** {{undefined}}
-
-                [=Content timeline=] steps:
-
-                1. Issue the subsequent steps on the [=Device timeline=] of
-                    |this|.{{GPUObjectBase/[[device]]}}.
-            </div>
-            <div data-timeline=device>
-                [=Device timeline=] steps:
-
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
-
-                    <div class=validusage>
-                        - |index| &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}.
-                    </div>
-                1. [=map/Remove=] |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|index|].
-                1. [=map/Remove=] |this|.{{GPUBindingCommandsMixin/[[dynamic_offsets]]}}[|index|].
             </div>
         </div>
 </dl>
@@ -11172,8 +11146,7 @@ interface mixin GPURenderCommandsMixin {
     undefined setPipeline(GPURenderPipeline pipeline);
 
     undefined setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset = 0, optional GPUSize64 size);
-    undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
-    undefined unsetVertexBuffer(GPUIndex32 slot);
+    undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer? buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
 
     undefined draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1,
         optional GPUSize32 firstVertex = 0, optional GPUSize32 firstInstance = 0);
@@ -11356,50 +11329,38 @@ It must only be included by interfaces which also include those mixins.
 
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
+                1. Let |bufferSize| be 0 if |buffer| is `null`, or |buffer|.{{GPUBuffer/size}} if not.
+                1. If |size| is missing, set |size| to max(0, |bufferSize| - |offset|).
                 1. If any of the following requirements are unmet, make |this| [=invalid=] and stop.
 
                     <div class=validusage>
-                        - |buffer| must be [$valid to use with$] |this|.
-                        - |buffer|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/VERTEX}}.
-                        - |slot| must be &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
-                        - |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
-                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}, where:
-
-                            : |bindGroupSpaceUsed| is
-                            :: (the maximum key in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1
-                            : |vertexBufferSpaceUsed| is
-                            :: max(|slot|, the maximum key in |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1
+                        - |slot| must be &lt;
+                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
                         - |offset| must be a multiple of 4.
-                        - |offset| + |size| must be &le; |buffer|.{{GPUBuffer/size}}.
+                        - |offset| + |size| must be &le; |bufferSize|.
                     </div>
-                1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
-                1. Set |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|] to be |buffer|.
-                1. Set |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|] to be |size|.
-            </div>
-        </div>
+                1. If |buffer| is `null`:
+                    1. [=map/Remove=] |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|].
+                    1. [=map/Remove=] |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|].
 
-    : <dfn>unsetVertexBuffer(slot)</dfn>
-    ::
-        Unsets the current vertex buffer for the given slot.
+                    Otherwise:
 
-        <div algorithm=GPURenderCommandsMixin.setVertexBuffer-unset>
-            **Called on:** {{GPURenderCommandsMixin}} this.
+                    1. If any of the following requirements are unmet, make |this| [=invalid=] and stop.
 
-            **Arguments:**
+                        <div class=validusage>
+                            - |buffer| must be [$valid to use with$] |this|.
+                            - |buffer|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/VERTEX}}.
+                            - |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
+                                |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}, where:
 
-            <pre class=argumentdef for="GPURenderCommandsMixin/unsetVertexBuffer(slot)">
-                |slot|: The vertex buffer slot to unset.
-            </pre>
-
-            **Returns:** {{undefined}}
-
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
-
-            <div class=device-timeline>
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. [=map/Remove=] |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|].
-                1. [=map/Remove=] |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|].
+                                : |bindGroupSpaceUsed| is
+                                :: (the maximum key in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}) + 1
+                                : |vertexBufferSpaceUsed| is
+                                :: max(|slot|, the maximum key in |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}) + 1
+                        </div>
+                    1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
+                    1. Set |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|] to be |buffer|.
+                    1. Set |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|] to be |size|.
             </div>
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9929,31 +9929,27 @@ It must only be included by interfaces which also include those mixins.
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following requirements are unmet, make |this| [=invalid=] and stop.
 
                     <div class=validusage>
-                        - |bindGroup| is [$valid to use with$] |this|.
-                        - |index| &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}.
-                        - |dynamicOffsets|.length is
+                        - |bindGroup| must be [$valid to use with$] |this|.
+                        - |index| must be &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}.
+                        - |dynamicOffsets|.length must be
                             |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
 
-                        - [$Iterate over each dynamic binding offset$] in |bindGroup| and
-                            run the following steps for each |bufferBinding|, |bufferLayout|,
-                            and |dynamicOffsetIndex|:
-
-                            - Let |bufferDynamicOffset| be |dynamicOffsets|[|dynamicOffsetIndex|].
-                            - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
-                                |bufferLayout|.{{GPUBufferBindingLayout/minBindingSize}} &le;
+                        - [$Iterate over each dynamic binding offset|For each dynamic binding$]
+                            (|bufferBinding|, |bufferLayout|, |dynamicOffsetIndex|) in |bindGroup|:
+                            - |bufferBinding|.{{GPUBufferBinding/offset}} + |dynamicOffsets|[|dynamicOffsetIndex|] +
+                                |bufferLayout|.{{GPUBufferBindingLayout/minBindingSize}} must be &le;
                                 |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/size}}.
-                            - if |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"uniform"}}:
+                            - If |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"uniform"}}:
 
-                                - |dynamicOffset| is a multiple of {{supported limits/minUniformBufferOffsetAlignment}}.
+                                - |dynamicOffset| must be a multiple of {{supported limits/minUniformBufferOffsetAlignment}}.
 
-                            - if |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"storage"}}
+                            - If |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"storage"}}
                                 or {{GPUBufferBindingType/"read-only-storage"}}:
 
-                                - |dynamicOffset| is a multiple of {{supported limits/minStorageBufferOffsetAlignment}}.
-
+                                - |dynamicOffset| must be a multiple of {{supported limits/minStorageBufferOffsetAlignment}}.
                     </div>
                 1. Set |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|index|] to be |bindGroup|.
                 1. Set |this|.{{GPUBindingCommandsMixin/[[dynamic_offsets]]}}[|index|] to be a copy of |dynamicOffsets|.
@@ -11315,14 +11311,14 @@ It must only be included by interfaces which also include those mixins.
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following requirements are unmet, make |this| [=invalid=] and stop.
 
                     <div class=validusage>
-                        - |buffer| is [$valid to use with$] |this|.
-                        - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/VERTEX}}.
-                        - |slot| &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
-                        - |offset| is a multiple of 4.
-                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/size}}.
+                        - |buffer| must be [$valid to use with$] |this|.
+                        - |buffer|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/VERTEX}}.
+                        - |slot| must be &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
+                        - |offset| must be a multiple of 4.
+                        - |offset| + |size| must be &le; |buffer|.{{GPUBuffer/size}}.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Set |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|] to be |buffer|.


### PR DESCRIPTION
My suggestion to use overloads with `null` didn't work (there's no `null` type in WebIDL), so I just did the simplest thing and we can bikeshed from here. Alternatives:

- Name as "bind" and some other type like `GPUBindGroup?`/`GPUBuffer?` in the overloads and explicitly throw a `TypeError` if not null (weird)
- Name as "bind" and write the overload so it just doesn't have a second parameter (why not rename it then?)
- Name as "unbind" (straightforward)
- Instead of an overload, just make the parameter ~optional~<ins>nullable</ins> (weird because extra parameters are thrown away; do we validate them?)

Fixes #3787
Fixes #2749
Closes #3788 (this PR includes that commit)