### PR TITLE
Add helpful note to array sizing rules about override idents vs override exprs.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2830,6 +2830,8 @@ An expression [=shader-creation error|must not=] evaluate to a runtime-sized arr
 
 The element count expression |N| of a fixed-size array is subject to the following constraints:
 * It [=shader-creation error|must=] be an [=override-expression=].
+  * Note:  To qualify for type-equivalency, the override expression must be an override identifier.
+See "Workgroup variables sized by overridable constants".
 * It [=shader-creation error|must=] evaluate to a [=type/concrete=] [=integer scalar=].
 * It is a [=pipeline-creation error=] if |N| is not greater than zero.
 


### PR DESCRIPTION
Our team got caught by this. The current text is technically correct, but doesn't allude to the difference for type equivalency, and so adding a note here I think would have prevented us getting caught up by this.