### PR TITLE
Revert "Simplify timestampWrites API"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -771,10 +771,6 @@ In this specification, the following syntactic shorthands are used:
 : The `.` ("dot") syntax, common in programming languages.
 ::
     The phrasing "`Foo.Bar`" means "the `Bar` member of the value (or interface) `Foo`."
-    If `Foo` is an [=ordered map=], [=asserts=] that the key `Bar` exists.
-
-    <div class="note editorial">
-    Some phrasing in this spec may currently assume this resolves to `undefined` if `Bar` doesn't exist.
 
     The phrasing "`Foo.Bar` is [=map/exist|provided=]" means
     "the `Bar` member [=map/exists=] in the [=map=] value `Foo`"
@@ -9351,10 +9347,9 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
                 1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
                     <div class=validusage>
-                        - If |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is [=map/exist|provided=]:
-                            - [$Validate timestampWrites$](|this|.{{GPUObjectBase/[[device]]}},
-                                |descriptor|.{{GPUComputePassDescriptor/timestampWrites}})
-                                must return true.
+                        - [$Validate timestampWrites$](|this|.{{GPUObjectBase/[[device]]}},
+                            |descriptor|.{{GPUComputePassDescriptor/timestampWrites}})
+                            must return true.
                     </div>
                 1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
                     1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
@@ -10255,16 +10250,21 @@ GPUComputePassEncoder includes GPUBindingCommandsMixin;
 ### Compute Pass Encoder Creation ### {#compute-pass-encoder-creation}
 
 <script type=idl>
-dictionary GPUComputePassTimestampWrites {
-    required GPUQuerySet querySet;
-    GPUSize32 beginningOfPassWriteIndex;
-    GPUSize32 endOfPassWriteIndex;
+enum GPUComputePassTimestampLocation {
+    "beginning",
+    "end"
 };
-</script>
 
-<script type=idl>
+dictionary GPUComputePassTimestampWrite {
+    required GPUQuerySet querySet;
+    required GPUSize32 queryIndex;
+    required GPUComputePassTimestampLocation location;
+};
+
+typedef sequence<GPUComputePassTimestampWrite> GPUComputePassTimestampWrites;
+
 dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
-    GPUComputePassTimestampWrites timestampWrites;
+    GPUComputePassTimestampWrites timestampWrites = [];
 };
 </script>
 
@@ -10601,19 +10601,24 @@ When executing encoded render pass commands as part of a {{GPUCommandBuffer}}, a
 ### Render Pass Encoder Creation ### {#render-pass-encoder-creation}
 
 <script type=idl>
-dictionary GPURenderPassTimestampWrites {
-    required GPUQuerySet querySet;
-    GPUSize32 beginningOfPassWriteIndex;
-    GPUSize32 endOfPassWriteIndex;
+enum GPURenderPassTimestampLocation {
+    "beginning",
+    "end"
 };
-</script>
 
-<script type=idl>
+dictionary GPURenderPassTimestampWrite {
+    required GPUQuerySet querySet;
+    required GPUSize32 queryIndex;
+    required GPURenderPassTimestampLocation location;
+};
+
+typedef sequence<GPURenderPassTimestampWrite> GPURenderPassTimestampWrites;
+
 dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     required sequence<GPURenderPassColorAttachment?> colorAttachments;
     GPURenderPassDepthStencilAttachment depthStencilAttachment;
     GPUQuerySet occlusionQuerySet;
-    GPURenderPassTimestampWrites timestampWrites;
+    GPURenderPassTimestampWrites timestampWrites = [];
     GPUSize64 maxDrawCount = 50000000;
 };
 </script>
@@ -10685,9 +10690,8 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/type}}
             must be {{GPUQueryType/occlusion}}.
 
-    1. If |this|.{{GPURenderPassDescriptor/timestampWrites}} is [=map/exist|provided=]:
-        - [$Validate timestampWrites$](|device|, |this|.{{GPURenderPassDescriptor/timestampWrites}})
-            must return true.
+    1. [$Validate timestampWrites$](|device|, |this|.{{GPURenderPassDescriptor/timestampWrites}})
+        must return true.
 
     1. No two entries in |this|.{{GPURenderPassDescriptor/timestampWrites}} may have the same
         [{{GPURenderPassTimestampWrite/querySet}}, {{GPURenderPassTimestampWrite/queryIndex}}] pair.
@@ -12704,18 +12708,13 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
 
     Return `true` if the following requirements are met, and `false` if not.
 
-    - {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |device|.
-    - |timestampWrites|.`querySet` must be [$valid to use with$] |device|.
-    - |timestampWrites|.`querySet`.{{GPUQuerySet/type}} must be {{GPUQueryType/"timestamp"}}.
-    - |timestampWrites|.`beginningOfPassWriteIndex` must be &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
-    - |timestampWrites|.`endOfPassWriteIndex` must be &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
-    - Of the write index members in |timestampWrites| (`beginningOfPassWriteIndex`, `endOfPassWriteIndex`):
-        - At least one must be [=map/exist|provided=].
-        - Of those which are [=map/exist|provided=], no two may be equal.
-
-    <!-- editorial note: any additional timestamp write locations that are compute- or
-    render-specific could either be written here conditionally, or written at the call sites
-    in compute/render pass descriptor validation. -->
+    - If |timestampWrites| is not [=list/is empty|empty=],
+        {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |device|.
+    - No two entries in |timestampWrites| may have the same `location`.
+    - For each |timestampWrite| in |timestampWrites|:
+        - |timestampWrite|.`querySet` must be [$valid to use with$] |device|.
+        - |timestampWrite|.`querySet`.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
+        - |timestampWrite|.`queryIndex` &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
 </div>
 
 # Canvas Rendering # {#canvas-rendering}


### PR DESCRIPTION
Reverts gpuweb/gpuweb#3930

Fixes build breakage.
Update was incomplete, build didn't catch it because of https://github.com/speced/bikeshed/issues/2496