### PR TITLE
Clarify workgroup array size limit

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8959,11 +8959,17 @@ shader that goes beyond the specified limits.
             For the purposes of this limit, [=bool=] has a size of 1 byte.
         <td>65535
     <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
-            [=address spaces/workgroup=] address space
+            [=address spaces/workgroup=] address space.
 
             For the purposes of this limit, [=bool=] has a size of 1 byte and a
             [=fixed footprint|fixed-footprint=] array is treated as a [=creation-fixed
             footprint=] array when substituting the override value.
+
+            This maps the WebGPU [=supported limits/maxComputeWorkgroupStorageSize=] limit
+            into a standalone WGSL limit.
+
+            Note: Several workgroup variables that individually
+            satisfy this limit can still combine to exceed the API limit.
         <td>[=supported limits/maxComputeWorkgroupStorageSize|16384=]
     <tr><td>Maximum number of elements in [=const-expression=] of [=array=] type<td>65535
 </table>


### PR DESCRIPTION
Fixes: #3917