### PR TITLE
wgsl: unpack2x16snorm has 3 ULP error on some implementations

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11547,7 +11547,7 @@ value with the same sign.
 
   <tr><td>`unpack4x8snorm(x)`<td>Correctly rounded<td>N/A
   <tr><td>`unpack4x8unorm(x)`<td>Correctly rounded<td>N/A
-  <tr><td>`unpack2x16snorm(x)`<td>Correctly rounded<td>N/A
+  <tr><td>`unpack2x16snorm(x)`<td>3 ULP<td>N/A
   <tr><td>`unpack2x16unorm(x)`<td>Correctly rounded<td>N/A
   <tr><td>`unpack2x16float(x)`<td>Correctly rounded<td>N/A
 


### PR DESCRIPTION
This occurs for AMD GPUs on macOS Ventura

Fixes: #3991