### PR TITLE
Add more adapter limit guarantees

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1723,7 +1723,7 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
     <tr><td><dfn>maxComputeWorkgroupStorageSize</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16384 bytes
     <tr class=row-continuation><td colspan=4>
-        The maximum number of bytes used for a compute stage
+        The maximum number of bytes of [=address spaces/workgroup=] storage used for a compute stage
         {{GPUShaderModule}} entry-point.
 
     <tr><td><dfn>maxComputeInvocationsPerWorkgroup</dfn>
@@ -2344,6 +2344,7 @@ Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the followi
     - Both {{GPUFeatureName/"texture-compression-etc2"}} and
         {{GPUFeatureName/"texture-compression-astc"}} are supported.
 - All supported limits must be either the [=limit/default=] value or [=limit/better=].
+- All [=limit class/alignment|alignment-class=] limits must be powers of 2.
 - {{supported limits/maxBindingsPerBindGroup}} must be must be &ge;
     ([=max bindings per shader stage=] &times; [=max shader stages per pipeline=]), where:
 
@@ -2367,6 +2368,13 @@ Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the followi
         Note: 32 bytes would be the alignment of `vec4<f64>`. See [[WGSL#alignment-and-size]].
 - {{supported limits/maxUniformBufferBindingSize}} must be &le; {{supported limits/maxBufferSize}}.
 - {{supported limits/maxStorageBufferBindingSize}} must be &le; {{supported limits/maxBufferSize}}.
+- {{supported limits/maxStorageBufferBindingSize}} must be a multiple of 4 bytes.
+- {{supported limits/maxVertexBufferArrayStride}} must be a multiple of 4 bytes.
+- {{supported limits/maxComputeWorkgroupSizeX}} must be &le; {{supported limits/maxComputeInvocationsPerWorkgroup}}.
+- {{supported limits/maxComputeWorkgroupSizeY}} must be &le; {{supported limits/maxComputeInvocationsPerWorkgroup}}.
+- {{supported limits/maxComputeWorkgroupSizeZ}} must be &le; {{supported limits/maxComputeInvocationsPerWorkgroup}}.
+- {{supported limits/maxComputeInvocationsPerWorkgroup}} must be &le; {{supported limits/maxComputeWorkgroupSizeX}}
+    &times; {{supported limits/maxComputeWorkgroupSizeY}} &times; {{supported limits/maxComputeWorkgroupSizeZ}}.
 
 ### Adapter Selection ### {#adapter-selection}
 


### PR DESCRIPTION
- Fixes #3888 (resolved by group)
- Fixes #3831 (not discussed by group but I think it's OK given it's exactly the same kind of thing)
- Also adds a guarantee about alignment limits being powers of 2 (^)
- Also editorial fix in maxComputeWorkgroupStorageSize