### PR TITLE
Reland "Simplify timestampWrites API" with the rest of the spec updated

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -769,6 +769,10 @@ In this specification, the following syntactic shorthands are used:
 : The `.` ("dot") syntax, common in programming languages.
 ::
     The phrasing "`Foo.Bar`" means "the `Bar` member of the value (or interface) `Foo`."
+    If `Foo` is an [=ordered map=], [=asserts=] that the key `Bar` exists.
+
+    <div class="note editorial">
+    Some phrasing in this spec may currently assume this resolves to `undefined` if `Bar` doesn't exist.
 
     The phrasing "`Foo.Bar` is [=map/exist|provided=]" means
     "the `Bar` member [=map/exists=] in the [=map=] value `Foo`"
@@ -9345,9 +9349,10 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
                 1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
                     <div class=validusage>
-                        - [$Validate timestampWrites$](|this|.{{GPUObjectBase/[[device]]}},
-                            |descriptor|.{{GPUComputePassDescriptor/timestampWrites}})
-                            must return true.
+                        - If |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is [=map/exist|provided=]:
+                            - [$Validate timestampWrites$](|this|.{{GPUObjectBase/[[device]]}},
+                                |descriptor|.{{GPUComputePassDescriptor/timestampWrites}})
+                                must return true.
                     </div>
                 1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
                     1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
@@ -10248,21 +10253,16 @@ GPUComputePassEncoder includes GPUBindingCommandsMixin;
 ### Compute Pass Encoder Creation ### {#compute-pass-encoder-creation}
 
 <script type=idl>
-enum GPUComputePassTimestampLocation {
-    "beginning",
-    "end"
-};
-
-dictionary GPUComputePassTimestampWrite {
+dictionary GPUComputePassTimestampWrites {
     required GPUQuerySet querySet;
-    required GPUSize32 queryIndex;
-    required GPUComputePassTimestampLocation location;
+    GPUSize32 beginningOfPassWriteIndex;
+    GPUSize32 endOfPassWriteIndex;
 };
+</script>
 
-typedef sequence<GPUComputePassTimestampWrite> GPUComputePassTimestampWrites;
-
+<script type=idl>
 dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
-    GPUComputePassTimestampWrites timestampWrites = [];
+    GPUComputePassTimestampWrites timestampWrites;
 };
 </script>
 
@@ -10599,24 +10599,19 @@ When executing encoded render pass commands as part of a {{GPUCommandBuffer}}, a
 ### Render Pass Encoder Creation ### {#render-pass-encoder-creation}
 
 <script type=idl>
-enum GPURenderPassTimestampLocation {
-    "beginning",
-    "end"
-};
-
-dictionary GPURenderPassTimestampWrite {
+dictionary GPURenderPassTimestampWrites {
     required GPUQuerySet querySet;
-    required GPUSize32 queryIndex;
-    required GPURenderPassTimestampLocation location;
+    GPUSize32 beginningOfPassWriteIndex;
+    GPUSize32 endOfPassWriteIndex;
 };
+</script>
 
-typedef sequence<GPURenderPassTimestampWrite> GPURenderPassTimestampWrites;
-
+<script type=idl>
 dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     required sequence<GPURenderPassColorAttachment?> colorAttachments;
     GPURenderPassDepthStencilAttachment depthStencilAttachment;
     GPUQuerySet occlusionQuerySet;
-    GPURenderPassTimestampWrites timestampWrites = [];
+    GPURenderPassTimestampWrites timestampWrites;
     GPUSize64 maxDrawCount = 50000000;
 };
 </script>
@@ -10688,8 +10683,9 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/type}}
             must be {{GPUQueryType/occlusion}}.
 
-    1. [$Validate timestampWrites$](|device|, |this|.{{GPURenderPassDescriptor/timestampWrites}})
-        must return true.
+    1. If |this|.{{GPURenderPassDescriptor/timestampWrites}} is [=map/exist|provided=]:
+        - [$Validate timestampWrites$](|device|, |this|.{{GPURenderPassDescriptor/timestampWrites}})
+            must return true.
 
     1. No two entries in |this|.{{GPURenderPassDescriptor/timestampWrites}} may have the same
         [{{GPURenderPassTimestampWrite/querySet}}, {{GPURenderPassTimestampWrite/queryIndex}}] pair.
@@ -12706,13 +12702,18 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
 
     Return `true` if the following requirements are met, and `false` if not.
 
-    - If |timestampWrites| is not [=list/is empty|empty=],
-        {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |device|.
-    - No two entries in |timestampWrites| may have the same `location`.
-    - For each |timestampWrite| in |timestampWrites|:
-        - |timestampWrite|.`querySet` must be [$valid to use with$] |device|.
-        - |timestampWrite|.`querySet`.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
-        - |timestampWrite|.`queryIndex` &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
+    - {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |device|.
+    - |timestampWrites|.`querySet` must be [$valid to use with$] |device|.
+    - |timestampWrites|.`querySet`.{{GPUQuerySet/type}} must be {{GPUQueryType/"timestamp"}}.
+    - |timestampWrites|.`beginningOfPassWriteIndex` must be &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
+    - |timestampWrites|.`endOfPassWriteIndex` must be &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
+    - Of the write index members in |timestampWrites| (`beginningOfPassWriteIndex`, `endOfPassWriteIndex`):
+        - At least one must be [=map/exist|provided=].
+        - Of those which are [=map/exist|provided=], no two may be equal.
+
+    <!-- editorial note: any additional timestamp write locations that are compute- or
+    render-specific could either be written here conditionally, or written at the call sites
+    in compute/render pass descriptor validation. -->
 </div>
 
 # Canvas Rendering # {#canvas-rendering}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12891,11 +12891,11 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
     - {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |device|.
     - |timestampWrites|.`querySet` must be [$valid to use with$] |device|.
     - |timestampWrites|.`querySet`.{{GPUQuerySet/type}} must be {{GPUQueryType/"timestamp"}}.
-    - |timestampWrites|.`beginningOfPassWriteIndex` must be &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
-    - |timestampWrites|.`endOfPassWriteIndex` must be &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
     - Of the write index members in |timestampWrites| (`beginningOfPassWriteIndex`, `endOfPassWriteIndex`):
         - At least one must be [=map/exist|provided=].
-        - Of those which are [=map/exist|provided=], no two may be equal.
+        - Of those which are [=map/exist|provided=]:
+            - No two may be equal.
+            - Each must be &lt; |timestampWrites|.`querySet`.{{GPUQuerySet/count}}.
 
     <!-- editorial note: any additional timestamp write locations that are compute- or
     render-specific could either be written here conditionally, or written at the call sites

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9070,11 +9070,11 @@ interface mixin GPUCommandsMixin {
 {{GPUCommandsMixin}} adds the following internal slots to interfaces which include it:
 
 <dl dfn-type=attribute dfn-for=GPUCommandsMixin>
-    : <dfn>\[[state]]</dfn>, of type [=encoder state=]
+    : <dfn>\[[state]]</dfn>, of type [=encoder state=], initially "[=encoder state/open=]"
     ::
-        The current state of the encoder, initially set to "[=encoder state/open=]".
+        The current state of the encoder.
 
-    : <dfn>\[[commands]]</dfn>, of type [=list=]&lt;[=GPU command=]&gt;
+    : <dfn>\[[commands]]</dfn>, of type [=list=]&lt;[=GPU command=]&gt;, initially `[]`
     ::
         A [=list=] of [=GPU commands=] to be executed on the [=Queue timeline=] when a
         {{GPUCommandBuffer}} containing these commands is submitted.
@@ -9295,13 +9295,29 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                     1. Set |pass|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}}.
                     1. Set |pass|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}.
                 1. Set |pass|.{{GPURenderCommandsMixin/[[layout]]}} to [$derive render targets layout from pass$](|descriptor|).
-                1. For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
-                    1. If |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"beginning"}},
+                1. If |descriptor|.{{GPURenderPassDescriptor/timestampWrites}} is [=map/exist|provided=]:
+                    1. Let |timestampWrites| be |descriptor|.{{GPURenderPassDescriptor/timestampWrites}}.
+                    1. If |timestampWrites|.{{GPURenderPassTimestampWrites/beginningOfPassWriteIndex}}
+                        is [=map/exist|provided=],
                         [=list/append=] a [=GPU command=] to |this|.{{GPUCommandsMixin/[[commands]]}}
-                        that writes the GPU's timestamp value into the |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}}th
-                        index in |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.
-                    1. Otherwise, if |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"end"}},
-                        [=list/Append=] |timestampWrite| to |pass|.{{GPURenderPassEncoder/[[endTimestampWrites]]}}.
+                        with the following steps:
+
+                        <div data-timeline=queue>
+                            1. Before the pass commands begin executing,
+                                write the current queue timestamp into index
+                                |timestampWrites|.{{GPURenderPassTimestampWrites/beginningOfPassWriteIndex}}
+                                of |timestampWrites|.{{GPURenderPassTimestampWrites/querySet}}.
+                        </div>
+                    1. If |timestampWrites|.{{GPURenderPassTimestampWrites/endOfPassWriteIndex}}
+                        is [=map/exist|provided=], set |pass|.{{GPURenderPassEncoder/[[endTimestampWrite]]}}
+                        to a [=GPU command=] with the following steps:
+
+                        <div data-timeline=queue>
+                            1. After the pass commands finish executing,
+                                write the current queue timestamp into index
+                                |timestampWrites|.{{GPURenderPassTimestampWrites/endOfPassWriteIndex}}
+                                of |timestampWrites|.{{GPURenderPassTimestampWrites/querySet}}.
+                        </div>
                 1. Set |pass|.{{GPURenderCommandsMixin/[[drawCount]]}} to 0.
                 1. Set |pass|.{{GPURenderPassEncoder/[[maxDrawCount]]}} to |descriptor|.{{GPURenderPassDescriptor/maxDrawCount}}.
 
@@ -9354,14 +9370,29 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                                 |descriptor|.{{GPUComputePassDescriptor/timestampWrites}})
                                 must return true.
                     </div>
-                1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
-                    1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
-                        [=list/append=] a [=GPU command=] to
-                        |this|.{{GPUCommandsMixin/[[commands]]}}
-                        that writes the GPU's timestamp value into the |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}}th
-                        index in |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.
-                    1. Otherwise, if |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"end"}},
-                        [=list/Append=] |timestampWrite| to |pass|.{{GPUComputePassEncoder/[[endTimestampWrites]]}}.
+                1. If |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is [=map/exist|provided=]:
+                    1. Let |timestampWrites| be |descriptor|.{{GPUComputePassDescriptor/timestampWrites}}.
+                    1. If |timestampWrites|.{{GPUComputePassTimestampWrites/beginningOfPassWriteIndex}}
+                        is [=map/exist|provided=],
+                        [=list/append=] a [=GPU command=] to |this|.{{GPUCommandsMixin/[[commands]]}}
+                        with the following steps:
+
+                        <div data-timeline=queue>
+                            1. Before the pass commands begin executing,
+                                write the current queue timestamp into index
+                                |timestampWrites|.{{GPUComputePassTimestampWrites/beginningOfPassWriteIndex}}
+                                of |timestampWrites|.{{GPUComputePassTimestampWrites/querySet}}.
+                        </div>
+                    1. If |timestampWrites|.{{GPUComputePassTimestampWrites/endOfPassWriteIndex}}
+                        is [=map/exist|provided=], set |pass|.{{GPUComputePassEncoder/[[endTimestampWrite]]}}
+                        to a [=GPU command=] with the following steps:
+
+                        <div data-timeline=queue>
+                            1. After the pass commands finish executing,
+                                write the current queue timestamp into index
+                                |timestampWrites|.{{GPUComputePassTimestampWrites/endOfPassWriteIndex}}
+                                of |timestampWrites|.{{GPUComputePassTimestampWrites/querySet}}.
+                        </div>
             </div>
         </div>
 </dl>
@@ -10245,9 +10276,9 @@ GPUComputePassEncoder includes GPUBindingCommandsMixin;
     ::
         The current {{GPUComputePipeline}}, initially `null`.
 
-    : <dfn>\[[endTimestampWrites]]</dfn>, of type {{GPUComputePassTimestampWrites}}, readonly
+    : <dfn>\[[endTimestampWrite]]</dfn>, of type [=GPU command=]?, readonly, defaulting to `null`
     ::
-        The timestamp attachments which need to be executed when the pass ends.
+        [=GPU command=], if any, writing a timestamp when the pass ends.
 </dl>
 
 ### Compute Pass Encoder Creation ### {#compute-pass-encoder-creation}
@@ -10269,7 +10300,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 <dl dfn-type=dict-member dfn-for=GPUComputePassDescriptor>
     : <dfn>timestampWrites</dfn>
     ::
-        A sequence of {{GPUComputePassTimestampWrite}} values define where and when timestamp values will be written for this pass.
+        Defines which timestamp values will be written for this pass, and where to write them to.
 </dl>
 
 ### Dispatch ### {#compute-pass-encoder-dispatch}
@@ -10494,12 +10525,9 @@ called the compute pass encoder can no longer be used.
                     </div>
                 1. [=list/Extend=] |parentEncoder|.{{GPUCommandsMixin/[[commands]]}}
                     with |this|.{{GPUCommandsMixin/[[commands]]}}.
-                1. For each |timestampWrite| in |this|.{{GPUComputePassEncoder/[[endTimestampWrites]]}}:
-                    1. [=Assert=]: |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"end"}}.
-                    1. [=list/Append=] a [=GPU command=] to
-                        |parentEncoder|.{{GPUCommandsMixin/[[commands]]}}
-                        that writes the GPU's timestamp value into the |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}}th
-                        index in |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.
+                1. If |this|.{{GPUComputePassEncoder/[[endTimestampWrite]]}} is not `null`:
+                    1. [=list/Extend=] |parentEncoder|.{{GPUCommandsMixin/[[commands]]}}
+                        with |this|.{{GPUComputePassEncoder/[[endTimestampWrite]]}}.
             </div>
         </div>
 </dl>
@@ -10558,9 +10586,9 @@ GPURenderPassEncoder includes GPURenderCommandsMixin;
     ::
         Whether the pass's {{GPURenderPassEncoder/[[occlusion_query_set]]}} is being written.
 
-    : <dfn>\[[endTimestampWrites]]</dfn>, of type {{GPURenderPassTimestampWrites}}, readonly
+    : <dfn>\[[endTimestampWrite]]</dfn>, of type [=GPU command=]?, readonly, defaulting to `null`
     ::
-        The timestamp attachments which need to be executed when the pass ends.
+        [=GPU command=], if any, writing a timestamp when the pass ends.
 
     : <dfn>\[[maxDrawCount]]</dfn> of type {{GPUSize64}}, readonly
     ::
@@ -10639,7 +10667,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     : <dfn>timestampWrites</dfn>
     ::
-        A sequence of {{GPURenderPassTimestampWrite}} values defines where and when timestamp values will be written for this pass.
+        Defines which timestamp values will be written for this pass, and where to write them to.
 
     : <dfn>maxDrawCount</dfn>
     ::
@@ -10686,9 +10714,6 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     1. If |this|.{{GPURenderPassDescriptor/timestampWrites}} is [=map/exist|provided=]:
         - [$Validate timestampWrites$](|device|, |this|.{{GPURenderPassDescriptor/timestampWrites}})
             must return true.
-
-    1. No two entries in |this|.{{GPURenderPassDescriptor/timestampWrites}} may have the same
-        [{{GPURenderPassTimestampWrite/querySet}}, {{GPURenderPassTimestampWrite/queryIndex}}] pair.
 </div>
 
 <div algorithm>
@@ -11081,13 +11106,9 @@ called the render pass encoder can no longer be used.
                     </div>
                 1. [=list/Extend=] |parentEncoder|.{{GPUCommandsMixin/[[commands]]}}
                     with |this|.{{GPUCommandsMixin/[[commands]]}}.
-                1. For each |timestampWrite| in |this|.{{GPURenderPassEncoder/[[endTimestampWrites]]}}:
-                    1. [=Assert=]: |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"end"}}.
-                    1. [=list/Append=] a [=GPU command=] to
-                        |parentEncoder|.{{GPUCommandsMixin/[[commands]]}}
-                        that writes the GPU's timestamp value into the |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}}th
-                        index in |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.
-
+                1. If |this|.{{GPURenderPassEncoder/[[endTimestampWrite]]}} is not `null`:
+                    1. [=list/Extend=] |parentEncoder|.{{GPUCommandsMixin/[[commands]]}}
+                        with |this|.{{GPURenderPassEncoder/[[endTimestampWrite]]}}.
                 1. [$Enqueue a render command$] on |this| which issues the subsequent steps on the
                     [=Queue timeline=] with |renderState| when executed.
             </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -771,7 +771,7 @@ In this specification, the following syntactic shorthands are used:
     The phrasing "`Foo.Bar`" means "the `Bar` member of the value (or interface) `Foo`."
     If `Foo` is an [=ordered map=], [=asserts=] that the key `Bar` exists.
 
-    <div class="note editorial">
+    <p class="note editorial">Editorial:
     Some phrasing in this spec may currently assume this resolves to `undefined` if `Bar` doesn't exist.
 
     The phrasing "`Foo.Bar` is [=map/exist|provided=]" means


### PR DESCRIPTION
First commit reverts #3977 (relands #3930).
Remaining spec fixes are in the second commit.