### PR TITLE
GPUDeviceLostReason "unknown" instead of undefined

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1408,7 +1408,7 @@ A [=device=] has the following internal slots:
 </div>
 
 Any time the user agent needs to revoke access to a device, it calls
-[=lose the device=](`device`, `undefined`) on the device's [=device timeline=],
+[=lose the device=](`device`, {{GPUDeviceLostReason/"unknown"}}) on the device's [=device timeline=],
 potentially ahead of other operations currently queued on that timeline.
 
 If an operation fails with side effects that would observably change the state
@@ -2593,7 +2593,7 @@ interface GPUAdapter {
                     or the user agent otherwise cannot fulfill the request:
 
                     1. Let |device| be a new [=device=].
-                    1. [=Lose the device=](|device|, `undefined`).
+                    1. [=Lose the device=](|device|, {{GPUDeviceLostReason/"unknown"}}).
 
                         Note:
                         This makes |adapter| [=invalid=], if it wasn't already.
@@ -13286,12 +13286,13 @@ is being composited into (e.g. an HTML page rendering, or a 2D canvas).
 
 <script type=idl>
 enum GPUDeviceLostReason {
+    "unknown",
     "destroyed"
 };
 
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUDeviceLostInfo {
-    readonly attribute (GPUDeviceLostReason or undefined) reason;
+    readonly attribute GPUDeviceLostReason reason;
     readonly attribute DOMString message;
 };
 


### PR DESCRIPTION
Fixes #3894