### PR TITLE
Define GPUImageCopyExternalImage source size

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -62,8 +62,9 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
         text: check the usability of the image argument; url: canvas.html#check-the-usability-of-the-image-argument
         text: placeholder canvas element; url: canvas.html#offscreencanvas-placeholder
         text: event loop processing model; url: webappapis.html#event-loop-processing-model
-        text: intrinsic width; url: media.html#concept-video-intrinsic-width
-        text: intrinsic height; url: media.html#concept-video-intrinsic-height
+        for: video
+            text: intrinsic width; url: media.html#concept-video-intrinsic-width
+            text: intrinsic height; url: media.html#concept-video-intrinsic-height
 spec: WEBGL-1; urlPrefix: https://www.khronos.org/registry/webgl/specs/latest/1.0/#
     type: interface
         text: WebGLRenderingContext; url: WEBGLRENDERINGCONTEXT

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -64,6 +64,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
         text: check the usability of the image argument; url: canvas.html#check-the-usability-of-the-image-argument
         text: placeholder canvas element; url: canvas.html#offscreencanvas-placeholder
         text: event loop processing model; url: webappapis.html#event-loop-processing-model
+        text: intrinsic width; url: media.html#concept-video-intrinsic-width
+        text: intrinsic height; url: media.html#concept-video-intrinsic-height
 spec: WEBGL-1; urlPrefix: https://www.khronos.org/registry/webgl/specs/latest/1.0/#
     type: interface
         text: WebGLRenderingContext; url: WEBGLRENDERINGCONTEXT

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -268,8 +268,8 @@ dictionary GPUImageCopyExternalImage {
                     <td>{{ImageBitmap/height|ImageBitmap.height}}
                 <tr>
                     <td>{{HTMLVideoElement}}
-                    <td>{{HTMLVideoElement/videoWidth|HTMLVideoElement.videoWidth}}
-                    <td>{{HTMLVideoElement/videoHeight|HTMLVideoElement.videoHeight}}
+                    <td>[[html#concept-video-intrinsic-width|intrinsic width]]]
+                    <td>[[html#concept-video-intrinsic-height|intrinsic height]]
                 <tr>
                     <td>{{HTMLCanvasElement}}
                     <td>{{HTMLCanvasElement/width|HTMLCanvasElement.width}}

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -268,8 +268,8 @@ dictionary GPUImageCopyExternalImage {
                     <td>{{ImageBitmap/height|ImageBitmap.height}}
                 <tr>
                     <td>{{HTMLVideoElement}}
-                    <td>[[html#concept-video-intrinsic-width|intrinsic width]]]
-                    <td>[[html#concept-video-intrinsic-height|intrinsic height]]
+                    <td>[[media.html#concept-video-intrinsic-width|intrinsic width]]]
+                    <td>[[media.html#concept-video-intrinsic-height|intrinsic height]]
                 <tr>
                     <td>{{HTMLCanvasElement}}
                     <td>{{HTMLCanvasElement/width|HTMLCanvasElement.width}}

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -268,8 +268,8 @@ dictionary GPUImageCopyExternalImage {
                     <td>{{ImageBitmap/height|ImageBitmap.height}}
                 <tr>
                     <td>{{HTMLVideoElement}}
-                    <td>[=intrinsic width=]
-                    <td>[=intrinsic height=]
+                    <td>[=intrinsic width|intrinsic width of the media resource=]
+                    <td>[=intrinsic height|intrinsic height of the media resource=]
                 <tr>
                     <td>{{HTMLCanvasElement}}
                     <td>{{HTMLCanvasElement/width|HTMLCanvasElement.width}}

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -268,8 +268,8 @@ dictionary GPUImageCopyExternalImage {
                     <td>{{ImageBitmap/height|ImageBitmap.height}}
                 <tr>
                     <td>{{HTMLVideoElement}}
-                    <td>[[media.html#concept-video-intrinsic-width|intrinsic width]]]
-                    <td>[[media.html#concept-video-intrinsic-height|intrinsic height]]
+                    <td>[=intrinsic width=]
+                    <td>[=intrinsic height=]
                 <tr>
                     <td>{{HTMLCanvasElement}}
                     <td>{{HTMLCanvasElement/width|HTMLCanvasElement.width}}

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -251,7 +251,35 @@ dictionary GPUImageCopyExternalImage {
     : <dfn>source</dfn>
     ::
         The source of the [=image copy=]. The copy source data is captured at the moment that
-        {{GPUQueue/copyExternalImageToTexture()}} is issued.
+        {{GPUQueue/copyExternalImageToTexture()}} is issued. Source size is defined by source
+        type, given by this table:
+        
+        <table class=data>
+            <thead>
+                <tr>
+                    <th>Source type
+                    <th>Width
+                    <th>Height
+            </thead>
+            <tbody>
+                <tr>
+                    <td>{{ImageBitmap}}
+                    <td>{{ImageBitmap/width|ImageBitmap.width}}
+                    <td>{{ImageBitmap/height|ImageBitmap.height}}
+                <tr>
+                    <td>{{HTMLVideoElement}}
+                    <td>{{HTMLVideoElement/videoWidth|HTMLVideoElement.videoWidth}}
+                    <td>{{HTMLVideoElement/videoHeight|HTMLVideoElement.videoHeight}}
+                <tr>
+                    <td>{{HTMLCanvasElement}}
+                    <td>{{HTMLCanvasElement/width|HTMLCanvasElement.width}}
+                    <td>{{HTMLCanvasElement/height|HTMLCanvasElement.height}}
+                <tr>
+                    <td>{{OffscreenCanvas}}
+                    <td>{{OffscreenCanvas/width|OffscreenCanvas.width}}
+                    <td>{{OffscreenCanvas/height|OffscreenCanvas.height}}
+            </tbody>
+        </table>
 
     : <dfn>origin</dfn>
     ::

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -268,8 +268,8 @@ dictionary GPUImageCopyExternalImage {
                     <td>{{ImageBitmap/height|ImageBitmap.height}}
                 <tr>
                     <td>{{HTMLVideoElement}}
-                    <td>[=intrinsic width|intrinsic width of the media resource=]
-                    <td>[=intrinsic height|intrinsic height of the media resource=]
+                    <td>[=video/intrinsic width|intrinsic width of the frame=]
+                    <td>[=video/intrinsic height|intrinsic height of the frame=]
                 <tr>
                     <td>{{HTMLCanvasElement}}
                     <td>{{HTMLCanvasElement/width|HTMLCanvasElement.width}}


### PR DESCRIPTION
GPUImageCopyExternalImage doesn't describe source size clearly. It might confuse developer when they use copyExternalImageToTexture() and set source origin and copy size.

This PR resolve this issue by providing exactly source size defination for different source type.