### PR TITLE
Require a depth attachment if frag_depth builtin is used

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -101,6 +101,9 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: line break; url: line-break
         for: address spaces
             text: workgroup; url: address-spaces-workgroup
+        for: builtin
+            text: sample_mask; url: built-in-values-sample_mask
+            text: frag_depth; url: built-in-values-frag_depth
         for: extension
             text: f16; url: extension-f16
     type: abstract-op
@@ -7747,9 +7750,15 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
         - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
             |descriptor|.{{GPURenderPipelineDescriptor/fragment}}, |layout|) succeeds.
         - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
-        - If the "sample_mask" [=builtin=] is a [=shader stage output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+        - If the [=builtin/sample_mask=] builtin is a [=shader stage output=] of
+            |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
             - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
-
+        - If the [=builtin/frag_depth=] builtin is a [=shader stage output=] of
+            |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+            - |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} must be
+                [=map/exist|provided=], and
+                |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.{{GPUDepthStencilState/format}}
+                must have a [=aspect/depth=] aspect.
     - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|) succeeds.
     - If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is [=map/exist|provided=]:
         - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.


### PR DESCRIPTION
Fixes #3728