### PR TITLE
Weaken asin & acos accuracy rule for f16

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11307,7 +11307,9 @@ value with the same sign.
        * Absolute error 6.77&times;10<sup>-5</sup>
        * Inherited from `atan2(sqrt(1.0 - x * x), x)`
 
-      <td>Inherited from `atan2(sqrt(1.0 - x * x), x)`
+      <td>The worse of:
+       * Absolute error 3.91&times;10<sup>-3</sup>
+       * Inherited from `atan2(sqrt(1.0 - x * x), x)`
           <p>TODO: check this with conformance tests
   <tr><td>`acosh(x)`<td colspan=2 style="text-align:left;">Inherited from `log(x + sqrt(x * x - 1.0))`
   <tr><td>`asin(x)`<td>
@@ -11315,7 +11317,9 @@ value with the same sign.
        * Absolute error 6.77&times;10<sup>-5</sup>
        * Inherited from `atan2(x, sqrt(1.0 - x * x))`
 
-      <td>Inherited from `atan2(x, sqrt(1.0 - x * x))`
+      <td>The worse of:
+       * Absolute error 3.91&times;10<sup>-3</sup>
+       * Inherited from `atan2(x, sqrt(1.0 - x * x))`
           <p>TODO: check this with conformance tests
   <tr><td>`asinh(x)`<td colspan=2 style="text-align:left;">Inherited from `log(x + sqrt(x * x + 1.0))`
   <tr><td>`atan(x)`<td>4096 ULP<td>5 ULP


### PR DESCRIPTION
Tests shows f16 asin and acos on some implementations does not meet the ULP accuracy rule on some range (expected output close to +/- 0.0), but absolute error guarantees.

Fixes: #3909