### PR TITLE
Add resource-hints spec to ignored-specs

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -36,13 +36,10 @@ Assume Explicit For: yes
 </pre>
 
 <pre class=link-defaults>
-spec:html;
-    type:interface; text:HTMLMediaElement
-    type:interface; text:Navigator
-spec:webidl;
-    type:interface; text:Promise
 </pre>
-
+<pre class=ignored-specs>
+spec:resource-hints;
+</pre>
 <pre class=anchors>
 spec: ECMA-262; urlPrefix: https://tc39.es/ecma262/#
     type: dfn


### PR DESCRIPTION
Removes ambiguity of several terms between html spec and resource-hints spec.