### PR TITLE
Fix up expiry timing definitions

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12916,7 +12916,7 @@ interface GPUCanvasContext {
             early as the next task, or as late as after all other task sources are empty
             (see [=automatic expiry task source=]).
             Expiry is only guaranteed when a visible canvas is displayed
-            ([=updating the rendering of a WebGPU canvas=]) and in other
+            ([$updating the rendering of a WebGPU canvas$]) and in other
             callers of [$Replace the drawing buffer$].
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2005,9 +2005,10 @@ It is used for the {{GPUDevice/uncapturederror}} event and {{GPUDevice}}.{{GPUDe
         to create |device|, and the steps |steps|.
 </div>
 
-### Automatic Expiry Task Source ### {#-automatic-expiry-task-source}
+<h4 id=automatic-expiry-task-source data-dfn-type=dfn>Automatic Expiry Task Source
+</h4>
 
-WebGPU defines a new [=task source=] called the <dfn dfn>automatic expiry task source</dfn>.
+WebGPU defines a new [=task source=] called the [=automatic expiry task source=].
 It is used for the automatic, timed expiry (destruction) of certain objects:
 
 - {{GPUTexture}}s returned by {{GPUCanvasContext/getCurrentTexture()}}
@@ -2023,25 +2024,16 @@ It is used for the automatic, timed expiry (destruction) of certain objects:
 
 Tasks from the [=automatic expiry task source=] **should** be processed with high priority; in
 particular, once queued, they **should** run before user-defined (JavaScript) tasks.
-This results in stricter behavior that helps developers write more portable applications, but
-developers are still strongly encouraged to test in multiple implementations.
 
 <div class=note>
-    Note: Since task source priority is not normatively defined, there is a range of points at which
-    tasks from this task queue can execute. In practice, this means these tasks can be implemented
-    with fixed steps inside the [=event loop processing model=].
-    All of the following options are valid:
+    Note:
+    This behavior is more predictable, and the strictness helps developers write more portable
+    applications by eagerly detecting incorrect assumptions about implicit lifetimes that may be
+    hard to detect. Developers are still strongly encouraged to test in multiple implementations.
 
-    - Immediately after running any task.
-    - Immediately after running animation frame callbacks.
-    - Immediately before rendering.
-        Note this choice results in less predictable expiry, especially for non-visible canvases
-        (e.g. scrolled off the screen or in a background tab), potentially allowing invalid programs
-        to appear correct or changing the behavior of websites which (incorrectly) rely on expiry
-        timing.
-
-        In the case of canvas texture expiry, expiry is also done in [$update the rendering of
-        the WebGPU canvas$], so it's equivalent for an implementation to elide the task entirely.
+    Implementation note:
+    It is valid to implement a high-priority expiry "task" by instead inserting additional steps at
+    a fixed point inside the [=event loop processing model=] rather than running an actual task.
 </div>
 
 ## Color Spaces and Encoding ## {#color-spaces}
@@ -5086,7 +5078,8 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
                     An external video texture should be imported in the same task that samples the texture
                     (which should generally be scheduled using `requestVideoFrameCallback` or
                     {{AnimationFrameProvider/requestAnimationFrame()}} depending on the application).
-                    Otherwise, a texture could get destroyed by these steps before it is used.
+                    Otherwise, a texture could get destroyed by these steps before the
+                    application is finished using it.
 
                 1. Set |result|.{{GPUObjectBase/label}} to |descriptor|.{{GPUObjectDescriptorBase/label}}.
                 1. Return |result|.
@@ -12911,6 +12904,22 @@ interface GPUCanvasContext {
         Get the {{GPUTexture}} that will be composited to the document by the {{GPUCanvasContext}}
         next.
 
+        <div class=note>
+            Note:
+            An application **should** call {{GPUCanvasContext/getCurrentTexture()}}
+            in the same task that renders to the canvas texture.
+            Otherwise, the texture could get destroyed by these steps before the
+            application is finished rendering to it.
+
+            The expiry task (defined below) is optional to implement.
+            Even if implemented, task source priority is not normatively defined, so may happen as
+            early as the next task, or as late as after all other task sources are empty
+            (see [=automatic expiry task source=]).
+            Expiry is only guaranteed when a visible canvas is displayed
+            ([=updating the rendering of a WebGPU canvas=]) and in other
+            callers of [$Replace the drawing buffer$].
+        </div>
+
         <div algorithm=GPUCanvasContext.getCurrentTexture>
             <div data-timeline=content>
                 **Called on:** {{GPUCanvasContext}} |this|.
@@ -12935,7 +12944,7 @@ interface GPUCanvasContext {
                         this generates and error and returns an [=invalid=] {{GPUTexture}}.
                         Some validation here is redundant with that done in {{GPUCanvasContext/configure()}}.
                         Implementations **must not** skip this redundant validation.
-                1. [$queue an automatic expiry task$] with device |device| and the following steps:
+                1. **Optionally**, [$queue an automatic expiry task$] with device |device| and the following steps:
 
                     <div data-timeline=content>
                         1. [$Expire the current texture$] of |this|.


### PR DESCRIPTION
This fix stems from yet another misunderstanding I had about the event loop: I thought it was allowed to starve a task source, but on closer reading I don't think it is.

This change specs the thing I said we were speccing so it's just an editorial fix. It more straightforwardly makes the timed canvas texture expiry task *optional*.

This doesn't change the expiry semantics of external textures, still just a task. I think this is OK, IIRC we didn't actually want expiry-on-rAF or similar for external textures.