### PR TITLE
[editorial] Change redundant inter-stage variable validation to assertion

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7770,12 +7770,6 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
         - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
         - If the "sample_mask" [=builtin=] is a [=shader stage output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
             - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
-        - For each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}} there
-            must be a user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}} that
-            [=location=], type, and [=interpolation=] of the input.
-
-            Note: This means that vertex-only pipelines can have user-defined outputs in the vertex stage:
-            they will be discarded.
 
     - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|) succeeds.
     - If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is [=map/exist|provided=]:
@@ -7794,29 +7788,46 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 
     **Returns:** {{boolean}}
 
-    1. Let |maxVertexShaderOutputComponents| be |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
-        1. If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}} is
-            {{GPUPrimitiveTopology/"point-list"}}:
+    1. Let |maxVertexShaderOutputComponents| be
+        |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
+        1. If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}}
+            is {{GPUPrimitiveTopology/"point-list"}}:
             1. Decrement |maxVertexShaderOutputComponents| by 1.
-    1. Let |maxFragmentShaderInputComponents| be |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
-        1. If the `front_facing` [=builtin=] is an input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
-            1. Decrement |maxFragmentShaderInputComponents| by 1.
-        1. If the `sample_index` [=builtin=] is an input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
-            1. Decrement |maxFragmentShaderInputComponents| by 1.
-        1. If the `sample_mask` [=builtin=] is an input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
-            1. Decrement |maxFragmentShaderInputComponents| by 1.
-    1. Return `true` if and only if all of the following conditions are satisfied:
-        - The [=location=] of each user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}} is less
-            than (|device|.limits.{{supported limits/maxInterStageShaderVariables}}).
-        - The [=location=] of each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is less
-            than (|device|.limits.{{supported limits/maxInterStageShaderVariables}}).
-        - There are no more than |maxVertexShaderOutputComponents| scalar
+    1. Return `false` if any of the following requirements are unmet:
+        - There must be no more than |maxVertexShaderOutputComponents| scalar
             components across all user-defined outputs for
             |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
             (For example, a `f32` output uses 1 component, and a `vec3<f32>` output uses 3 components.)
-        - There are no more than |maxFragmentShaderInputComponents| scalar
-            components across all user-defined inputs for
-            |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
+        - The [=location=] of each user-defined output of
+            |descriptor|.{{GPURenderPipelineDescriptor/vertex}} must be
+            &lt; |device|.limits.{{supported limits/maxInterStageShaderVariables}}.
+    1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} [=map/exist|is provided=]:
+        1. Let |maxFragmentShaderInputComponents| be
+            |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
+            1. If the `front_facing` [=builtin=] is an input of
+                |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+                1. Decrement |maxFragmentShaderInputComponents| by 1.
+            1. If the `sample_index` [=builtin=] is an input of
+                |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+                1. Decrement |maxFragmentShaderInputComponents| by 1.
+            1. If the `sample_mask` [=builtin=] is an input of
+                |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+                1. Decrement |maxFragmentShaderInputComponents| by 1.
+        1. Return `false` if any of the following requirements are unmet:
+            - There must be no more than |maxFragmentShaderInputComponents| scalar
+                components across all user-defined inputs for
+                |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
+            - For each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}} there
+                must be a user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}} that
+                [=location=], type, and [=interpolation=] of the input.
+
+                Note: Vertex-only pipelines **can** have user-defined outputs in the vertex stage;
+                their values will be discarded.
+        1. [=Assert=] that the [=location=] of each user-defined input of
+            |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is less
+            than |device|.limits.{{supported limits/maxInterStageShaderVariables}}
+            (resulting from the above rules).
+    1. Return `true`.
 </div>
 
 <div class=example>


### PR DESCRIPTION
- Moved the vertex-fragment subset rule to this algorithm
- Fixed algorithm for vertex-only pipelines
- Changed fragment-input index validation to an assertion

Fixes #3865