### PR TITLE
Build fixes for latest Bikeshed 3.11.18

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2344,13 +2344,13 @@ Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the followi
 - {{supported limits/maxBindingsPerBindGroup}} must be must be &ge;
     ([=max bindings per shader stage=] &times; [=max shader stages per pipeline=]), where:
 
-    - <dfn dfn for=>max bindings per shader stage</dfn> is
+    - <dfn dfn for="">max bindings per shader stage</dfn> is
         ({{supported limits/maxSampledTexturesPerShaderStage}} +
         {{supported limits/maxSamplersPerShaderStage}} +
         {{supported limits/maxStorageBuffersPerShaderStage}} +
         {{supported limits/maxStorageTexturesPerShaderStage}} +
         {{supported limits/maxUniformBuffersPerShaderStage}}).
-    - <dfn dfn for=>max shader stages per pipeline</dfn> is `2`, because a
+    - <dfn dfn for="">max shader stages per pipeline</dfn> is `2`, because a
         {{GPURenderPipeline}} supports both a vertex and fragment shader.
 
     Note: {{supported limits/maxBindingsPerBindGroup}} does not reflect a fundamental limit;
@@ -3020,7 +3020,7 @@ enum GPUBufferMapState {
 <dl dfn-type=attribute dfn-for=GPUBuffer data-timeline=content>
     : <dfn>mapState</dfn>
     ::
-        The current <dfn enum for=>GPUBufferMapState</dfn> of the buffer:
+        The current <dfn enum for="">GPUBufferMapState</dfn> of the buffer:
 
         <dl dfn-type=enum-value dfn-for=GPUBufferMapState>
             : <dfn>"unmapped"</dfn>
@@ -3063,7 +3063,7 @@ enum GPUBufferMapState {
         Set if and only if the buffer is currently mapped for use by {{GPUBuffer/getMappedRange()}}.
         Null otherwise (even if there is a {{GPUBuffer/[[pending_map]]}}).
 
-        An <dfn dfn for=>active buffer mapping</dfn> is a structure with the following fields:
+        An <dfn dfn for="">active buffer mapping</dfn> is a structure with the following fields:
 
         <dl dfn-type=dfn dfn-for="active buffer mapping">
             : <dfn>data</dfn>, of type [=Data Block=]
@@ -3088,7 +3088,7 @@ enum GPUBufferMapState {
         </dl>
 
         <div algorithm>
-            To <dfn abstract-op for=>initialize an active buffer mapping</dfn> with mode |mode| and
+            To <dfn abstract-op for="">initialize an active buffer mapping</dfn> with mode |mode| and
             range |range|:
 
             1. Let |size| be |range|[1] - |range|[0].
@@ -4012,7 +4012,7 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
         Formats in this list must be [=texture view format compatible=] with the texture format.
 
         <div algorithm>
-            Two {{GPUTextureFormat}}s |format| and |viewFormat| are <dfn dfn for=>texture view format compatible</dfn> if:
+            Two {{GPUTextureFormat}}s |format| and |viewFormat| are <dfn dfn for="">texture view format compatible</dfn> if:
 
             - |format| equals |viewFormat|, or
             - |format| and |viewFormat| differ only in whether they are `srgb` formats (have the `-srgb` suffix).
@@ -6796,7 +6796,7 @@ enum GPUPipelineErrorReason {
     : <dfn>reason</dfn>
     ::
         A read-only [=slot-backed attribute=] exposing the type of error encountered in pipeline creation
-        as a <dfn enum for=>GPUPipelineErrorReason</dfn>:
+        as a <dfn enum for="">GPUPipelineErrorReason</dfn>:
 
         <ul dfn-type=enum-value dfn-for=GPUPipelineErrorReason>
             - <dfn>"validation"</dfn>: A [$validation error$].
@@ -7077,7 +7077,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         The key of each key-value pair must equal the identifier string of one such constant.
         When the pipeline is executed, that constant will have the specified value.
 
-        Values are specified as <dfn typedef for=>GPUPipelineConstantValue</dfn>, which is a {{double}}.
+        Values are specified as <dfn typedef for="">GPUPipelineConstantValue</dfn>, which is a {{double}}.
         They are converted [$to WGSL type$] of the pipeline-overridable constant (`bool`/`i32`/`u32`/`f32`/`f16`).
         If conversion fails, a validation error is generated.
 
@@ -10383,7 +10383,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
         from a {{GPUBuffer}}.
         See [[#computing-operations]] for the detailed specification.
 
-        The <dfn dfn for=>indirect dispatch parameters</dfn> encoded in the buffer must be a tightly
+        The <dfn dfn for="">indirect dispatch parameters</dfn> encoded in the buffer must be a tightly
         packed block of **three 32-bit unsigned integer values (12 bytes total)**,
         given in the same order as the arguments for {{GPUComputePassEncoder/dispatchWorkgroups()}}.
         For example:
@@ -11448,7 +11448,7 @@ It must only be included by interfaces which also include those mixins.
         Draws primitives using parameters read from a {{GPUBuffer}}.
         See [[#rendering-operations]] for the detailed specification.
 
-        The <dfn dfn for=>indirect draw parameters</dfn> encoded in the buffer must be a tightly
+        The <dfn dfn for="">indirect draw parameters</dfn> encoded in the buffer must be a tightly
         packed block of **four 32-bit unsigned integer values (16 bytes total)**, given in the same
         order as the arguments for {{GPURenderCommandsMixin/draw()}}. For example:
 
@@ -11519,7 +11519,7 @@ It must only be included by interfaces which also include those mixins.
         Draws indexed primitives using parameters read from a {{GPUBuffer}}.
         See [[#rendering-operations]] for the detailed specification.
 
-        The <dfn dfn for=>indirect drawIndexed parameters</dfn> encoded in the buffer must be a
+        The <dfn dfn for="">indirect drawIndexed parameters</dfn> encoded in the buffer must be a
         tightly packed block of **five 32-bit unsigned integer values (20 bytes total)**, given in
         the same order as the arguments for {{GPURenderCommandsMixin/drawIndexed()}}. For example:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -781,9 +781,9 @@ In this specification, the following syntactic shorthands are used:
     The phrasing "`Foo?.Bar`" means
     "if `Foo` is `null` or `undefined` or `Bar` does not [=map/exist=] in `Foo`, `undefined`; otherwise, `Foo.Bar`".
 
-    For example, where `buffer` is a {{GPUBuffer}}, `buffer?.[[device]].[[adapter]]` means
+    For example, where `buffer` is a {{GPUBuffer}}, `buffer?.\[[device]].\[[adapter]]` means
     "if `buffer` is `null` or `undefined`, then `undefined`; otherwise,
-    the `[[adapter]]` internal slot of the `[[device]]` internal slot of `buffer`.
+    the `\[[adapter]]` internal slot of the `\[[device]]` internal slot of `buffer`.
 
 : The `??` ("nullish coalescing") syntax, adopted from JavaScript.
 ::
@@ -838,7 +838,7 @@ interface mixin GPUObjectBase {
         1. Let |device| be |parent|.{{GPUObjectBase/[[device]]}}.
         1. Let |object| be a new instance of |T|.
         1. Let |internals| be a new (uninitialized) instance of the type of
-            |T|.`[[internals]]` (which may override {{GPUObjectBase}}.{{GPUObjectBase/[[internals]]}})
+            |T|.`\[[internals]]` (which may override {{GPUObjectBase}}.{{GPUObjectBase/[[internals]]}})
             that is accessible only from the [=device timeline=] of |device|.
         1. Set |object|.{{GPUObjectBase/[[device]]}} to |device|.
         1. Set |object|.{{GPUObjectBase/[[internals]]}} to |internals|.
@@ -4966,7 +4966,7 @@ GPUExternalTexture includes GPUObjectBase;
         Initially set to `false`.
 
         Note:
-        Unlike similar `[[destroyed]]` slots, this can change from `true` back to `false`.
+        Unlike similar `\[[destroyed]]` slots, this can change from `true` back to `false`.
 
     : <dfn>\[[descriptor]]</dfn>, of type {{GPUExternalTextureDescriptor}}
     ::

--- a/tools/install-dependencies.sh
+++ b/tools/install-dependencies.sh
@@ -5,7 +5,7 @@ code=1
 for opt in "$@"; do
     case "$opt" in
         bikeshed)
-            pip3 install bikeshed==3.11.1
+            pip3 install bikeshed==3.11.16
             bikeshed update
             code=0
             ;;

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11027,7 +11027,7 @@ That path is a subpath of the overall invalid path from [=RequiredToBeUniform.S=
       }
     }
   </xmp>
-</div
+</div>
 
 <div class=example5>
   <figure>


### PR DESCRIPTION
Fixes API spec build for Bikeshed 3.11.18
WGSL spec still doesn't work after 3.11.16, so upgrading to that in pinned dependency, but that doesn't fix publish-TR-wgsl which always uses latest Bikeshed.