### PR TITLE
Variable address space restrictions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -262,6 +262,7 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
         text: front-facing; url: front-facing
         text: shader-output mask; url: shader-output-mask
         text: framebuffer; url: framebuffer
+        text: bindGroupLayout creation; url: bind-group-layout-creation
         for: supported limits
             text: maxComputeWorkgroupStorageSize; url: dom-supported-limits-maxcomputeworkgroupstoragesize
     type: abstract-op
@@ -4288,7 +4289,7 @@ effective-value-type.
 
 <tr><td class="nowrap">
         [=variable|var=]&lt;[=address spaces/storage=], read&gt;<br>
-        [=variable|var=]&lt;[=address spaces/storage=]&gt;
+        [=variable|var=]&lt;[=address spaces/storage=]&gt;<sup>5</sup>
     <td>Immutable
     <td>[=module scope|Module=]
     <td>[=type/concrete|Concrete=] [=host-shareable=]
@@ -4297,7 +4298,7 @@ effective-value-type.
     <td>Yes.<br>[=storage buffer=]
 
 <tr><td class="nowrap">
-        [=variable|var=]&lt;[=address spaces/storage=], read_write&gt;<sup>5</sup>
+        [=variable|var=]&lt;[=address spaces/storage=], read_write&gt;<sup>5,6</sup>
     <td>Mutable
     <td>[=module scope|Module=]
     <td>[=type/concrete|Concrete=] [=host-shareable=]
@@ -4313,8 +4314,8 @@ effective-value-type.
     <td>
     <td>Yes.<br>[=uniform buffer=]
 
-<tr><td>[=variable|var=]
-    <td>Immutable<sup>6</sup>
+<tr><td>[=variable|var=]<sup>6</sup>
+    <td>Immutable<sup>7</sup>
     <td>[=module scope|Module=]
     <td>[=texture type|Texture=]
     <td>Disallowed
@@ -4329,11 +4330,11 @@ effective-value-type.
     <td>
     <td>Yes.<br>[=sampler resource=]
 
-<tr><td>[=variable|var=]&lt;[=address spaces/workgroup=]&gt;<sup>5</sup>
+<tr><td>[=variable|var=]&lt;[=address spaces/workgroup=]&gt;<sup>6,8</sup>
     <td>Mutable
     <td>[=module scope|Module=]
-    <td>[=type/concrete|Concrete=] [=plain type=] with a [=fixed footprint=]<sup>7</sup>
-    <td>Disallowed<sup>8</sup>
+    <td>[=type/concrete|Concrete=] [=plain type=] with a [=fixed footprint=]<sup>9</sup>
+    <td>Disallowed<sup>10</sup>
     <td>
     <td>No
 
@@ -4341,7 +4342,7 @@ effective-value-type.
     <td>Mutable
     <td>[=module scope|Module=]
     <td>[=type/concrete|Concrete=] [=constructible=]
-    <td>Optional<sup>8</sup>
+    <td>Optional<sup>10</sup>
     <td>[=const-expression=] or [=override-expression=]
     <td>No
 
@@ -4350,7 +4351,7 @@ effective-value-type.
     <td>Mutable
     <td>[=function scope|Function=]
     <td>[=type/concrete|Concrete=] [=constructible=]
-    <td>Optional<sup>8</sup>
+    <td>Optional<sup>10</sup>
     <td>[=const-expression=], [=override-expression=], or [=runtime expression=]
     <td>No
 
@@ -4363,15 +4364,20 @@ effective-value-type.
     creation|pipeline-creation time=].
 4. [=Override-declarations=] are part of the shader interface, but are not
     bound resources.
-5. [=Atomic types=] can only appear in mutable storage buffers or workgroup
+5. [=Storage buffers=] and [=storage textures=] cannot be [=statically accessed=]
+    in a [=vertex shader stage=].
+    See [=bindGroupLayout creation=].
+6. [=Atomic types=] can only appear in mutable storage buffers or workgroup
     variables.
-6. The data in [[#texture-storage|storage textures]] with a [=access/write=]
+7. The data in [[#texture-storage|storage textures]] with a [=access/write=]
     [=access mode=] is mutable, but can only be modified via
     [[#texturestore|textureStore]] built-in function.
     The variable itself cannot be modified.
-7. The [=element count=] of the outermost [=array=] may be an
+8. Variables in the [=address spaces/workgroup=] address space can only be
+    [=statically accessed=] in a [=compute shader stage=].
+9. The [=element count=] of the outermost [=array=] may be an
     [=override-expression=].
-8. If there is no initializer, the variable is [=default initial value|default
+10. If there is no initializer, the variable is [=default initial value|default
     initialized=].
 
 ## Variables vs Values ## {#var-vs-value}
@@ -9041,6 +9047,15 @@ table.
 </table>
 
 WGSL [=predeclared|predeclares=] an [=enumerant=] for each address space, except for the `handle` address space.
+
+[=Variables=] in the [=address spaces/workgroup=] address space
+[=shader-creation error|must=] only be [=statically accessed=] in a [=compute
+shader stage=].
+
+[=Variables=] in the [=address spaces/storage=] address space ([=storage
+buffers=]) and variables whose [=store type=] is a
+[=storage texture=] cannot be [=statically accessed=] by a [=vertex shader stage=].
+See [=bindGroupLayout creation=].
 
 Note: Each address space may have different performance characteristics.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -262,7 +262,6 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
         text: front-facing; url: front-facing
         text: shader-output mask; url: shader-output-mask
         text: framebuffer; url: framebuffer
-        text: bindGroupLayout creation; url: bind-group-layout-creation
         for: supported limits
             text: maxComputeWorkgroupStorageSize; url: dom-supported-limits-maxcomputeworkgroupstoragesize
     type: abstract-op
@@ -4366,7 +4365,7 @@ effective-value-type.
     bound resources.
 5. [=Storage buffers=] and [=storage textures=] cannot be [=statically accessed=]
     in a [=vertex shader stage=].
-    See [=bindGroupLayout creation=].
+    See WebGPU {{GPUDevice/createBindGroupLayout()}}.
 6. [=Atomic types=] can only appear in mutable storage buffers or workgroup
     variables.
 7. The data in [[#texture-storage|storage textures]] with a [=access/write=]
@@ -9055,7 +9054,7 @@ shader stage=].
 [=Variables=] in the [=address spaces/storage=] address space ([=storage
 buffers=]) and variables whose [=store type=] is a
 [=storage texture=] cannot be [=statically accessed=] by a [=vertex shader stage=].
-See [=bindGroupLayout creation=].
+See WebGPU {{GPUDevice/createBindGroupLayout()}}.
 
 Note: Each address space may have different performance characteristics.
 


### PR DESCRIPTION
* Workgroup limited to compute
* Storage buffers and textures cannot be used in vertex (linked to API spec)