### PR TITLE
alphaToCoverage comes from output 0, not target 0

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14454,7 +14454,7 @@ based on the vertex position output. The depth testing and stencil operations ca
 
 In alpha-to-coverage mode, an additional <dfn dfn>alpha-to-coverage mask</dfn>
 of MSAA samples is generated based on the |alpha| component of the
-fragment shader output value of the {{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}[0].
+fragment shader output value at `@location(0)`.
 
 The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
 It guarantees that:


### PR DESCRIPTION
Related: #3982