### PR TITLE
editorial: Texel format and access mode are not context-dependent names

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3996,8 +3996,8 @@ See [[#texture-builtin-functions]].
 `texture_storage_3d<texel_format,access>`
 </pre>
 
-* `texel_format` is a [=context-dependent name=] and [=shader-creation error|must=] be one of the texel types specified in [=storage-texel-formats=]
-* `access` is a [=context-dependent name=] and [=shader-creation error|must=] be [=access/write=].
+* `texel_format` [=shader-creation error|must=] be an [=enumerant=] for one of the [=storage-texel-formats|texel formats for storage textures=]
+* `access` [=shader-creation error|must=] be the [=enumerant=] for [=access/write=] [=access mode=].
 
 ### Depth Texture Types ### {#texture-depth}
 <pre class='def'>


### PR DESCRIPTION
Fix the text in the description of storage textures.

Fixes: #3963