### PR TITLE
editorial: Define and use "logical texel address"

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3757,7 +3757,7 @@ A texture is either arrayed, or non-arrayed:
 A texture has the following features:
 
 : texel format
-:: The data in each texel. See [[#texel-formats]].
+:: The data representation in each texel. See [[#texel-formats]].
 :  <dfn dfn-for=texture noexport>dimensionality</dfn>
 :: The number of dimensions in the grid coordinates, and how the coordinates are interpreted.
     The number of dimensions is 1, 2, or 3.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3751,24 +3751,23 @@ A WGSL texture corresponds to a WebGPU {{GPUTexture}}.
 
 A texture is either arrayed, or non-arrayed:
 
-* A <dfn noexport>non-arrayed texture</dfn> is a grid of texels. Each texel has a unique grid coordinate.
+* A <dfn noexport>non-arrayed texture</dfn> is a grid of texels.
 * An <dfn noexport>arrayed texture</dfn> is a homogeneous array of grids of texels.
-    In an arrayed texture, each texel is identified with its unique combination of array index and grid coordinate.
 
 A texture has the following features:
 
 : texel format
 :: The data in each texel. See [[#texel-formats]].
-:  dimensionality
+:  <dfn dfn-for=texture noexport>dimensionality</dfn>
 :: The number of dimensions in the grid coordinates, and how the coordinates are interpreted.
     The number of dimensions is 1, 2, or 3.
     Most textures use cartesian coordinates.
     Cube textures have six square faces, and are sampled with
     a three dimensional coordinate interpreted as a direction vector from the origin toward
     the cube centered on the origin.
-: size
-:: The extent of grid coordinates along each dimension.
-: mip level count
+: <dfn dfn-for=texture noexport>size</dfn>
+:: The extent of grid coordinates along each dimension. This is a function of [=mip level=].
+: <dfn dfn-for=texture noexport>mip level count</dfn>
 :: The mip level count is at least 1 for sampled textures, and equal to 1 for storage textures.<br>
     <dfn>Mip level</dfn> 0 contains a full size version of the texture.
     Each successive mip level contains a filtered version of the previous mip level
@@ -3778,10 +3777,21 @@ A texture has the following features:
     filtering to produce the sampled value.
 : arrayed
 :: Whether the texture is arrayed.
-: <dfn noexport>array size</dfn>
-:: The number of homogeneous grids, if the texture is arrayed
+: <dfn dfn-for=texture noexport>array size</dfn>
+:: The number of homogeneous grids, if the texture is [=arrayed texture|arrayed=]
+: <dfn dfn-for=texture noexport>sample count</dfn>
+:: The number of samples, if the texture is [[#multisampled-texture-type|multisampled]].
 
-A texture's representation is typically optimized for rendering operations.
+Each texel in a texture is associated with a unique <dfn noexport>logical texel address</dfn>,
+which is an integer tuple having:
+* A [=mip level=] in [0, [=texture/mip level count=]).
+* A number of components, controlled by the [=texture/dimensionality=], with each
+    component value in [0, [=texture/size=]).
+    Note that [=texture/size=] is a function of [=mip level=].
+* An array index in [0, [=texture/array size=]), if the texture is [=arrayed texture|arrayed=].
+* A sample index in [0, [=texture/sample count=]), if the texture is [[#multisampled-texture-type|multisampled]].
+
+A texture's physical organization is typically optimized for rendering operations.
 To achieve this, many details are hidden from the programmer, including data layouts, data types, and
 internal operations that cannot be expressed directly in the shader language.
 
@@ -3811,6 +3821,7 @@ The <dfn>texture types</dfn> are the set of types defined in:
 * [[#sampled-texture-type]]
 * [[#multisampled-texture-type]]
 * [[#external-texture-type]]
+* [[#texture-storage]]
 * [[#texture-depth]]
 
 A [=sampler=] is an opaque handle that controls how [=texels=] are accessed
@@ -15066,14 +15077,14 @@ Reads a single texel from a texture without sampling or filtering.
 
 The unfiltered texel data.
 
-An [=out of bounds access=] occurs if:
+The [=logical texel address=] is invalid if:
 * any element of `coords` is outside the range `[0, textureDimensions(t, level))`
     for the corresponding element, or
 * `array_index` is outside the range `[0, textureNumLayers(t))`, or
 * `level` is outside the range `[0, textureNumLevels(t))`, or
 * `sample_index` is outside the range `[0, textureNumSamples(s))`
 
-If an [=out of bounds access=] occurs, the built-in function returns one of:
+If the logical texel addresss is invalid, the built-in function returns one of:
 * The data for some texel within bounds of the texture
 * A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
 * 0.0 for depth textures
@@ -16015,12 +16026,12 @@ fn textureStore(t: texture_storage_3d<F,write>,
 
 **Note:**
 
-An out-of-bounds access occurs if:
+The [=logical texel address=] is invalid if:
 * any element of `coords` is outside the range `[0, textureDimensions(t))`
     for the corresponding element, or
 * `array_index` is outside the range of `[0, textureNumLayers(t))`
 
-If an out-of-bounds access occurs, the built-in function may do any of the following:
+If the logical texel addresss is invalid, the built-in function may do any of the following:
 * not be executed
 * store `value` to some in bounds texel
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3749,16 +3749,11 @@ See [[#texture-builtin-functions]] for a complete list.
 
 A WGSL texture corresponds to a WebGPU {{GPUTexture}}.
 
-A texture is either arrayed, or non-arrayed:
-
-* A <dfn noexport>non-arrayed texture</dfn> is a grid of texels.
-* An <dfn noexport>arrayed texture</dfn> is a homogeneous array of grids of texels.
-
 A texture has the following features:
 
-: texel format
-:: The data representation in each texel. See [[#texel-formats]].
-:  <dfn dfn-for=texture noexport>dimensionality</dfn>
+: <dfn dfn-for=texture noexport>texel format</dfn>
+:: The data representation of each texel. See [[#texel-formats]].
+: <dfn dfn-for=texture noexport>dimensionality</dfn>
 :: The number of dimensions in the grid coordinates, and how the coordinates are interpreted.
     The number of dimensions is 1, 2, or 3.
     Most textures use cartesian coordinates.
@@ -3775,10 +3770,12 @@ A texture has the following features:
     When sampling a texture, an explicit or implicitly-computed level-of-detail is used
     to select the mip levels from which to read texel data.  These are then combined via
     filtering to produce the sampled value.
-: arrayed
+: <dfn dfn-for=texture noexport>arrayed</dfn>
 :: Whether the texture is arrayed.
+    * A non-arrayed texture is a grid of texels.
+    * An arrayed texture is a homogeneous array of grids of texels.
 : <dfn dfn-for=texture noexport>array size</dfn>
-:: The number of homogeneous grids, if the texture is [=arrayed texture|arrayed=]
+:: The number of homogeneous grids, if the texture is [=texture/arrayed=].
 : <dfn dfn-for=texture noexport>sample count</dfn>
 :: The number of samples, if the texture is [[#multisampled-texture-type|multisampled]].
 
@@ -3787,8 +3784,8 @@ which is an integer tuple having:
 * A [=mip level=] in [0, [=texture/mip level count=]).
 * A number of components, controlled by the [=texture/dimensionality=], with each
     component value in [0, [=texture/size=]).
+* An array index in [0, [=texture/array size=]), if the texture is [=texture/arrayed=].
     Note that [=texture/size=] is a function of [=mip level=].
-* An array index in [0, [=texture/array size=]), if the texture is [=arrayed texture|arrayed=].
 * A sample index in [0, [=texture/sample count=]), if the texture is [[#multisampled-texture-type|multisampled]].
 
 A texture's physical organization is typically optimized for rendering operations.
@@ -15091,7 +15088,7 @@ If the logical texel addresss is invalid, the built-in function returns one of:
 
 ### `textureNumLayers` ### {#texturenumlayers}
 
-Returns the number of layers (elements) of an array texture.
+Returns the number of layers (elements) of an [=texture/arrayed=] texture.
 
 <table class='data'>
   <thead>
@@ -15120,7 +15117,7 @@ Returns the number of layers (elements) of an array texture.
 
 **Returns:**
 
-The number of layers (elements) of the array texture.
+The number of layers (elements) of the [=texture/arrayed=] texture.
 
 
 ### `textureNumLevels` ### {#texturenumlevels}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3751,7 +3751,7 @@ A WGSL texture corresponds to a WebGPU {{GPUTexture}}.
 
 A texture has the following features:
 
-: <dfn dfn-for=texture noexport>texel format</dfn>
+: [=texel format=]
 :: The data representation of each texel. See [[#texel-formats]].
 : <dfn dfn-for=texture noexport>dimensionality</dfn>
 :: The number of dimensions in the grid coordinates, and how the coordinates are interpreted.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3783,7 +3783,7 @@ Each texel in a texture is associated with a unique <dfn noexport>logical texel 
 which is an integer tuple having:
 * A [=mip level=] in [0, [=texture/mip level count=]).
 * A number of components, controlled by the [=texture/dimensionality=], with each
-    component value in [0, [=texture/size=]).
+    component value in [0, *S*<sub>i</sub>), where *S*<sub>i</sub> is the [=texture/size=] in the *i*'th component.
 * An array index in [0, [=texture/array size=]), if the texture is [=texture/arrayed=].
     Note that [=texture/size=] is a function of [=mip level=].
 * A sample index in [0, [=texture/sample count=]), if the texture is [[#multisampled-texture-type|multisampled]].
@@ -14635,13 +14635,16 @@ Returns the dimensions of a texture, or texture's mip level in texels.
   [multisampled](#multisampled-texture-type), [depth](#texture-depth),
   [storage](#texture-storage), or [external](#external-texture-type) texture.
   <tr><td>`level`<td>
-  The mip level, with level 0 containing a full size version of the texture.<br>
+  The [=mip level=], with level 0 containing a full size version of the texture.<br>
   If omitted, the dimensions of level 0 are returned.
 </table>
 
 **Returns:**
 
-The dimensions of the texture in texels.
+The coordinate dimensions of the texture.
+
+That is, the result provides the integer bounds on the coordinates of the [=logical texel address=],
+excluding the [=texture/mip level count=], [=texture/array size=], and [=texture/sample count=].
 
 For textures based on cubes, the results are the dimensions of each face of the cube.
 Cube faces are square, so the x and y components of the result are equal.
@@ -15065,7 +15068,7 @@ Reads a single texel from a texture without sampling or filtering.
   <tr><td>`array_index`<td>
   The 0-based texture array index.
   <tr><td>`level`<td>
-  The mip level, with level 0 containing a full size version of the texture.
+  The [=mip level=], with level 0 containing a full size version of the texture.
   <tr><td>`sample_index`<td>
   The 0-based sample index of the multisampled texture.
 </table>
@@ -15117,8 +15120,9 @@ Returns the number of layers (elements) of an [=texture/arrayed=] texture.
 
 **Returns:**
 
-The number of layers (elements) of the [=texture/arrayed=] texture.
+If the texture is based on cubes, returns the number of cubes in the cube arrayed texture.
 
+Otherwise returns the number of layers (homogeneous grids of texels) in the arrayed texture.
 
 ### `textureNumLevels` ### {#texturenumlevels}
 
@@ -15149,7 +15153,7 @@ Returns the number of mip levels of a texture.
 
 **Returns:**
 
-The number of mip levels for the texture.
+The [=texture/mip level count=] for the texture.
 
 
 ### `textureNumSamples` ### {#texturenumsamples}
@@ -15178,7 +15182,7 @@ Returns the number samples per texel in a multisampled texture.
 
 **Returns:**
 
-The number of samples per texel in the multisampled texture.
+The [=texture/sample count=] for the multisampled texture.
 
 
 ### `textureSample` ### {#texturesample}


### PR DESCRIPTION
The edge cases for textureLoad and textureStore are defined in terms of valid and invalid logial texel addresses, instead of out-of-bound accesses.

This decouples the texture accesses from OOB processing for references and pointers, as part of #3893