### PR TITLE
Switch all GPUExtent/Origin accessors namespace

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1530,25 +1530,25 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
     <tr><td><dfn>maxTextureDimension1D</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8192
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=]
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"1d"}}.
 
     <tr><td><dfn>maxTextureDimension2D</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8192
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=] and {{GPUTextureDescriptor/size}}.[=Extent3D/height=]
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] and {{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"2d"}}.
 
     <tr><td><dfn>maxTextureDimension3D</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=], {{GPUTextureDescriptor/size}}.[=Extent3D/height=] and {{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=]
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=], {{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] and {{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"3d"}}.
 
     <tr><td><dfn>maxTextureArrayLayers</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>256
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=]
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"2d"}}.
 
     <tr><td><dfn>maxBindGroups</dfn>
@@ -3879,8 +3879,8 @@ GPUTexture includes GPUObjectBase;
     **Returns:** {{GPUExtent3DDict}}
 
     1. Let |extent| be a new {{GPUExtent3DDict}} object.
-    1. Set |extent|.{{GPUExtent3DDict/width}} to max(1, |baseSize|.[=Extent3D/width=] &Gt; |mipLevel|).
-    1. Set |extent|.{{GPUExtent3DDict/height}} to max(1, |baseSize|.[=Extent3D/height=] &Gt; |mipLevel|).
+    1. Set |extent|.{{GPUExtent3DDict/width}} to max(1, |baseSize|.[=GPUExtent3D/width=] &Gt; |mipLevel|).
+    1. Set |extent|.{{GPUExtent3DDict/height}} to max(1, |baseSize|.[=GPUExtent3D/height=] &Gt; |mipLevel|).
     1. Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
     1. Return |extent|.
 </div>
@@ -3904,21 +3904,21 @@ The <dfn dfn>logical miplevel-specific texture extent</dfn> of a [=texture=] is 
         <dl class=switch>
             : {{GPUTextureDimension/"1d"}}
             ::
-                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] &Gt; |mipLevel|).
                 - Set |extent|.{{GPUExtent3DDict/height}} to 1.
                 - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
 
             : {{GPUTextureDimension/"2d"}}
             ::
-                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
-                - Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
-                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=].
 
             : {{GPUTextureDimension/"3d"}}
             ::
-                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
-                - Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
-                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] &Gt; |mipLevel|).
         </dl>
     1. Return |extent|.
 </div>
@@ -3944,21 +3944,21 @@ to form complete [=texel blocks=] in the [=texture=]. It is calculated by this p
         <dl class=switch>
             : {{GPUTextureDimension/"1d"}}
             ::
-                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
+                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=GPUExtent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
                 - Set |extent|.{{GPUExtent3DDict/height}} to 1.
                 - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
 
             : {{GPUTextureDimension/"2d"}}
             ::
-                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
-                - Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
-                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
+                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=GPUExtent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
+                - Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=GPUExtent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=GPUExtent3D/depthOrArrayLayers=].
 
             : {{GPUTextureDimension/"3d"}}
             ::
-                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
-                - Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
-                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
+                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=GPUExtent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
+                - Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=GPUExtent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=GPUExtent3D/depthOrArrayLayers=].
         </dl>
     1. Return |extent|.
 </div>
@@ -4124,10 +4124,10 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                 :: Return 1.
 
                 : {{GPUTextureDimension/"2d"}}
-                :: Let |m| = max(|size|.[=Extent3D/width=], |size|.[=Extent3D/height=]).
+                :: Let |m| = max(|size|.[=GPUExtent3D/width=], |size|.[=GPUExtent3D/height=]).
 
                 : {{GPUTextureDimension/"3d"}}
-                :: Let |m| = max(max(|size|.[=Extent3D/width=], |size|.[=Extent3D/height=]), |size|.[=Extent3D/depthOrArrayLayer=]).
+                :: Let |m| = max(max(|size|.[=GPUExtent3D/width=], |size|.[=GPUExtent3D/height=]), |size|.[=GPUExtent3D/depthOrArrayLayer=]).
             </dl>
     1. Return floor(log<sub>2</sub>(|m|)) + 1.
 </div>
@@ -4157,9 +4157,9 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                 1. [=?=] [$Validate texture format required features$] of each element of
                     |descriptor|.{{GPUTextureDescriptor/viewFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
                 1. Let |t| be a new {{GPUTexture}} object.
-                1. Set |t|.{{GPUTexture/width}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
-                1. Set |t|.{{GPUTexture/height}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
-                1. Set |t|.{{GPUTexture/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+                1. Set |t|.{{GPUTexture/width}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=].
+                1. Set |t|.{{GPUTexture/height}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=].
+                1. Set |t|.{{GPUTexture/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=].
                 1. Set |t|.{{GPUTexture/mipLevelCount}} to |descriptor|.{{GPUTextureDescriptor/mipLevelCount}}.
                 1. Set |t|.{{GPUTexture/sampleCount}} to |descriptor|.{{GPUTextureDescriptor/sampleCount}}.
                 1. Set |t|.{{GPUTexture/dimension}} to |descriptor|.{{GPUTextureDescriptor/dimension}}.
@@ -4192,9 +4192,9 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
     - |this| must be a [=valid=] {{GPUDevice}}.
     - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
     - |descriptor|.{{GPUTextureDescriptor/usage}} must contain only bits present in |this|'s [=allowed texture usages=].
-    - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=],
-        |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=],
-        and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be &gt; zero.
+    - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=],
+        |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=],
+        and |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be &gt; zero.
     - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be &gt; zero.
     - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be either 1 or 4.
     - If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
@@ -4202,38 +4202,38 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
         <dl class=switch>
             : {{GPUTextureDimension/"1d"}}
             ::
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be &le;
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be &le;
                     |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension1D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be 1.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be 1.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be 1.
                 - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
                 - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
 
             : {{GPUTextureDimension/"2d"}}
             ::
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be &le;
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be &le;
                     |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be &le;
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be &le;
                     |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be &le;
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be &le;
                     |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureArrayLayers}}.
 
             : {{GPUTextureDimension/"3d"}}
             ::
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be &le;
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be &le;
                     |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be &le;
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be &le;
                     |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be &le;
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be &le;
                     |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
                 - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
                 - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
         </dl>
-    - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be multiple of [=texel block width=].
-    - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be multiple of [=texel block height=].
+    - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be multiple of [=texel block width=].
+    - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be multiple of [=texel block height=].
     - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
         - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
-        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
+        - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be 1.
         - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE_BINDING}} bit.
         - |descriptor|.{{GPUTextureDescriptor/usage}} must include the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit.
         - |descriptor|.{{GPUTextureDescriptor/format}} must support multisampling according to [[#texture-format-caps]].
@@ -12378,11 +12378,11 @@ GPUQueue includes GPUObjectBase;
                 1. If any of the following requirements are unmet, throw an {{OperationError}} and stop.
 
                     <div class=validusage>
-                        - |source|.|origin|.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]
+                        - |source|.|origin|.[=GPUOrigin3D/x=] + |copySize|.[=GPUExtent3D/width=]
                             must be &le; the width of |sourceImage|.
-                        - |source|.|origin|.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]
+                        - |source|.|origin|.[=GPUOrigin3D/y=] + |copySize|.[=GPUExtent3D/height=]
                             must be &le; the height of |sourceImage|.
-                        - |source|.|origin|.[=Origin3D/z=] + |copySize|.[=Extent3D/depthOrArrayLayers=]
+                        - |source|.|origin|.[=GPUOrigin3D/z=] + |copySize|.[=GPUExtent3D/depthOrArrayLayers=]
                             must be &le; 1.
                     </div>
                 1. Let |usability| be [=?=] [=check the usability of the image argument=](|source|).
@@ -14535,11 +14535,7 @@ dictionary GPUOrigin2DDict {
 typedef (sequence<GPUIntegerCoordinate> or GPUOrigin2DDict) GPUOrigin2D;
 </script>
 
-An <dfn dfn>Origin2D</dfn> is a {{GPUOrigin2D}}.
-[=Origin2D=] is a spec namespace for the following definitions:
-<!-- This is silly, but provides convenient syntax for the spec. -->
-
-<div algorithm="GPUOrigin2D accessors" dfn-for=Origin2D>
+<div algorithm="GPUOrigin2D accessors" dfn-for=GPUOrigin2D>
     For a given {{GPUOrigin2D}} value |origin|, depending on its type, the syntax:
 
     - |origin|.<dfn dfn>x</dfn> refers to
@@ -14570,11 +14566,7 @@ dictionary GPUOrigin3DDict {
 typedef (sequence<GPUIntegerCoordinate> or GPUOrigin3DDict) GPUOrigin3D;
 </script>
 
-An <dfn dfn>Origin3D</dfn> is a {{GPUOrigin3D}}.
-[=Origin3D=] is a spec namespace for the following definitions:
-<!-- This is silly, but provides convenient syntax for the spec. -->
-
-<div algorithm="GPUOrigin3D accessors" dfn-for=Origin3D>
+<div algorithm="GPUOrigin3D accessors" dfn-for=GPUOrigin3D>
     For a given {{GPUOrigin3D}} value |origin|, depending on its type, the syntax:
 
     - |origin|.<dfn dfn>x</dfn> refers to
@@ -14609,11 +14601,7 @@ dictionary GPUExtent3DDict {
 typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 </script>
 
-An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
-[=Extent3D=] is a spec namespace for the following definitions:
-<!-- This is silly, but provides convenient syntax for the spec. -->
-
-<div algorithm="GPUExtent3D accessors" dfn-for=Extent3D>
+<div algorithm="GPUExtent3D accessors" dfn-for=GPUExtent3D>
     For a given {{GPUExtent3D}} value |extent|, depending on its type, the syntax:
 
     - |extent|.<dfn dfn>width</dfn> refers to
@@ -15506,7 +15494,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
 
 Eventually all of these should disappear but they are useful to avoid warning while building the specification.
 
-[=Origin2D/x=] [=Origin2D/y=]
+[=GPUOrigin2D/x=] [=GPUOrigin2D/y=]
 [=vertex buffer=]
 [=buffer internals/state=]
 [=buffer internals/state/available=]

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -176,8 +176,8 @@ dictionary GPUImageCopyTexture {
         - |imageCopyTexture|.{{GPUImageCopyTexture/texture}} must be a [=valid=] {{GPUTexture}}.
         - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be &lt;
             |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/mipLevelCount}}.
-        - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
-        - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/x=] must be a multiple of |blockWidth|.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/y=] must be a multiple of |blockHeight|.
         - The [=imageCopyTexture subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
             the following conditions is true:
             - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}} is a depth-stencil format.
@@ -281,7 +281,7 @@ dictionary GPUImageCopyExternalImage {
 
     The [=imageCopyTexture subresource size=] of |imageCopyTexture| is calculated as follows:
 
-    Its [=Extent3D/width=], [=Extent3D/height=] and [=Extent3D/depthOrArrayLayers=] are the width, height, and depth, respectively,
+    Its [=GPUExtent3D/width=], [=GPUExtent3D/height=] and [=GPUExtent3D/depthOrArrayLayers=] are the width, height, and depth, respectively,
     of the [=physical miplevel-specific texture extent=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} [=subresource=] at [=mipmap level=]
     |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}}.
 </div>
@@ -301,9 +301,9 @@ dictionary GPUImageCopyExternalImage {
     :: Extent of the texture to copy.
 
     1. Let:
-        - |widthInBlocks| be |copyExtent|.[=Extent3D/width=] &divide; the [=texel block width=] of |format|.
+        - |widthInBlocks| be |copyExtent|.[=GPUExtent3D/width=] &divide; the [=texel block width=] of |format|.
             [=Assert=] this is an integer.
-        - |heightInBlocks| be |copyExtent|.[=Extent3D/height=] &divide; the [=texel block height=] of |format|.
+        - |heightInBlocks| be |copyExtent|.[=GPUExtent3D/height=] &divide; the [=texel block height=] of |format|.
             [=Assert=] this is an integer.
         - |bytesInLastRow| be |widthInBlocks| &times; the [=texel block copy footprint=] of |format|.
     1. Fail if the following input validation requirements are not met:
@@ -311,7 +311,7 @@ dictionary GPUImageCopyExternalImage {
         <div class=validusage>
             - If |heightInBlocks| &gt; 1,
                 |layout|.{{GPUImageDataLayout/bytesPerRow}} must be specified.
-            - If |copyExtent|.[=Extent3D/depthOrArrayLayers=] &gt; 1,
+            - If |copyExtent|.[=GPUExtent3D/depthOrArrayLayers=] &gt; 1,
                 |layout|.{{GPUImageDataLayout/bytesPerRow}} and
                 |layout|.{{GPUImageDataLayout/rowsPerImage}} must be specified.
             - If specified, |layout|.{{GPUImageDataLayout/bytesPerRow}}
@@ -325,9 +325,9 @@ dictionary GPUImageCopyExternalImage {
 
         Note: These default values have no effect, as they're always multiplied by 0.
     1. Let |requiredBytesInCopy| be 0.
-    1. If |copyExtent|.[=Extent3D/depthOrArrayLayers=] &gt; 0:
+    1. If |copyExtent|.[=GPUExtent3D/depthOrArrayLayers=] &gt; 0:
         1. Increment |requiredBytesInCopy| by
-            |bytesPerRow| &times; |rowsPerImage| &times; (|copyExtent|.[=Extent3D/depthOrArrayLayers=] &minus; 1).
+            |bytesPerRow| &times; |rowsPerImage| &times; (|copyExtent|.[=GPUExtent3D/depthOrArrayLayers=] &minus; 1).
         1. If |heightInBlocks| &gt; 0:
             1. Increment |requiredBytesInCopy| by
                 |bytesPerRow| &times; (|heightInBlocks| &minus; 1) + |bytesInLastRow|.
@@ -354,11 +354,11 @@ dictionary GPUImageCopyExternalImage {
     1. Let |subresourceSize| be the [=imageCopyTexture subresource size=] of |imageCopyTexture|.
     1. Return whether all the conditions below are satisfied:
 
-        - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]) &le; |subresourceSize|.[=Extent3D/width=]
-        - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]) &le; |subresourceSize|.[=Extent3D/height=]
-        - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depthOrArrayLayers=]) &le; |subresourceSize|.[=Extent3D/depthOrArrayLayers=]
-        - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
-        - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
+        - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/x=] + |copySize|.[=GPUExtent3D/width=]) &le; |subresourceSize|.[=GPUExtent3D/width=]
+        - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/y=] + |copySize|.[=GPUExtent3D/height=]) &le; |subresourceSize|.[=GPUExtent3D/height=]
+        - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/z=] + |copySize|.[=GPUExtent3D/depthOrArrayLayers=]) &le; |subresourceSize|.[=GPUExtent3D/depthOrArrayLayers=]
+        - |copySize|.[=GPUExtent3D/width=] must be a multiple of |blockWidth|.
+        - |copySize|.[=GPUExtent3D/height=] must be a multiple of |blockHeight|.
 </div>
 
 <div algorithm>
@@ -379,7 +379,7 @@ dictionary GPUImageCopyExternalImage {
         |imageCopyTexture|.{{GPUImageCopyTexture/aspect}}.
     - If |texture|.{{GPUTexture/dimension}} is {{GPUTextureDimension/"2d"}}:
         - The [=array layer=] of |s| is &ge;
-            |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=] and &lt;
-            |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=] +
-            |copySize|.[=Extent3D/depthOrArrayLayers=].
+            |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/z=] and &lt;
+            |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/z=] +
+            |copySize|.[=GPUExtent3D/depthOrArrayLayers=].
 </div>


### PR DESCRIPTION
I think when we wrote this we didn't realize we could namespace dfn definitions inside typedef definitions, so we created the Origin2D/Origin3D/Extent3D dfns for namespacing. This cleans that up.

Landing without review because this is trivial (find-replace) and likely to have merge conflicts (sorry to anyone who hits this).