### PR TITLE
Require at least one attachment in GPURenderPipelineDescriptor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7754,6 +7754,10 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     - If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is [=map/exist|provided=]:
         - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
     - [$validating GPUMultisampleState$](|descriptor|.{{GPURenderPipelineDescriptor/multisample}}) succeeds.
+    - There must exist at least one attachment, either:
+        - A non-`null` value in
+            |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}, or
+        - A |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.
     - [$validating inter-stage interfaces$](|device|, |descriptor|) returns `true`.
 </div>
 
@@ -10661,10 +10665,6 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be &le;
         |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
 
-    1. If |this|.{{GPURenderPassDescriptor/colorAttachments}} contains no non-`null` values:
-
-        1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must [=map/exist|be provided=].
-
     1. For each non-`null` |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:
 
         1. |colorAttachment| must meet the [$GPURenderPassColorAttachment/GPURenderPassColorAttachment Valid Usage$] rules.
@@ -10672,6 +10672,10 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     1. If |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} is [=map/exist|provided=]:
 
         1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must meet the [$GPURenderPassDepthStencilAttachment/GPURenderPassDepthStencilAttachment Valid Usage$] rules.
+
+    1. There must exist at least one attachment, either:
+        - A non-`null` value in |this|.{{GPURenderPassDescriptor/colorAttachments}}, or
+        - A |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
 
     1. [$Validating GPURenderPassDescriptor's color attachment bytes per sample$](|device|, |this|.{{GPURenderPassDescriptor/colorAttachments}}) succeeds.
 
@@ -12061,19 +12065,21 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                         - |this| is [=valid=].
                         - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be &le;
                             |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
-                        - If |descriptor|.{{GPURenderPassLayout/colorFormats}} contains no non-`null` members:
-                            - |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must [=map/exist|be provided=].
                         - For each non-`null` |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:
                             - |colorFormat| must be a [=color renderable format=].
                         - [$Calculating color attachment bytes per sample$](|descriptor|.{{GPURenderPassLayout/colorFormats}})
                             must be &le; |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachmentBytesPerSample}}.
-                        - Let |depthStencilFormat| be |descriptor|.{{GPURenderPassLayout/depthStencilFormat}},
-                            or `null` if not [=map/exist|provided=].
-                        - If |depthStencilFormat| is not `null`:
-                            - |depthStencilFormat| must be a [=depth-or-stencil format=].
-                            - If |depthStencilFormat| is a [=combined depth-stencil format=]:
+                        - If |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} is [=map/exist|provided=]:
+                            - |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must be a
+                                [=depth-or-stencil format=].
+                            - If |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} is a
+                                [=combined depth-stencil format=]:
                                 - |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}} must be equal to
-                                    |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}
+                                    |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}.
+                        - There must exist at least one attachment, either:
+                            - A non-`null` value in
+                                |descriptor|.{{GPURenderPassLayout/colorFormats}}, or
+                            - A |descriptor|.{{GPURenderPassLayout/depthStencilFormat}}.
                     </div>
                 1. Set |e|.{{GPURenderCommandsMixin/[[layout]]}} to a copy of |descriptor|'s included {{GPURenderPassLayout}} interface.
                 1. Set |e|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}}.


### PR DESCRIPTION
This was already validated in GPURenderPassDescriptor and GPURenderBundleDescriptor. Edited all 3 for readability.

Fixes #3702