### PR TITLE
Adds maxFragmentCombinedOutputResources to GPUSupportedLimits.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1772,6 +1772,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxStorageBuffersPerShaderStage;
     readonly attribute unsigned long maxStorageTexturesPerShaderStage;
     readonly attribute unsigned long maxUniformBuffersPerShaderStage;
+    readonly attribute unsigned long maxFragmentCombinedOutputResources;
     readonly attribute unsigned long long maxUniformBufferBindingSize;
     readonly attribute unsigned long long maxStorageBufferBindingSize;
     readonly attribute unsigned long minUniformBufferOffsetAlignment;


### PR DESCRIPTION
I think this was left out of the original spec update. #3829