### PR TITLE
editorial: Change "race conditions" to "data race"

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -421,7 +421,7 @@ Invocations within a shader stage execute concurrently, and may often execute in
 The shader author is responsible for ensuring the dynamic behavior of the invocations
 in a shader stage:
 * Meet the [[#uniformity|uniformity]] requirements of certain primitive operations, including texture sampling and control barriers.
-* Coordinate potentially conflicting accesses to shared variables, to avoid race conditions.
+* Coordinate potentially conflicting accesses to shared variables, to avoid data races.
 
 WGSL sometimes permits several possible behaviors for a given feature.
 This is a portability hazard, as different implementations may exhibit the different behaviors.
@@ -561,7 +561,7 @@ A processing error may occur during three phases in the shader lifecycle:
 * A <dfn export>dynamic error</dfn> is an error occurring during shader execution.
     These errors may or may not be detectable.
 
-Note: For example, a race condition may not be detectable.
+Note: For example, a data race may not be detectable.
 
 Each requirement [=behavioral requirement|will=] be checked at the earliest opportunity.
 That is:


### PR DESCRIPTION
It's a more precise reference to UB-inducing race conditions in other environments.