### PR TITLE
Move all `<xmp>` to start on their own line

### DIFF
--- a/tools/install-dependencies.sh
+++ b/tools/install-dependencies.sh
@@ -5,7 +5,7 @@ code=1
 for opt in "$@"; do
     case "$opt" in
         bikeshed)
-            pip3 install bikeshed==3.11.16
+            pip3 install bikeshed==3.11.19
             bikeshed update
             code=0
             ;;

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11920,7 +11920,8 @@ Note: WGSL does not have zero built-in functions for [=atomic types=],
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn T() -> T</xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn T() -> T</xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=constructible=] type.<br>
   <tr><td>Description
@@ -11983,9 +11984,10 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn array<T, N>(e1 : T, ..., eN : T) -> array<T, N>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn array<T, N>(e1 : T, ..., eN : T) -> array<T, N>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=type/concrete=] and [=constructible=]
   <tr><td>Description
@@ -11997,9 +11999,10 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn array(e1 : T, ..., eN : T) -> array<T, N>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn array(e1 : T, ..., eN : T) -> array<T, N>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=constructible=]
   <tr><td>Description
@@ -12013,7 +12016,8 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn bool(e : T) -> bool</xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn bool(e : T) -> bool</xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=] type.
   <tr><td>Description
@@ -12028,7 +12032,8 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn f16(e : T) -> f16</xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn f16(e : T) -> f16</xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=] type
   <tr><td>Description
@@ -12043,7 +12048,8 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn f32(e : T) -> f32</xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn f32(e : T) -> f32</xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=] type
   <tr><td>Description
@@ -12058,7 +12064,8 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn i32(e : T) -> i32</xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn i32(e : T) -> i32</xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=] type
   <tr><td>Description
@@ -12074,10 +12081,11 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat2x2<T>(e : mat2x2<S>) -> mat2x2<T>
-@const @must_use fn mat2x2(e : mat2x2<S>) -> mat2x2<S>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat2x2<T>(e : mat2x2<S>) -> mat2x2<T>
+          @const @must_use fn mat2x2(e : mat2x2<S>) -> mat2x2<S>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=f16=] or [=f32=]<br>
       `S` is [FLOATSCALAR]
@@ -12088,10 +12096,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat2x2<T>(v1 : vec2<T>, v2 : vec2<T>) -> mat2x2<T>
-@const @must_use fn mat2x2(v1 : vec2<T>, v2 : vec2<T>) -> mat2x2<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat2x2<T>(v1 : vec2<T>, v2 : vec2<T>) -> mat2x2<T>
+          @const @must_use fn mat2x2(v1 : vec2<T>, v2 : vec2<T>) -> mat2x2<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12099,10 +12108,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat2x2<T>(e1 : T, e2 : T, e3 : T, e4 : T) -> mat2x2<T>
-@const @must_use fn mat2x2(e1 : T, e2 : T, e3 : T, e4 : T) -> mat2x2<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat2x2<T>(e1 : T, e2 : T, e3 : T, e4 : T) -> mat2x2<T>
+          @const @must_use fn mat2x2(e1 : T, e2 : T, e3 : T, e4 : T) -> mat2x2<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12113,10 +12123,11 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat2x3<T>(e : mat2x3<S>) -> mat2x3<T>
-@const @must_use fn mat2x3(e : mat2x3<S>) -> mat2x3<S>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat2x3<T>(e : mat2x3<S>) -> mat2x3<T>
+          @const @must_use fn mat2x3(e : mat2x3<S>) -> mat2x3<S>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=f16=] or [=f32=]<br>
       `S` is [FLOATSCALAR]
@@ -12127,10 +12138,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat2x3<T>(v1 : vec3<T>, v2 : vec3<T>) -> mat2x3<T>
-@const @must_use fn mat2x3(v1 : vec3<T>, v2 : vec3<T>) -> mat2x3<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat2x3<T>(v1 : vec3<T>, v2 : vec3<T>) -> mat2x3<T>
+          @const @must_use fn mat2x3(v1 : vec3<T>, v2 : vec3<T>) -> mat2x3<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12138,10 +12150,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat2x3<T>(e1 : T, ..., e6 : T) -> mat2x3<T>
-@const @must_use fn mat2x3(e1 : T, ..., e6 : T) -> mat2x3<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat2x3<T>(e1 : T, ..., e6 : T) -> mat2x3<T>
+          @const @must_use fn mat2x3(e1 : T, ..., e6 : T) -> mat2x3<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12152,10 +12165,11 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat2x4<T>(e : mat2x4<S>) -> mat2x4<T>
-@const @must_use fn mat2x4(e : mat2x4<S>) -> mat2x4<S>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat2x4<T>(e : mat2x4<S>) -> mat2x4<T>
+          @const @must_use fn mat2x4(e : mat2x4<S>) -> mat2x4<S>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=f16=] or [=f32=]<br>
       `S` is [FLOATSCALAR]
@@ -12166,10 +12180,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat2x4<T>(v1 : vec4<T>, v2 : vec4<T>) -> mat2x4<T>
-@const @must_use fn mat2x4(v1 : vec4<T>, v2 : vec4<T>) -> mat2x4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat2x4<T>(v1 : vec4<T>, v2 : vec4<T>) -> mat2x4<T>
+          @const @must_use fn mat2x4(v1 : vec4<T>, v2 : vec4<T>) -> mat2x4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12177,10 +12192,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat2x4<T>(e1 : T, ..., e8 : T) -> mat2x4<T>
-@const @must_use fn mat2x4(e1 : T, ..., e8 : T) -> mat2x4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat2x4<T>(e1 : T, ..., e8 : T) -> mat2x4<T>
+          @const @must_use fn mat2x4(e1 : T, ..., e8 : T) -> mat2x4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12191,10 +12207,11 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat3x2<T>(e : mat3x2<S>) -> mat3x2<T>
-@const @must_use fn mat3x2(e : mat3x2<S>) -> mat3x2<S>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat3x2<T>(e : mat3x2<S>) -> mat3x2<T>
+          @const @must_use fn mat3x2(e : mat3x2<S>) -> mat3x2<S>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=f16=] or [=f32=]<br>
       `S` is [FLOATSCALAR]
@@ -12205,14 +12222,15 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat3x2<T>(v1 : vec2<T>,
-                              v2 : vec2<T>,
-                              v3 : vec2<T>) -> mat3x2<T>
-@const @must_use fn mat3x2(v1 : vec2<T>,
-                           v2 : vec2<T>,
-                           v3 : vec2<T>) -> mat3x2<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat3x2<T>(v1 : vec2<T>,
+                                        v2 : vec2<T>,
+                                        v3 : vec2<T>) -> mat3x2<T>
+          @const @must_use fn mat3x2(v1 : vec2<T>,
+                                     v2 : vec2<T>,
+                                     v3 : vec2<T>) -> mat3x2<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12220,10 +12238,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat3x2<T>(e1 : T, ..., e6 : T) -> mat3x2<T>
-@const @must_use fn mat3x2(e1 : T, ..., e6 : T) -> mat3x2<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat3x2<T>(e1 : T, ..., e6 : T) -> mat3x2<T>
+          @const @must_use fn mat3x2(e1 : T, ..., e6 : T) -> mat3x2<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12234,10 +12253,11 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat3x3<T>(e : mat3x3<S>) -> mat3x3<T>
-@const @must_use fn mat3x3(e : mat3x3<S>) -> mat3x3<S>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat3x3<T>(e : mat3x3<S>) -> mat3x3<T>
+          @const @must_use fn mat3x3(e : mat3x3<S>) -> mat3x3<S>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=f16=] or [=f32=]<br>
       `S` is [FLOATSCALAR]
@@ -12248,14 +12268,15 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat3x3<T>(v1 : vec3<T>,
-                              v2 : vec3<T>,
-                              v3 : vec3<T>) -> mat3x3<T>
-@const @must_use fn mat3x3(v1 : vec3<T>,
-                           v2 : vec3<T>,
-                           v3 : vec3<T>) -> mat3x3<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat3x3<T>(v1 : vec3<T>,
+                                        v2 : vec3<T>,
+                                        v3 : vec3<T>) -> mat3x3<T>
+          @const @must_use fn mat3x3(v1 : vec3<T>,
+                                     v2 : vec3<T>,
+                                     v3 : vec3<T>) -> mat3x3<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12263,10 +12284,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat3x3<T>(e1 : T, ..., e9 : T) -> mat3x3<T>
-@const @must_use fn mat3x3(e1 : T, ..., e9 : T) -> mat3x3<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat3x3<T>(e1 : T, ..., e9 : T) -> mat3x3<T>
+          @const @must_use fn mat3x3(e1 : T, ..., e9 : T) -> mat3x3<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12277,10 +12299,11 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat3x4<T>(e : mat3x4<S>) -> mat3x4<T>
-@const @must_use fn mat3x4(e : mat3x4<S>) -> mat3x4<S>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat3x4<T>(e : mat3x4<S>) -> mat3x4<T>
+          @const @must_use fn mat3x4(e : mat3x4<S>) -> mat3x4<S>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=f16=] or [=f32=]<br>
       `S` is [FLOATSCALAR]
@@ -12291,14 +12314,15 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat3x4<T>(v1 : vec4<T>,
-                              v2 : vec4<T>,
-                              v3 : vec4<T>) -> mat3x4<T>
-@const @must_use fn mat3x4(v1 : vec4<T>,
-                           v2 : vec4<T>,
-                           v3 : vec4<T>) -> mat3x4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat3x4<T>(v1 : vec4<T>,
+                                        v2 : vec4<T>,
+                                        v3 : vec4<T>) -> mat3x4<T>
+          @const @must_use fn mat3x4(v1 : vec4<T>,
+                                     v2 : vec4<T>,
+                                     v3 : vec4<T>) -> mat3x4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12306,10 +12330,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat3x4<T>(e1 : T, ..., e12 : T) -> mat3x4<T>
-@const @must_use fn mat3x4(e1 : T, ..., e12 : T) -> mat3x4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat3x4<T>(e1 : T, ..., e12 : T) -> mat3x4<T>
+          @const @must_use fn mat3x4(e1 : T, ..., e12 : T) -> mat3x4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12320,10 +12345,11 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat4x2<T>(e : mat4x2<S>) -> mat4x2<T>
-@const @must_use fn mat4x2(e : mat4x2<S>) -> mat4x2<S>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat4x2<T>(e : mat4x2<S>) -> mat4x2<T>
+          @const @must_use fn mat4x2(e : mat4x2<S>) -> mat4x2<S>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=f16=] or [=f32=]<br>
       `S` is [FLOATSCALAR]
@@ -12334,16 +12360,17 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat4x2<T>(v1 : vec2<T>,
-                              v2 : vec2<T>,
-                              v3 : vec2<T>,
-                              v4: vec2<T>) -> mat4x2<T>
-@const @must_use fn mat4x2(v1 : vec2<T>,
-                           v2 : vec2<T>,
-                           v3 : vec2<T>,
-                           v4: vec2<T>) -> mat4x2<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat4x2<T>(v1 : vec2<T>,
+                                        v2 : vec2<T>,
+                                        v3 : vec2<T>,
+                                        v4: vec2<T>) -> mat4x2<T>
+          @const @must_use fn mat4x2(v1 : vec2<T>,
+                                     v2 : vec2<T>,
+                                     v3 : vec2<T>,
+                                     v4: vec2<T>) -> mat4x2<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12351,10 +12378,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat4x2<T>(e1 : T, ..., e8 : T) -> mat4x2<T>
-@const @must_use fn mat4x2(e1 : T, ..., e8 : T) -> mat4x2<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat4x2<T>(e1 : T, ..., e8 : T) -> mat4x2<T>
+          @const @must_use fn mat4x2(e1 : T, ..., e8 : T) -> mat4x2<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12365,10 +12393,11 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat4x3<T>(e : mat4x3<S>) -> mat4x3<T>
-@const @must_use fn mat4x3(e : mat4x3<S>) -> mat4x3<S>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat4x3<T>(e : mat4x3<S>) -> mat4x3<T>
+          @const @must_use fn mat4x3(e : mat4x3<S>) -> mat4x3<S>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=f16=] or [=f32=]<br>
       `S` is [FLOATSCALAR]
@@ -12379,16 +12408,17 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat4x3<T>(v1 : vec3<T>,
-                              v2 : vec3<T>,
-                              v3 : vec3<T>,
-                              v4 : vec4<T>) -> mat4x3<T>
-@const @must_use fn mat4x3(v1 : vec3<T>,
-                           v2 : vec3<T>,
-                           v3 : vec3<T>,
-                           v4 : vec4<T>) -> mat4x3<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat4x3<T>(v1 : vec3<T>,
+                                        v2 : vec3<T>,
+                                        v3 : vec3<T>,
+                                        v4 : vec4<T>) -> mat4x3<T>
+          @const @must_use fn mat4x3(v1 : vec3<T>,
+                                     v2 : vec3<T>,
+                                     v3 : vec3<T>,
+                                     v4 : vec4<T>) -> mat4x3<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12396,10 +12426,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat4x3<T>(e1 : T, ..., e12 : T) -> mat4x3<T>
-@const @must_use fn mat4x3(e1 : T, ..., e12 : T) -> mat4x3<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat4x3<T>(e1 : T, ..., e12 : T) -> mat4x3<T>
+          @const @must_use fn mat4x3(e1 : T, ..., e12 : T) -> mat4x3<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12410,10 +12441,11 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat4x4<T>(e : mat4x4<S>) -> mat4x4<T>
-@const @must_use fn mat4x4(e : mat4x4<S>) -> mat4x4<S>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat4x4<T>(e : mat4x4<S>) -> mat4x4<T>
+          @const @must_use fn mat4x4(e : mat4x4<S>) -> mat4x4<S>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=f16=] or [=f32=]<br>
       `S` is [FLOATSCALAR]
@@ -12424,16 +12456,17 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat4x4<T>(v1 : vec4<T>,
-                              v2 : vec4<T>,
-                              v3 : vec4<T>,
-                              v4 : vec4<T>) -> mat4x4<T>
-@const @must_use fn mat4x4(v1 : vec4<T>,
-                           v2 : vec4<T>,
-                           v3 : vec4<T>,
-                           v4 : vec4<T>) -> mat4x4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat4x4<T>(v1 : vec4<T>,
+                                        v2 : vec4<T>,
+                                        v3 : vec4<T>,
+                                        v4 : vec4<T>) -> mat4x4<T>
+          @const @must_use fn mat4x4(v1 : vec4<T>,
+                                     v2 : vec4<T>,
+                                     v3 : vec4<T>,
+                                     v4 : vec4<T>) -> mat4x4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12441,10 +12474,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn mat4x4<T>(e1 : T, ..., e16 : T) -> mat4x4<T>
-@const @must_use fn mat4x4(e1 : T, ..., e16 : T) -> mat4x4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat4x4<T>(e1 : T, ..., e16 : T) -> mat4x4<T>
+          @const @must_use fn mat4x4(e1 : T, ..., e16 : T) -> mat4x4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [FLOATSCALAR]
   <tr><td>Description
@@ -12455,7 +12489,8 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn S(e1 : T1, ..., eN : TN) -> S</xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn S(e1 : T1, ..., eN : TN) -> S</xmp>
   <tr><td>Parameterization
       <td>`S` is a [=constructible=] structure type with members having types `T1` ... `TN`.
   <tr><td>Description
@@ -12466,7 +12501,8 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn u32(e : T) -> u32</xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn u32(e : T) -> u32</xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=] type or [=AbstractInt=]
   <tr><td>Description
@@ -12487,9 +12523,11 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec2<T>(e : vec2<S>) -> vec2<T>
-@const @must_use fn vec2(e : vec2<S>) -> vec2<S></xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec2<T>(e : vec2<S>) -> vec2<T>
+          @const @must_use fn vec2(e : vec2<S>) -> vec2<S>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=]<br>
       `S` is [=scalar=]
@@ -12500,9 +12538,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec2<T>(e1 : T, e2 : T) -> vec2<T>
-@const @must_use fn vec2(e1 : T, e2 : T) -> vec2<T></xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec2<T>(e1 : T, e2 : T) -> vec2<T>
+          @const @must_use fn vec2(e1 : T, e2 : T) -> vec2<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=scalar=]
   <tr><td>Description
@@ -12513,10 +12553,11 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec3<T>(e : vec3<S>) -> vec3<T>
-@const @must_use fn vec3(e : vec3<S>) -> vec3<S>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec3<T>(e : vec3<S>) -> vec3<T>
+          @const @must_use fn vec3(e : vec3<S>) -> vec3<S>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=]<br>
       `S` is [=scalar=]
@@ -12527,10 +12568,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec3<T>(e1 : T, e2 : T, e3 : T) -> vec3<T>
-@const @must_use fn vec3(e1 : T, e2 : T, e3 : T) -> vec3<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec3<T>(e1 : T, e2 : T, e3 : T) -> vec3<T>
+          @const @must_use fn vec3(e1 : T, e2 : T, e3 : T) -> vec3<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=scalar=]
   <tr><td>Description
@@ -12538,10 +12580,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec3<T>(v1 : vec2<T>, e1 : T) -> vec3<T>
-@const @must_use fn vec3(v1 : vec2<T>, e1 : T) -> vec3<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec3<T>(v1 : vec2<T>, e1 : T) -> vec3<T>
+          @const @must_use fn vec3(v1 : vec2<T>, e1 : T) -> vec3<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=scalar=]
   <tr><td>Description
@@ -12549,10 +12592,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec3<T>(e1 : T, v1 : vec2<T>) -> vec3<T>
-@const @must_use fn vec3(e1 : T, v1 : vec2<T>) -> vec3<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec3<T>(e1 : T, v1 : vec2<T>) -> vec3<T>
+          @const @must_use fn vec3(e1 : T, v1 : vec2<T>) -> vec3<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=scalar=]
   <tr><td>Description
@@ -12563,10 +12607,11 @@ specify the component type; the component type is inferred from the constructor 
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec4<T>(e : vec4<S>) -> vec4<T>
-@const @must_use fn vec4(e : vec4<S>) -> vec4<S>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec4<T>(e : vec4<S>) -> vec4<T>
+          @const @must_use fn vec4(e : vec4<S>) -> vec4<S>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=]<br>
       `S` is [=scalar=]
@@ -12577,10 +12622,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec4<T>(e1 : T, e2 : T, e3 : T, e4 : T) -> vec4<T>
-@const @must_use fn vec4(e1 : T, e2 : T, e3 : T, e4 : T) -> vec4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec4<T>(e1 : T, e2 : T, e3 : T, e4 : T) -> vec4<T>
+          @const @must_use fn vec4(e1 : T, e2 : T, e3 : T, e4 : T) -> vec4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=scalar=]
   <tr><td>Description
@@ -12588,10 +12634,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec4<T>(e1 : T, v1 : vec2<T>, e2 : T) -> vec4<T>
-@const @must_use fn vec4(e1 : T, v1 : vec2<T>, e2 : T) -> vec4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec4<T>(e1 : T, v1 : vec2<T>, e2 : T) -> vec4<T>
+          @const @must_use fn vec4(e1 : T, v1 : vec2<T>, e2 : T) -> vec4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=scalar=]
   <tr><td>Description
@@ -12599,10 +12646,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec4<T>(e1 : T, e2 : T, v1 : vec2<T>) -> vec4<T>
-@const @must_use fn vec4(e1 : T, e2 : T, v1 : vec2<T>) -> vec4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec4<T>(e1 : T, e2 : T, v1 : vec2<T>) -> vec4<T>
+          @const @must_use fn vec4(e1 : T, e2 : T, v1 : vec2<T>) -> vec4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=scalar=]
   <tr><td>Description
@@ -12610,10 +12658,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec4<T>(v1 : vec2<T>, v2 : vec2<T>) -> vec4<T>
-@const @must_use fn vec4(v1 : vec2<T>, v2 : vec2<T>) -> vec4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec4<T>(v1 : vec2<T>, v2 : vec2<T>) -> vec4<T>
+          @const @must_use fn vec4(v1 : vec2<T>, v2 : vec2<T>) -> vec4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=scalar=]
   <tr><td>Description
@@ -12621,10 +12670,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec4<T>(v1 : vec2<T>, e1 : T, e2 : T) -> vec4<T>
-@const @must_use fn vec4(v1 : vec2<T>, e1 : T, e2 : T) -> vec4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec4<T>(v1 : vec2<T>, e1 : T, e2 : T) -> vec4<T>
+          @const @must_use fn vec4(v1 : vec2<T>, e1 : T, e2 : T) -> vec4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=scalar=]
   <tr><td>Description
@@ -12632,10 +12682,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec4<T>(v1 : vec3<T>, e1 : T) -> vec4<T>
-@const @must_use fn vec4(v1 : vec3<T>, e1 : T) -> vec4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec4<T>(v1 : vec3<T>, e1 : T) -> vec4<T>
+          @const @must_use fn vec4(v1 : vec3<T>, e1 : T) -> vec4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=scalar=]
   <tr><td>Description
@@ -12643,10 +12694,11 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>
-@const @must_use fn vec4<T>(e1 : T, v1 : vec3<T>) -> vec4<T>
-@const @must_use fn vec4(e1 : T, v1 : vec3<T>) -> vec4<T>
-</xmp>
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec4<T>(e1 : T, v1 : vec3<T>) -> vec4<T>
+          @const @must_use fn vec4(e1 : T, v1 : vec3<T>) -> vec4<T>
+        </xmp>
   <tr><td>Parameterization
       <td>`T` is [=scalar=]
   <tr><td>Description
@@ -12664,7 +12716,8 @@ The internal layout rules are described in [[#internal-value-layout]].
 
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn bitcast<T>(e : T) -> T</xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn bitcast<T>(e : T) -> T</xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=numeric scalar=] or [=type/concrete=] [=numeric vector=]
   <tr><td>Description
@@ -12674,7 +12727,8 @@ The internal layout rules are described in [[#internal-value-layout]].
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn bitcast<T>(e : S) -> T</xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn bitcast<T>(e : S) -> T</xmp>
   <tr><td>Parameterization
       <td>`S` is i32, u32, or f32<br>
       `T` is not `S` and is i32, u32, or f32
@@ -12684,7 +12738,8 @@ The internal layout rules are described in [[#internal-value-layout]].
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn bitcast<vecN<T>>(e : vecN<S>) -> T</xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn bitcast<vecN<T>>(e : vecN<S>) -> T</xmp>
   <tr><td>Parameterization
       <td>`S` is i32, u32, or f32<br>
       `T` is not `S` and is i32, u32, or f32
@@ -12694,7 +12749,8 @@ The internal layout rules are described in [[#internal-value-layout]].
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn bitcast<T>(e : vec2<f16>) -> T</xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn bitcast<T>(e : vec2<f16>) -> T</xmp>
   <tr><td>Parameterization
       <td>`T` is i32, u32, or f32
   <tr><td>Description
@@ -12703,7 +12759,8 @@ The internal layout rules are described in [[#internal-value-layout]].
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn bitcast<vec2<T>>(e : vec4<f16>) -> vec2<T></xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn bitcast<vec2<T>>(e : vec4<f16>) -> vec2<T></xmp>
   <tr><td>Parameterization
       <td>`T` is i32, u32, or f32<br>
   <tr><td>Description
@@ -12712,7 +12769,8 @@ The internal layout rules are described in [[#internal-value-layout]].
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn bitcast<vec2<f16>>(e : T) -> vec2<f16></xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn bitcast<vec2<f16>>(e : T) -> vec2<f16></xmp>
   <tr><td>Parameterization
       <td>`T` is i32, u32, or f32
   <tr><td>Description
@@ -12721,7 +12779,8 @@ The internal layout rules are described in [[#internal-value-layout]].
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
-      <td><xmp highlight=rust>@const @must_use fn bitcast<vec4<f16>>(e : vec2<T>) -> vec4<f16></xmp>
+      <td>
+        <xmp highlight=rust>@const @must_use fn bitcast<vec4<f16>>(e : vec2<T>) -> vec4<f16></xmp>
   <tr><td>Parameterization
       <td>`T` is i32, u32, or f32
   <tr><td>Description
@@ -12735,7 +12794,8 @@ The internal layout rules are described in [[#internal-value-layout]].
 <table class='data builtin'>
   <tr algorithm="vector all">
     <td style="width:10%">Overload
-    <td><xmp highlight=rust>@const @must_use fn all(e: vecN<bool>) -> bool</xmp>
+    <td>
+      <xmp highlight=rust>@const @must_use fn all(e: vecN<bool>) -> bool</xmp>
   <tr>
     <td>Description
     <td>Returns true if each component of `e` is true.
@@ -12744,7 +12804,8 @@ The internal layout rules are described in [[#internal-value-layout]].
 <table class='data builtin'>
   <tr algorithm="scalar all">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>@const @must_use fn all(e: bool) -> bool</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>@const @must_use fn all(e: bool) -> bool</xmp>
   <tr>
     <td>Description
     <td>Returns `e`.
@@ -12754,9 +12815,10 @@ The internal layout rules are described in [[#internal-value-layout]].
 <table class='data builtin'>
   <tr algorithm="vector any">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn any(e: vecN<bool>) -> bool
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn any(e: vecN<bool>) -> bool
+      </xmp>
   <tr>
     <td style="width:10%">Description
     <td>Returns true if any component of `e` is true.
@@ -12765,7 +12827,8 @@ The internal layout rules are described in [[#internal-value-layout]].
 <table class='data builtin'>
   <tr algorithm="scalar any">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>@const @must_use fn any(e: bool) -> bool</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>@const @must_use fn any(e: bool) -> bool</xmp>
   <tr>
     <td>Description
     <td>Returns `e`.
@@ -12775,11 +12838,12 @@ The internal layout rules are described in [[#internal-value-layout]].
 <table class='data builtin'>
   <tr algorithm="scalar select">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn select(f: T,
-                           t: T,
-                           cond: bool) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn select(f: T,
+                                   t: T,
+                                   cond: bool) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is [=scalar=] or [=vector=]
@@ -12791,11 +12855,12 @@ The internal layout rules are described in [[#internal-value-layout]].
 <table class='data builtin'>
   <tr algorithm="vector select">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn select(f: vecN<T>,
-                           t: vecN<T>,
-                           cond: vecN<bool>) -> vecN<T>
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn select(f: vecN<T>,
+                                   t: vecN<T>,
+                                   cond: vecN<bool>) -> vecN<T>
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is [=scalar=]
@@ -12811,9 +12876,10 @@ The internal layout rules are described in [[#internal-value-layout]].
 <table class='data builtin'>
   <tr algorithm="runtime-sized array length">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@must_use fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @must_use fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`E` is an element type for a [=runtime-sized=] array,<br>
@@ -12851,9 +12917,10 @@ fn num_point_lights() -> u32 {
 <table class='data builtin'>
   <tr algorithm="float abs">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn abs(e: T ) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn abs(e: T ) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLNUMERICDECL]
@@ -12872,9 +12939,10 @@ fn num_point_lights() -> u32 {
 <table class='data builtin'>
   <tr algorithm="acos">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn acos(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn acos(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -12895,9 +12963,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
 <table class='data builtin'>
   <tr algorithm="acosh">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn acosh(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn acosh(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -12920,9 +12989,10 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
 <table class='data builtin'>
   <tr algorithm="asin">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn asin(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn asin(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -12943,9 +13013,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
 <table class='data builtin'>
   <tr algorithm="asinh">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn asinh(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn asinh(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -12961,9 +13032,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
 <table class='data builtin'>
   <tr algorithm="atan">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn atan(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn atan(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -12979,9 +13051,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
 <table class='data builtin'>
   <tr algorithm="atanh">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn atanh(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn atanh(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13003,10 +13076,11 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="atan2">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn atan2(y: T,
-                          x: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn atan2(y: T,
+                                  x: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13030,9 +13104,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="ceil">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn ceil(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn ceil(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13046,11 +13121,12 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="clamp">
   <td style="width:10%">Overload
-  <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn clamp(e: T,
-                          low: T,
-                          high: T) -> T
-</xmp>
+  <td class="nowrap">
+    <xmp highlight=rust>
+      @const @must_use fn clamp(e: T,
+                                low: T,
+                                high: T) -> T
+    </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLNUMERICDECL]
@@ -13074,9 +13150,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="cos">
   <td style="width:10%">Overload
-  <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn cos(e: T) -> T
-</xmp>
+  <td class="nowrap">
+    <xmp highlight=rust>@const @must_use fn cos(e: T) -> T</xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13090,9 +13165,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="cosh">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn cosh(arg: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn cosh(arg: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13109,9 +13185,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="count leading zeroes">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn countLeadingZeros(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn countLeadingZeros(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is [INTEGRAL]
@@ -13127,9 +13204,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="count 1 bits">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn countOneBits(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn countOneBits(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is [INTEGRAL]
@@ -13144,9 +13222,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="count trailing zeroes">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn countTrailingZeros(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn countTrailingZeros(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is [INTEGRAL]
@@ -13162,10 +13241,11 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="vector case, cross">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn cross(e1: vec3<T>,
-                          e2: vec3<T>) -> vec3<T>
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn cross(e1: vec3<T>,
+                                  e2: vec3<T>) -> vec3<T>
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is AbstractFloat, f32, or f16
@@ -13178,9 +13258,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="degrees">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn degrees(e1: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn degrees(e1: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13194,9 +13275,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="determinant">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn determinant(e: matCxC<T>) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn determinant(e: matCxC<T>) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is AbstractFloat, f32, or f16
@@ -13209,10 +13291,11 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="distance">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn distance(e1: T,
-                             e2: T) -> S
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn distance(e1: T,
+                                     e2: T) -> S
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13225,10 +13308,11 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="dot">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn dot(e1: vecN<T>,
-                        e2: vecN<T>) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn dot(e1: vecN<T>,
+                                e2: vecN<T>) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is AbstractInt, AbstractFloat, i32, u32, f32, or f16
@@ -13241,9 +13325,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="exp">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn exp(e1: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn exp(e1: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13257,9 +13342,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="exp2">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn exp2(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn exp2(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13273,11 +13359,12 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="signed extract bits">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn extractBits(e: T,
-                                offset: u32,
-                                count: u32) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn extractBits(e: T,
+                                        offset: u32,
+                                        count: u32) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is [SIGNEDINTEGRAL]
@@ -13306,11 +13393,12 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="unsigned extract bits">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn extractBits(e: T,
-                                offset: u32,
-                                count: u32) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn extractBits(e: T,
+                                        offset: u32,
+                                        count: u32) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is [UNSIGNEDINTEGRAL]
@@ -13339,11 +13427,12 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="faceForward">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn faceForward(e1: T,
-                                e2: T,
-                                e3: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn faceForward(e1: T,
+                                        e2: T,
+                                        e3: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is vecN&lt;AbstractFloat&gt;, vecN&lt;f32&gt;, or vecN&lt;f16&gt;
@@ -13356,9 +13445,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 <table class='data builtin'>
   <tr algorithm="signed find most significant one bit">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn firstLeadingBit(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn firstLeadingBit(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is [SIGNEDINTEGRAL]
@@ -13385,9 +13475,10 @@ the sign bit appears in the most significant bit position.
 <table class='data builtin'>
   <tr algorithm="unsigned find most significant one bit">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn firstLeadingBit(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn firstLeadingBit(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is [UNSIGNEDINTEGRAL]
@@ -13406,9 +13497,10 @@ the sign bit appears in the most significant bit position.
 <table class='data builtin'>
   <tr algorithm="find least significant one bit">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn firstTrailingBit(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn firstTrailingBit(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is [INTEGRAL]
@@ -13427,9 +13519,10 @@ the sign bit appears in the most significant bit position.
 <table class='data builtin'>
   <tr algorithm="floor">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn floor(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn floor(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13443,11 +13536,12 @@ the sign bit appears in the most significant bit position.
 <table class='data builtin'>
   <tr algorithm="fma">
   <td style="width:10%">Overload
-  <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn fma(e1: T,
-                        e2: T,
-                        e3: T) -> T
-</xmp>
+  <td class="nowrap">
+    <xmp highlight=rust>
+      @const @must_use fn fma(e1: T,
+                              e2: T,
+                              e3: T) -> T
+    </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13472,9 +13566,10 @@ the sign bit appears in the most significant bit position.
 <table class='data builtin'>
   <tr algorithm="fract">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn fract(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn fract(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13495,9 +13590,10 @@ For example, if `e` is a very small negative number, then `fract(e)` may be 1.0.
 <table class='data builtin'>
   <tr algorithm="scalar case, binary32, frexp">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn frexp(e: T) -> __frexp_result_f32
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn frexp(e: T) -> __frexp_result_f32
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f32
@@ -13542,9 +13638,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="scalar case, binary16, frexp">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn frexp(e: T) -> __frexp_result_f16
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn frexp(e: T) -> __frexp_result_f16
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f16
@@ -13578,9 +13675,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="scalar case, abstract, frexp">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn frexp(e: T) -> __frexp_result_abstract
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn frexp(e: T) -> __frexp_result_abstract
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is AbstractFloat
@@ -13626,9 +13724,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="vector case, binary32, frexp">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn frexp(e: T) -> __frexp_result_vecN_f32
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn frexp(e: T) -> __frexp_result_vecN_f32
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is vecN&lt;f32&gt;
@@ -13662,9 +13761,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="vector case, binary16, frexp">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn frexp(e: T) -> __frexp_result_vecN_f16
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn frexp(e: T) -> __frexp_result_vecN_f16
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is vecN&lt;f16&gt;
@@ -13698,9 +13798,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="vector case, abstract, frexp">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn frexp(e: T) -> __frexp_result_vecN_abstract
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn frexp(e: T) -> __frexp_result_vecN_abstract
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is vecN&lt;AbstractFloat&gt;
@@ -13736,12 +13837,13 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="insert bits">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn insertBits(e: T,
-                               newbits: T,
-                               offset: u32,
-                               count: u32) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn insertBits(e: T,
+                                      newbits: T,
+                                      offset: u32,
+                                      count: u32) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is [INTEGRAL]
@@ -13770,9 +13872,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="inverseSqrt">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn inverseSqrt(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn inverseSqrt(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13791,10 +13894,11 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
 <table class='data builtin'>
   <tr algorithm="ldexp">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn ldexp(e1: T,
-                          e2: I) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn ldexp(e1: T,
+                                  e2: I) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]<br>
@@ -13832,9 +13936,10 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
 <table class='data builtin'>
   <tr algorithm="length">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn length(e: T) -> S
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn length(e: T) -> S
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13852,9 +13957,10 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
 <table class='data builtin'>
   <tr algorithm="log">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn log(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn log(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13873,9 +13979,10 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
 <table class='data builtin'>
   <tr algorithm="log2">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn log2(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn log2(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13894,10 +14001,11 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
 <table class='data builtin'>
   <tr algorithm="max">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn max(e1: T,
-                        e2: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn max(e1: T,
+                                e2: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLNUMERICDECL]
@@ -13916,10 +14024,11 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
 <table class='data builtin'>
   <tr algorithm="min">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn min(e1: T,
-                        e2: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn min(e1: T,
+                                e2: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLNUMERICDECL]
@@ -13938,11 +14047,12 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
 <table class='data builtin'>
   <tr algorithm="mix all same type operands">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn mix(e1: T,
-                        e2: T,
-                        e3: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn mix(e1: T,
+                                e2: T,
+                                e3: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -13955,11 +14065,12 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
 <table class='data builtin'>
   <tr algorithm="vector mix with scalar blending factor">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn mix(e1: T2,
-                        e2: T2,
-                        e3: T) -> T2
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn mix(e1: T2,
+                                e2: T2,
+                                e3: T) -> T2
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is AbstractFloat, f32, or f16<br>
@@ -13975,9 +14086,10 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
 <table class='data builtin'>
   <tr algorithm="scalar case, binary32, modf">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn modf(e: T) -> __modf_result_f32
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn modf(e: T) -> __modf_result_f32
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f32
@@ -14019,9 +14131,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="scalar case, binary16, modf">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn modf(e: T) -> __modf_result_f16
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn modf(e: T) -> __modf_result_f16
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f16
@@ -14050,9 +14163,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="scalar case, abstract, modf">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn modf(e: T) -> __modf_result_abstract
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn modf(e: T) -> __modf_result_abstract
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is AbstractFloat
@@ -14094,9 +14208,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="vector case, binary32, modf">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn modf(e: T) -> __modf_result_vecN_f32
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn modf(e: T) -> __modf_result_vecN_f32
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is vecN&lt;f32&gt;
@@ -14126,9 +14241,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="vector case, binary16, modf">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn modf(e: T) -> __modf_result_vecN_f16
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn modf(e: T) -> __modf_result_vecN_f16
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is vecN&lt;f16&gt;
@@ -14158,9 +14274,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="vector case, abstract, modf">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn modf(e: T) -> __modf_result_vecN_abstract
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn modf(e: T) -> __modf_result_vecN_abstract
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is vecN&lt;AbstractFloat&gt;
@@ -14191,9 +14308,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="vector case, normalize">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn normalize(e: vecN<T> ) -> vecN<T>
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn normalize(e: vecN<T> ) -> vecN<T>
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is AbstractFloat, f32, or f16
@@ -14206,10 +14324,11 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="pow">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn pow(e1: T,
-                        e2: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn pow(e1: T,
+                                e2: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -14223,9 +14342,10 @@ but a value may infer the type.
 <table class='data builtin'>
   <tr algorithm="quantize to f16">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn quantizeToF16(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn quantizeToF16(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f32 or vecN&lt;f32&gt;
@@ -14258,9 +14378,10 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="radians">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn radians(e1: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn radians(e1: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -14274,10 +14395,11 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="reflect">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn reflect(e1: T,
-                            e2: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn reflect(e1: T,
+                                    e2: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is vecN&lt;AbstractFloat&gt;, vecN&lt;f32&gt;, or vecN&lt;f16&gt;
@@ -14291,11 +14413,12 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="refract">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn refract(e1: T,
-                            e2: T,
-                            e3: I) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn refract(e1: T,
+                                    e2: T,
+                                    e3: I) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is vecN&lt;I&gt;<br>
@@ -14313,9 +14436,10 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="bit reversal">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn reverseBits(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn reverseBits(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is [INTEGRAL]
@@ -14330,9 +14454,10 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="round">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn round(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn round(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -14348,9 +14473,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="saturate">
   <td style="width:10%">Overload
-  <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn saturate(e: T) -> T
-</xmp>
+  <td class="nowrap">
+    <xmp highlight=rust>@const @must_use fn saturate(e: T) -> T</xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -14364,9 +14488,10 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="numeric sign">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn sign(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn sign(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLSIGNEDNUMERICDECL]
@@ -14386,9 +14511,10 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="sin">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn sin(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn sin(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -14402,9 +14528,10 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="sinh">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn sinh(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn sinh(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -14422,11 +14549,12 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="smoothstep">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn smoothstep(low: T,
-                               high: T,
-                               x: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn smoothstep(low: T,
+                                       high: T,
+                                       x: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -14444,9 +14572,10 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="sqrt">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn sqrt(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn sqrt(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -14460,10 +14589,11 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="step">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn step(edge: T,
-                         x: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn step(edge: T,
+                                 x: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -14477,9 +14607,10 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="tan">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn tan(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn tan(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -14493,9 +14624,10 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="tanh">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn tanh(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn tanh(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -14513,9 +14645,10 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="transpose">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn transpose(e: matRxC<T>) -> matCxR<T>
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn transpose(e: matRxC<T>) -> matCxR<T>
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is AbstractFloat, f32, or f16
@@ -14528,9 +14661,10 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 <table class='data builtin'>
   <tr algorithm="trunc">
         <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn trunc(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn trunc(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
@@ -14554,9 +14688,10 @@ Calls to these functions:
 <table class='data builtin'>
   <tr algorithm="dpdx">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@must_use fn dpdx(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @must_use fn dpdx(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f32 or vecN&lt;f32&gt;
@@ -14572,9 +14707,10 @@ Calls to these functions:
 <table class='data builtin'>
   <tr algorithm="dpdxCoarse">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@must_use fn dpdxCoarse(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @must_use fn dpdxCoarse(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f32 or vecN&lt;f32&gt;
@@ -14590,9 +14726,10 @@ Calls to these functions:
 <table class='data builtin'>
   <tr algorithm="dpdxFine">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@must_use fn dpdxFine(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @must_use fn dpdxFine(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f32 or vecN&lt;f32&gt;
@@ -14607,9 +14744,8 @@ Calls to these functions:
 <table class='data builtin'>
   <tr algorithm="dpdy">
   <td style="width:10%">Overload
-  <td class="nowrap"><xmp highlight=rust>
-@must_use fn dpdy(e: T) -> T
-</xmp>
+  <td class="nowrap">
+    <xmp highlight=rust>@must_use fn dpdy(e: T) -> T</xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f32 or vecN&lt;f32&gt;
@@ -14625,9 +14761,10 @@ Calls to these functions:
 <table class='data builtin'>
   <tr algorithm="dpdyCoarse">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@must_use fn dpdyCoarse(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @must_use fn dpdyCoarse(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f32 or vecN&lt;f32&gt;
@@ -14643,9 +14780,10 @@ Calls to these functions:
 <table class='data builtin'>
   <tr algorithm="dpdyFine">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@must_use fn dpdyFine(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @must_use fn dpdyFine(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f32 or vecN&lt;f32&gt;
@@ -14660,9 +14798,10 @@ Calls to these functions:
 <table class='data builtin'>
   <tr algorithm="fwidth">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@must_use fn fwidth(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @must_use fn fwidth(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f32 or vecN&lt;f32&gt;
@@ -14677,9 +14816,10 @@ Calls to these functions:
 <table class='data builtin'>
   <tr algorithm="fwidthCoarse">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@must_use fn fwidthCoarse(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @must_use fn fwidthCoarse(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f32 or vecN&lt;f32&gt;
@@ -14694,9 +14834,10 @@ Calls to these functions:
 <table class='data builtin'>
   <tr algorithm="fwidthFine">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@must_use fn fwidthFine(e: T) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @must_use fn fwidthFine(e: T) -> T
+      </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>`T` is f32 or vecN&lt;f32&gt;
@@ -14724,16 +14865,19 @@ Returns the dimensions of a texture, or texture's mip level in texels.
         <var ignore>F</var> is a [=texel format=]<br>
         <var ignore>A</var> is an [=access mode=]<br><br>
         |T| is `texture_1d<ST>` or `texture_storage_1d<F,A>`
-    <td><xmp highlight=rust>fn textureDimensions(t: T) -> u32</xmp>
+    <td>
+      <xmp highlight=rust>fn textureDimensions(t: T) -> u32</xmp>
 
   <tr algorithm="textureDimensions 1d level">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
         |T| is `texture_1d<ST>`
 
         <var ignore>L</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureDimensions(t: T,
-                               level: L) -> u32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureDimensions(t: T,
+                                       level: L) -> u32
+      </xmp>
 
   <tr algorithm="textureDimensions 2d">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br>
@@ -14745,7 +14889,8 @@ Returns the dimensions of a texture, or texture's mip level in texels.
                `texture_depth_cube_array`, `texture_depth_multisampled_2d`,
                `texture_storage_2d<F,A>`, `texture_storage_2d_array<F,A>`,
                or `texture_external`
-    <td><xmp highlight=rust>fn textureDimensions(t: T) -> vec2<u32></xmp>
+    <td>
+      <xmp highlight=rust>fn textureDimensions(t: T) -> vec2<u32></xmp>
 
   <tr algorithm="textureDimensions 2d level">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
@@ -14754,25 +14899,30 @@ Returns the dimensions of a texture, or texture's mip level in texels.
                `texture_depth_cube`, or `texture_depth_cube_array`
 
         <var ignore>L</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureDimensions(t: T,
-                               level: L) -> vec2<u32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureDimensions(t: T,
+                                       level: L) -> vec2<u32>
+      </xmp>
 
   <tr algorithm="textureDimensions 3d">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br>
         <var ignore>F</var> is a [=texel format=]<br>
         <var ignore>A</var> is an [=access mode=]<br><br>
         |T| is `texture_3d<ST>` or `texture_storage_3d<F,A>`
-    <td><xmp highlight=rust>fn textureDimensions(t: T) -> vec3<u32></xmp>
+    <td>
+      <xmp highlight=rust>fn textureDimensions(t: T) -> vec3<u32></xmp>
 
   <tr algorithm="textureDimensions 3d level">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
         |T| is `texture_3d<ST>`
 
         <var ignore>L</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureDimensions(t: T,
-                               level: L) -> vec3<u32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureDimensions(t: T,
+                                       level: L) -> vec3<u32>
+      </xmp>
 </table>
 
 **Parameters:**
@@ -14838,111 +14988,135 @@ https://github.com/gpuweb/gpuweb/issues/2343
   <tr algorithm="textureGather 2d">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
-    <td><xmp highlight=rust>
-@must_use fn textureGather(component: C,
-                           t: texture_2d<ST>,
-                           s: sampler,
-                           coords: vec2<f32>) -> vec4<ST></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGather(component: C,
+                                   t: texture_2d<ST>,
+                                   s: sampler,
+                                   coords: vec2<f32>) -> vec4<ST>
+      </xmp>
 
   <tr algorithm="textureGather 2d offset">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
-    <td><xmp highlight=rust>
-@must_use fn textureGather(component: C,
-                           t: texture_2d<ST>,
-                           s: sampler,
-                           coords: vec2<f32>,
-                           offset: vec2<i32>) -> vec4<ST></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGather(component: C,
+                                   t: texture_2d<ST>,
+                                   s: sampler,
+                                   coords: vec2<f32>,
+                                   offset: vec2<i32>) -> vec4<ST>
+      </xmp>
 
   <tr algorithm="textureGather 2d array">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
-    <td><xmp highlight=rust>
-@must_use fn textureGather(component: C,
-                           t: texture_2d_array<ST>,
-                           s: sampler,
-                           coords: vec2<f32>,
-                           array_index: A) -> vec4<ST></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGather(component: C,
+                                   t: texture_2d_array<ST>,
+                                   s: sampler,
+                                   coords: vec2<f32>,
+                                   array_index: A) -> vec4<ST>
+      </xmp>
 
   <tr algorithm="textureGather 2d array offset">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
-    <td><xmp highlight=rust>
-@must_use fn textureGather(component: C,
-                           t: texture_2d_array<ST>,
-                           s: sampler,
-                           coords: vec2<f32>,
-                           array_index: A,
-                           offset: vec2<i32>) -> vec4<ST></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGather(component: C,
+                                   t: texture_2d_array<ST>,
+                                   s: sampler,
+                                   coords: vec2<f32>,
+                                   array_index: A,
+                                   offset: vec2<i32>) -> vec4<ST>
+      </xmp>
 
   <tr algorithm="textureGather cube">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
-    <td><xmp highlight=rust>
-@must_use fn textureGather(component: C,
-                           t: texture_cube<ST>,
-                           s: sampler,
-                           coords: vec3<f32>) -> vec4<ST></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGather(component: C,
+                                   t: texture_cube<ST>,
+                                   s: sampler,
+                                   coords: vec3<f32>) -> vec4<ST>
+      </xmp>
 
   <tr algorithm="textureGather cube array">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
-    <td><xmp highlight=rust>
-@must_use fn textureGather(component: C,
-                           t: texture_cube_array<ST>,
-                           s: sampler,
-                           coords: vec3<f32>,
-                           array_index: A) -> vec4<ST></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGather(component: C,
+                                   t: texture_cube_array<ST>,
+                                   s: sampler,
+                                   coords: vec3<f32>,
+                                   array_index: A) -> vec4<ST>
+      </xmp>
 
   <tr algorithm="textureGather 2d depth">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureGather(t: texture_depth_2d,
-                           s: sampler,
-                           coords: vec2<f32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGather(t: texture_depth_2d,
+                                   s: sampler,
+                                   coords: vec2<f32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureGather 2d depth offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureGather(t: texture_depth_2d,
-                           s: sampler,
-                           coords: vec2<f32>,
-                           offset: vec2<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGather(t: texture_depth_2d,
+                                   s: sampler,
+                                   coords: vec2<f32>,
+                                   offset: vec2<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureGather cube depth">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureGather(t: texture_depth_cube,
-                           s: sampler,
-                           coords: vec3<f32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGather(t: texture_depth_cube,
+                                   s: sampler,
+                                   coords: vec3<f32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureGather 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureGather(t: texture_depth_2d_array,
-                           s: sampler,
-                           coords: vec2<f32>,
-                           array_index: A) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGather(t: texture_depth_2d_array,
+                                   s: sampler,
+                                   coords: vec2<f32>,
+                                   array_index: A) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureGather 2d depth array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureGather(t: texture_depth_2d_array,
-                           s: sampler,
-                           coords: vec2<f32>,
-                           array_index: A,
-                           offset: vec2<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGather(t: texture_depth_2d_array,
+                                   s: sampler,
+                                   coords: vec2<f32>,
+                                   array_index: A,
+                                   offset: vec2<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureGather cube depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureGather(t: texture_depth_cube_array,
-                           s: sampler,
-                           coords: vec3<f32>,
-                           array_index: A) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGather(t: texture_depth_cube_array,
+                                   s: sampler,
+                                   coords: vec3<f32>,
+                                   array_index: A) -> vec4<f32>
+      </xmp>
 </table>
 
 **Parameters:**
@@ -15025,56 +15199,68 @@ texture and collects the results into a single vector, as follows:
   </thead>
   <tr algorithm="textureGatherCompare 2d depth">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureGatherCompare(t: texture_depth_2d,
-                                  s: sampler_comparison,
-                                  coords: vec2<f32>,
-                                  depth_ref: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGatherCompare(t: texture_depth_2d,
+                                          s: sampler_comparison,
+                                          coords: vec2<f32>,
+                                          depth_ref: f32) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureGatherCompare 2d depth offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureGatherCompare(t: texture_depth_2d,
-                                  s: sampler_comparison,
-                                  coords: vec2<f32>,
-                                  depth_ref: f32,
-                                  offset: vec2<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGatherCompare(t: texture_depth_2d,
+                                          s: sampler_comparison,
+                                          coords: vec2<f32>,
+                                          depth_ref: f32,
+                                          offset: vec2<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureGatherCompare 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureGatherCompare(t: texture_depth_2d_array,
-                                  s: sampler_comparison,
-                                  coords: vec2<f32>,
-                                  array_index: A,
-                                  depth_ref: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGatherCompare(t: texture_depth_2d_array,
+                                          s: sampler_comparison,
+                                          coords: vec2<f32>,
+                                          array_index: A,
+                                          depth_ref: f32) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureGatherCompare 2d depth array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureGatherCompare(t: texture_depth_2d_array,
-                                  s: sampler_comparison,
-                                  coords: vec2<f32>,
-                                  array_index: A,
-                                  depth_ref: f32,
-                                  offset: vec2<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGatherCompare(t: texture_depth_2d_array,
+                                          s: sampler_comparison,
+                                          coords: vec2<f32>,
+                                          array_index: A,
+                                          depth_ref: f32,
+                                          offset: vec2<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureGatherCompare 2d depth cube">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureGatherCompare(t: texture_depth_cube,
-                                  s: sampler_comparison,
-                                  coords: vec3<f32>,
-                                  depth_ref: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGatherCompare(t: texture_depth_cube,
+                                          s: sampler_comparison,
+                                          coords: vec3<f32>,
+                                          depth_ref: f32) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureGatherCompare 2d depth cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureGatherCompare(t: texture_depth_cube_array,
-                                  s: sampler_comparison,
-                                  coords: vec3<f32>,
-                                  array_index: A,
-                                  depth_ref: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureGatherCompare(t: texture_depth_cube_array,
+                                          s: sampler_comparison,
+                                          coords: vec3<f32>,
+                                          array_index: A,
+                                          depth_ref: f32) -> vec4<f32>
+      </xmp>
 
 </table>
 
@@ -15127,80 +15313,98 @@ Reads a single texel from a texture without sampling or filtering.
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
-    <td><xmp highlight=rust>
-@must_use fn textureLoad(t: texture_1d<ST>,
-                         coords: C,
-                         level: L) -> vec4<ST></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureLoad(t: texture_1d<ST>,
+                                 coords: C,
+                                 level: L) -> vec4<ST>
+      </xmp>
 
   <tr algorithm="textureLoad 2d">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
-    <td><xmp highlight=rust>
-@must_use fn textureLoad(t: texture_2d<ST>,
-                         coords: vec2<C>,
-                         level: L) -> vec4<ST></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureLoad(t: texture_2d<ST>,
+                                 coords: vec2<C>,
+                                 level: L) -> vec4<ST>
+      </xmp>
 
   <tr algorithm="textureLoad 2d array">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
-    <td><xmp highlight=rust>
-@must_use fn textureLoad(t: texture_2d_array<ST>,
-                        coords: vec2<C>,
-                        array_index: A,
-                        level: L) -> vec4<ST></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureLoad(t: texture_2d_array<ST>,
+                                coords: vec2<C>,
+                                array_index: A,
+                                level: L) -> vec4<ST>
+      </xmp>
 
   <tr algorithm="textureLoad 3d">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
-    <td><xmp highlight=rust>
-@must_use fn textureLoad(t: texture_3d<ST>,
-                         coords: vec3<C>,
-                         level: L) -> vec4<ST></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureLoad(t: texture_3d<ST>,
+                                 coords: vec3<C>,
+                                 level: L) -> vec4<ST>
+      </xmp>
 
   <tr algorithm="textureLoad 2d multisampled">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>S</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
-    <td><xmp highlight=rust>
-@must_use fn textureLoad(t: texture_multisampled_2d<ST>,
-                         coords: vec2<C>,
-                         sample_index: S)-> vec4<ST></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureLoad(t: texture_multisampled_2d<ST>,
+                                 coords: vec2<C>,
+                                 sample_index: S)-> vec4<ST>
+      </xmp>
 
   <tr algorithm="textureLoad 2d depth">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureLoad(t: texture_depth_2d,
-                         coords: vec2<C>,
-                         level: L) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureLoad(t: texture_depth_2d,
+                                 coords: vec2<C>,
+                                 level: L) -> f32
+      </xmp>
 
   <tr algorithm="textureLoad 2d depth array">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureLoad(t: texture_depth_2d_array,
-                         coords: vec2<C>,
-                         array_index: A,
-                         level: L) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureLoad(t: texture_depth_2d_array,
+                                 coords: vec2<C>,
+                                 array_index: A,
+                                 level: L) -> f32
+      </xmp>
 
 <tr algorithm="textureLoad 2d depth multisampled">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>S</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureLoad(t: texture_depth_multisampled_2d,
-                         coords: vec2<C>,
-                         sample_index: S)-> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureLoad(t: texture_depth_multisampled_2d,
+                                 coords: vec2<C>,
+                                 sample_index: S)-> f32
+      </xmp>
 
   <tr algorithm="textureLoad external">
     <td><var ignore>C</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureLoad(t: texture_external,
-                         coords: vec2<C>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureLoad(t: texture_external,
+                                 coords: vec2<C>) -> vec4<f32>
+      </xmp>
 
 </table>
 
@@ -15252,9 +15456,8 @@ Returns the number of layers (elements) of an [=texture/arrayed=] texture.
         <var ignore>T</var> is `texture_2d_array<ST>`, `texture_cube_array<ST>`,
                                `texture_depth_2d_array`, `texture_depth_cube_array`,
                                or `texture_storage_2d_array<F,A>`
-    <td><xmp highlight=rust>
-@must_use fn textureNumLayers(t: T) -> u32</xmp>
-
+    <td>
+      <xmp highlight=rust>@must_use fn textureNumLayers(t: T) -> u32</xmp>
 </table>
 
 **Parameters:**
@@ -15287,9 +15490,8 @@ Returns the number of mip levels of a texture.
                                `texture_cube<ST>`, `texture_cube_array<ST>`,
                                `texture_depth_2d`, `texture_depth_2d_array`,
                                `texture_depth_cube`, or `texture_depth_cube_array`
-    <td><xmp highlight=rust>
-@must_use fn textureNumLevels(t: T) -> u32</xmp>
-
+    <td>
+      <xmp highlight=rust>@must_use fn textureNumLevels(t: T) -> u32</xmp>
 </table>
 
 **Parameters:**
@@ -15316,9 +15518,8 @@ Returns the number samples per texel in a multisampled texture.
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
         <var ignore>T</var> is `texture_multisampled_2d<ST>`
                                 or `texture_depth_multisampled_2d`
-    <td><xmp highlight=rust>
-@must_use fn textureNumSamples(t: T) -> u32</xmp>
-
+    <td>
+      <xmp highlight=rust>@must_use fn textureNumSamples(t: T) -> u32</xmp>
 </table>
 
 **Parameters:**
@@ -15348,112 +15549,140 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
   </thead>
   <tr algorithm="textureSample 1d">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_1d<f32>,
-                           s: sampler,
-                           coords: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_1d<f32>,
+                                   s: sampler,
+                                   coords: f32) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSample 2d">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_2d<f32>,
-                           s: sampler,
-                           coords: vec2<f32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_2d<f32>,
+                                   s: sampler,
+                                   coords: vec2<f32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSample 2d offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_2d<f32>,
-                           s: sampler,
-                           coords: vec2<f32>,
-                           offset: vec2<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_2d<f32>,
+                                   s: sampler,
+                                   coords: vec2<f32>,
+                                   offset: vec2<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSample 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_2d_array<f32>,
-                           s: sampler,
-                           coords: vec2<f32>,
-                           array_index: A) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_2d_array<f32>,
+                                   s: sampler,
+                                   coords: vec2<f32>,
+                                   array_index: A) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSample 2d array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_2d_array<f32>,
-                           s: sampler,
-                           coords: vec2<f32>,
-                           array_index: A,
-                           offset: vec2<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_2d_array<f32>,
+                                   s: sampler,
+                                   coords: vec2<f32>,
+                                   array_index: A,
+                                   offset: vec2<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSample 3d">
     <td><var ignore>T</var> is `texture_3d<f32>`, or `texture_cube<f32>`
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: T,
-                           s: sampler,
-                           coords: vec3<f32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: T,
+                                   s: sampler,
+                                   coords: vec3<f32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSample 3d offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_3d<f32>,
-                           s: sampler,
-                           coords: vec3<f32>,
-                           offset: vec3<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_3d<f32>,
+                                   s: sampler,
+                                   coords: vec3<f32>,
+                                   offset: vec3<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSample cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_cube_array<f32>,
-                           s: sampler,
-                           coords: vec3<f32>,
-                           array_index: A) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_cube_array<f32>,
+                                   s: sampler,
+                                   coords: vec3<f32>,
+                                   array_index: A) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSample 2d depth">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_depth_2d,
-                           s: sampler,
-                           coords: vec2<f32>) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_depth_2d,
+                                   s: sampler,
+                                   coords: vec2<f32>) -> f32
+      </xmp>
 
   <tr algorithm="textureSample 2d depth offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_depth_2d,
-                           s: sampler,
-                           coords: vec2<f32>,
-                           offset: vec2<i32>) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_depth_2d,
+                                   s: sampler,
+                                   coords: vec2<f32>,
+                                   offset: vec2<i32>) -> f32
+      </xmp>
 
   <tr algorithm="textureSample 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_depth_2d_array,
-                           s: sampler,
-                           coords: vec2<f32>,
-                           array_index: A) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_depth_2d_array,
+                                   s: sampler,
+                                   coords: vec2<f32>,
+                                   array_index: A) -> f32
+      </xmp>
 
   <tr algorithm="textureSample 2d depth array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_depth_2d_array,
-                           s: sampler,
-                           coords: vec2<f32>,
-                           array_index: A,
-                           offset: vec2<i32>) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_depth_2d_array,
+                                   s: sampler,
+                                   coords: vec2<f32>,
+                                   array_index: A,
+                                   offset: vec2<i32>) -> f32
+      </xmp>
 
   <tr algorithm="textureSample cube depth">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_depth_cube,
-                           s: sampler,
-                           coords: vec3<f32>) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_depth_cube,
+                                   s: sampler,
+                                   coords: vec3<f32>) -> f32
+      </xmp>
 
   <tr algorithm="textureSample cube depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSample(t: texture_depth_cube_array,
-                           s: sampler,
-                           coords: vec3<f32>,
-                           array_index: A) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSample(t: texture_depth_cube_array,
+                                   s: sampler,
+                                   coords: vec3<f32>,
+                                   array_index: A) -> f32
+      </xmp>
 
 </table>
 
@@ -15499,65 +15728,79 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
   </thead>
   <tr algorithm="textureSampleBias 2d">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleBias(t: texture_2d<f32>,
-                               s: sampler,
-                               coords: vec2<f32>,
-                               bias: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleBias(t: texture_2d<f32>,
+                                       s: sampler,
+                                       coords: vec2<f32>,
+                                       bias: f32) -> vec4<f32>
+      </xmp>
 
 <tr algorithm="textureSampleBias 2d offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleBias(t: texture_2d<f32>,
-                               s: sampler,
-                               coords: vec2<f32>,
-                               bias: f32,
-                               offset: vec2<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleBias(t: texture_2d<f32>,
+                                       s: sampler,
+                                       coords: vec2<f32>,
+                                       bias: f32,
+                                       offset: vec2<i32>) -> vec4<f32>
+      </xmp>
 
 <tr algorithm="textureSampleBias 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleBias(t: texture_2d_array<f32>,
-                               s: sampler,
-                               coords: vec2<f32>,
-                               array_index: A,
-                               bias: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleBias(t: texture_2d_array<f32>,
+                                       s: sampler,
+                                       coords: vec2<f32>,
+                                       array_index: A,
+                                       bias: f32) -> vec4<f32>
+      </xmp>
 
 <tr algorithm="textureSampleBias 2d array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleBias(t: texture_2d_array<f32>,
-                               s: sampler,
-                               coords: vec2<f32>,
-                               array_index: A,
-                               bias: f32,
-                               offset: vec2<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleBias(t: texture_2d_array<f32>,
+                                       s: sampler,
+                                       coords: vec2<f32>,
+                                       array_index: A,
+                                       bias: f32,
+                                       offset: vec2<i32>) -> vec4<f32>
+      </xmp>
 
 <tr algorithm="textureSampleBias 3d">
     <td><var ignore>T</var> is `texture_3d<f32>`, or `texture_cube<f32>`
-    <td><xmp highlight=rust>
-@must_use fn textureSampleBias(t: T,
-                               s: sampler,
-                               coords: vec3<f32>,
-                               bias: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleBias(t: T,
+                                       s: sampler,
+                                       coords: vec3<f32>,
+                                       bias: f32) -> vec4<f32>
+      </xmp>
 
 <tr algorithm="textureSampleBias 3d offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleBias(t: texture_3d<f32>,
-                               s: sampler,
-                               coords: vec3<f32>,
-                               bias: f32,
-                               offset: vec3<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleBias(t: texture_3d<f32>,
+                                       s: sampler,
+                                       coords: vec3<f32>,
+                                       bias: f32,
+                                       offset: vec3<i32>) -> vec4<f32>
+      </xmp>
 
 <tr algorithm="textureSampleBias cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleBias(t: texture_cube_array<f32>,
-                               s: sampler,
-                               coords: vec3<f32>,
-                               array_index: A,
-                               bias: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleBias(t: texture_cube_array<f32>,
+                                       s: sampler,
+                                       coords: vec3<f32>,
+                                       array_index: A,
+                                       bias: f32) -> vec4<f32>
+      </xmp>
 
 </table>
 
@@ -15605,56 +15848,68 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
   </thead>
   <tr algorithm="textureSampleCompare 2d depth">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleCompare(t: texture_depth_2d,
-                                  s: sampler_comparison,
-                                  coords: vec2<f32>,
-                                  depth_ref: f32) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleCompare(t: texture_depth_2d,
+                                          s: sampler_comparison,
+                                          coords: vec2<f32>,
+                                          depth_ref: f32) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleCompare 2d depth offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleCompare(t: texture_depth_2d,
-                                  s: sampler_comparison,
-                                  coords: vec2<f32>,
-                                  depth_ref: f32,
-                                  offset: vec2<i32>) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleCompare(t: texture_depth_2d,
+                                          s: sampler_comparison,
+                                          coords: vec2<f32>,
+                                          depth_ref: f32,
+                                          offset: vec2<i32>) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleCompare 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleCompare(t: texture_depth_2d_array,
-                                  s: sampler_comparison,
-                                  coords: vec2<f32>,
-                                  array_index: A,
-                                  depth_ref: f32) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleCompare(t: texture_depth_2d_array,
+                                          s: sampler_comparison,
+                                          coords: vec2<f32>,
+                                          array_index: A,
+                                          depth_ref: f32) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleCompare 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleCompare(t: texture_depth_2d_array,
-                                  s: sampler_comparison,
-                                  coords: vec2<f32>,
-                                  array_index: A,
-                                  depth_ref: f32,
-                                  offset: vec2<i32>) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleCompare(t: texture_depth_2d_array,
+                                          s: sampler_comparison,
+                                          coords: vec2<f32>,
+                                          array_index: A,
+                                          depth_ref: f32,
+                                          offset: vec2<i32>) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleCompare cube depth">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleCompare(t: texture_depth_cube,
-                                  s: sampler_comparison,
-                                  coords: vec3<f32>,
-                                  depth_ref: f32) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleCompare(t: texture_depth_cube,
+                                          s: sampler_comparison,
+                                          coords: vec3<f32>,
+                                          depth_ref: f32) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleCompare cube depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleCompare(t: texture_depth_cube_array,
-                                  s: sampler_comparison,
-                                  coords: vec3<f32>,
-                                  array_index: A,
-                                  depth_ref: f32) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleCompare(t: texture_depth_cube_array,
+                                          s: sampler_comparison,
+                                          coords: vec3<f32>,
+                                          array_index: A,
+                                          depth_ref: f32) -> f32
+      </xmp>
 
 </table>
 
@@ -15704,56 +15959,68 @@ Samples a depth texture and compares the sampled depth values against a referenc
   </thead>
   <tr algorithm="textureSampleCompareLevel 2d depth">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleCompareLevel(t: texture_depth_2d,
-                                       s: sampler_comparison,
-                                       coords: vec2<f32>,
-                                       depth_ref: f32) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleCompareLevel(t: texture_depth_2d,
+                                               s: sampler_comparison,
+                                               coords: vec2<f32>,
+                                               depth_ref: f32) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleCompareLevel 2d depth offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleCompareLevel(t: texture_depth_2d,
-                                       s: sampler_comparison,
-                                       coords: vec2<f32>,
-                                       depth_ref: f32,
-                                       offset: vec2<i32>) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleCompareLevel(t: texture_depth_2d,
+                                               s: sampler_comparison,
+                                               coords: vec2<f32>,
+                                               depth_ref: f32,
+                                               offset: vec2<i32>) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleCompareLevel 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleCompareLevel(t: texture_depth_2d_array,
-                                       s: sampler_comparison,
-                                       coords: vec2<f32>,
-                                       array_index: A,
-                                       depth_ref: f32) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleCompareLevel(t: texture_depth_2d_array,
+                                               s: sampler_comparison,
+                                               coords: vec2<f32>,
+                                               array_index: A,
+                                               depth_ref: f32) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleCompareLevel 2d depth array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleCompareLevel(t: texture_depth_2d_array,
-                                       s: sampler_comparison,
-                                       coords: vec2<f32>,
-                                       array_index: A,
-                                       depth_ref: f32,
-                                       offset: vec2<i32>) -> f32</xmp>
+    <td>
+    <xmp highlight=rust>
+      @must_use fn textureSampleCompareLevel(t: texture_depth_2d_array,
+                                             s: sampler_comparison,
+                                             coords: vec2<f32>,
+                                             array_index: A,
+                                             depth_ref: f32,
+                                             offset: vec2<i32>) -> f32
+    </xmp>
 
   <tr algorithm="textureSampleCompareLevel cube depth">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleCompareLevel(t: texture_depth_cube,
-                                       s: sampler_comparison,
-                                       coords: vec3<f32>,
-                                       depth_ref: f32) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleCompareLevel(t: texture_depth_cube,
+                                               s: sampler_comparison,
+                                               coords: vec3<f32>,
+                                               depth_ref: f32) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleCompareLevel cube depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleCompareLevel(t: texture_depth_cube_array,
-                                       s: sampler_comparison,
-                                       coords: vec3<f32>,
-                                       array_index: A,
-                                       depth_ref: f32) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleCompareLevel(t: texture_depth_cube_array,
+                                               s: sampler_comparison,
+                                               coords: vec3<f32>,
+                                               array_index: A,
+                                               depth_ref: f32) -> f32
+      </xmp>
 
 </table>
 
@@ -15800,72 +16067,86 @@ Samples a texture using explicit gradients.
   </thead>
   <tr algorithm="textureSampleGrad 2d">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleGrad(t: texture_2d<f32>,
-                               s: sampler,
-                               coords: vec2<f32>,
-                               ddx: vec2<f32>,
-                               ddy: vec2<f32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleGrad(t: texture_2d<f32>,
+                                       s: sampler,
+                                       coords: vec2<f32>,
+                                       ddx: vec2<f32>,
+                                       ddy: vec2<f32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleGrad 2d offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleGrad(t: texture_2d<f32>,
-                               s: sampler,
-                               coords: vec2<f32>,
-                               ddx: vec2<f32>,
-                               ddy: vec2<f32>,
-                               offset: vec2<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleGrad(t: texture_2d<f32>,
+                                       s: sampler,
+                                       coords: vec2<f32>,
+                                       ddx: vec2<f32>,
+                                       ddy: vec2<f32>,
+                                       offset: vec2<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleGrad 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleGrad(t: texture_2d_array<f32>,
-                               s: sampler,
-                               coords: vec2<f32>,
-                               array_index: A,
-                               ddx: vec2<f32>,
-                               ddy: vec2<f32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleGrad(t: texture_2d_array<f32>,
+                                       s: sampler,
+                                       coords: vec2<f32>,
+                                       array_index: A,
+                                       ddx: vec2<f32>,
+                                       ddy: vec2<f32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleGrad 2d array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleGrad(t: texture_2d_array<f32>,
-                               s: sampler,
-                               coords: vec2<f32>,
-                               array_index: A,
-                               ddx: vec2<f32>,
-                               ddy: vec2<f32>,
-                               offset: vec2<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleGrad(t: texture_2d_array<f32>,
+                                       s: sampler,
+                                       coords: vec2<f32>,
+                                       array_index: A,
+                                       ddx: vec2<f32>,
+                                       ddy: vec2<f32>,
+                                       offset: vec2<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleGrad 3d">
     <td><var ignore>T</var> is `texture_3d<f32>`, or `texture_cube<f32>`
-    <td><xmp highlight=rust>
-@must_use fn textureSampleGrad(t: T,
-                               s: sampler,
-                               coords: vec3<f32>,
-                               ddx: vec3<f32>,
-                               ddy: vec3<f32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleGrad(t: T,
+                                       s: sampler,
+                                       coords: vec3<f32>,
+                                       ddx: vec3<f32>,
+                                       ddy: vec3<f32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleGrad 3d offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleGrad(t: texture_3d<f32>,
-                               s: sampler,
-                               coords: vec3<f32>,
-                               ddx: vec3<f32>,
-                               ddy: vec3<f32>,
-                               offset: vec3<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleGrad(t: texture_3d<f32>,
+                                       s: sampler,
+                                       coords: vec3<f32>,
+                                       ddx: vec3<f32>,
+                                       ddy: vec3<f32>,
+                                       offset: vec3<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleGrad cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleGrad(t: texture_cube_array<f32>,
-                               s: sampler,
-                               coords: vec3<f32>,
-                               array_index: A,
-                               ddx: vec3<f32>,
-                               ddy: vec3<f32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleGrad(t: texture_cube_array<f32>,
+                                       s: sampler,
+                                       coords: vec3<f32>,
+                                       array_index: A,
+                                       ddx: vec3<f32>,
+                                       ddy: vec3<f32>) -> vec4<f32>
+      </xmp>
 
 </table>
 
@@ -15908,122 +16189,147 @@ Samples a texture using an explicit mip level.
   </thead>
   <tr algorithm="textureSampleLevel 2d">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: texture_2d<f32>,
-                                s: sampler,
-                                coords: vec2<f32>,
-                                level: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: texture_2d<f32>,
+                                        s: sampler,
+                                        coords: vec2<f32>,
+                                        level: f32) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleLevel 2d offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: texture_2d<f32>,
-                                s: sampler,
-                                coords: vec2<f32>,
-                                level: f32,
-                                offset: vec2<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: texture_2d<f32>,
+                                        s: sampler,
+                                        coords: vec2<f32>,
+                                        level: f32,
+                                        offset: vec2<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleLevel 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: texture_2d_array<f32>,
-                                s: sampler,
-                                coords: vec2<f32>,
-                                array_index: A,
-                                level: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: texture_2d_array<f32>,
+                                        s: sampler,
+                                        coords: vec2<f32>,
+                                        array_index: A,
+                                        level: f32) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleLevel 2d array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: texture_2d_array<f32>,
-                                s: sampler,
-                                coords: vec2<f32>,
-                                array_index: A,
-                                level: f32,
-                                offset: vec2<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: texture_2d_array<f32>,
+                                        s: sampler,
+                                        coords: vec2<f32>,
+                                        array_index: A,
+                                        level: f32,
+                                        offset: vec2<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleLevel 3d">
     <td><var ignore>T</var> is `texture_3d<f32>`, or `texture_cube<f32>`
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: T,
-                                s: sampler,
-                                coords: vec3<f32>,
-                                level: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: T,
+                                        s: sampler,
+                                        coords: vec3<f32>,
+                                        level: f32) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleLevel 3d offset">
     <td>
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: texture_3d<f32>,
-                                s: sampler,
-                                coords: vec3<f32>,
-                                level: f32,
-                                offset: vec3<i32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: texture_3d<f32>,
+                                        s: sampler,
+                                        coords: vec3<f32>,
+                                        level: f32,
+                                        offset: vec3<i32>) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleLevel cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: texture_cube_array<f32>,
-                                s: sampler,
-                                coords: vec3<f32>,
-                                array_index: A,
-                                level: f32) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: texture_cube_array<f32>,
+                                        s: sampler,
+                                        coords: vec3<f32>,
+                                        array_index: A,
+                                        level: f32) -> vec4<f32>
+      </xmp>
 
   <tr algorithm="textureSampleLevel 2d depth">
     <td><var ignore>L</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: texture_depth_2d,
-                                s: sampler,
-                                coords: vec2<f32>,
-                                level: L) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: texture_depth_2d,
+                                        s: sampler,
+                                        coords: vec2<f32>,
+                                        level: L) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleLevel 2d depth offset">
     <td><var ignore>L</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: texture_depth_2d,
-                                s: sampler,
-                                coords: vec2<f32>,
-                                level: L,
-                                offset: vec2<i32>) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: texture_depth_2d,
+                                        s: sampler,
+                                        coords: vec2<f32>,
+                                        level: L,
+                                        offset: vec2<i32>) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleLevel 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: texture_depth_2d_array,
-                                s: sampler,
-                                coords: vec2<f32>,
-                                array_index: A,
-                                level: L) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: texture_depth_2d_array,
+                                        s: sampler,
+                                        coords: vec2<f32>,
+                                        array_index: A,
+                                        level: L) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleLevel 2d depth array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: texture_depth_2d_array,
-                                s: sampler,
-                                coords: vec2<f32>,
-                                array_index: A,
-                                level: L,
-                                offset: vec2<i32>) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: texture_depth_2d_array,
+                                        s: sampler,
+                                        coords: vec2<f32>,
+                                        array_index: A,
+                                        level: L,
+                                        offset: vec2<i32>) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleLevel cube depth">
     <td><var ignore>L</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: texture_depth_cube,
-                                s: sampler,
-                                coords: vec3<f32>,
-                                level: L) -> f32</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: texture_depth_cube,
+                                        s: sampler,
+                                        coords: vec3<f32>,
+                                        level: L) -> f32
+      </xmp>
 
   <tr algorithm="textureSampleLevel cube depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]
-    <td><xmp highlight=rust>
-@must_use fn textureSampleLevel(t: texture_depth_cube_array,
-                                s: sampler,
-                                coords: vec3<f32>,
-                                array_index: A,
-                                level: L) -> f32
-</xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleLevel(t: texture_depth_cube_array,
+                                        s: sampler,
+                                        coords: vec3<f32>,
+                                        array_index: A,
+                                        level: L) -> f32
+      </xmp>
 </table>
 
 **Parameters:**
@@ -16068,10 +16374,12 @@ with texture coordinates clamped to the edge as described below.
 
   <tr algorithm="textureSampleBaseClampToEdge">
     <td><var ignore>T</var> is `texture_2d<f32>` or `texture_external`
-    <td><xmp highlight=rust>
-@must_use fn textureSampleBaseClampToEdge(t: T,
-                                          s: sampler,
-                                          coords: vec2<f32>) -> vec4<f32></xmp>
+    <td>
+      <xmp highlight=rust>
+        @must_use fn textureSampleBaseClampToEdge(t: T,
+                                                  s: sampler,
+                                                  coords: vec2<f32>) -> vec4<f32>
+      </xmp>
 </table>
 
 **Parameters:**
@@ -16118,10 +16426,12 @@ Writes a single texel to a texture.
         <var ignore>CF</var> depends on the storage texel format |F|.
         [See the texel format table](#storage-texel-formats) for the mapping of texel
         format to channel format.
-    <td><xmp highlight=rust>
-fn textureStore(t: texture_storage_1d<F,write>,
-                coords: C,
-                value: vec4<CF>)</xmp>
+    <td>
+      <xmp highlight=rust>
+        fn textureStore(t: texture_storage_1d<F,write>,
+                        coords: C,
+                        value: vec4<CF>)
+      </xmp>
 
   <tr algorithm="textureStore 2d">
     <td>|F| is a [=texel format=]<br>
@@ -16129,10 +16439,12 @@ fn textureStore(t: texture_storage_1d<F,write>,
         <var ignore>CF</var> depends on the storage texel format |F|.
         [See the texel format table](#storage-texel-formats) for the mapping of texel
         format to channel format.
-    <td><xmp highlight=rust>
-fn textureStore(t: texture_storage_2d<F,write>,
-                coords: vec2<C>,
-                value: vec4<CF>)</xmp>
+    <td>
+      <xmp highlight=rust>
+        fn textureStore(t: texture_storage_2d<F,write>,
+                        coords: vec2<C>,
+                        value: vec4<CF>)
+      </xmp>
 
   <tr algorithm="textureStore 2d array">
     <td>|F| is a [=texel format=]<br>
@@ -16141,11 +16453,13 @@ fn textureStore(t: texture_storage_2d<F,write>,
         <var ignore>CF</var> depends on the storage texel format |F|.
         [See the texel format table](#storage-texel-formats) for the mapping of texel
         format to channel format.
-    <td><xmp highlight=rust>
-fn textureStore(t: texture_storage_2d_array<F,write>,
-                coords: vec2<C>,
-                array_index: A,
-                value: vec4<CF>)</xmp>
+    <td>
+      <xmp highlight=rust>
+        fn textureStore(t: texture_storage_2d_array<F,write>,
+                        coords: vec2<C>,
+                        array_index: A,
+                        value: vec4<CF>)
+      </xmp>
 
   <tr algorithm="textureStore 3d">
     <td>|F| is a [=texel format=]<br>
@@ -16153,10 +16467,12 @@ fn textureStore(t: texture_storage_2d_array<F,write>,
         <var ignore>CF</var> depends on the storage texel format |F|.
         [See the texel format table](#storage-texel-formats) for the mapping of texel
         format to channel format.
-    <td><xmp highlight=rust>
-fn textureStore(t: texture_storage_3d<F,write>,
-                coords: vec3<C>,
-                value: vec4<CF>)</xmp>
+    <td>
+      <xmp highlight=rust>
+        fn textureStore(t: texture_storage_3d<F,write>,
+                        coords: vec3<C>,
+                        value: vec4<CF>)
+      </xmp>
 
 </table>
 
@@ -16293,9 +16609,10 @@ Note: For packing snorm values, the normalized floating point values are in the 
 <table class='data builtin'>
   <tr algorithm="packing 4x8snorm">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn pack4x8snorm(e: vec4<f32>) -> u32
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn pack4x8snorm(e: vec4<f32>) -> u32
+      </xmp>
   <tr>
     <td>Description
     <td>Converts four normalized floating point values to 8-bit signed integers, and then combines them
@@ -16310,9 +16627,10 @@ Note: For packing snorm values, the normalized floating point values are in the 
 <table class='data builtin'>
   <tr algorithm="packing 4x8unorm">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn pack4x8unorm(e: vec4<f32>) -> u32
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn pack4x8unorm(e: vec4<f32>) -> u32
+      </xmp>
   <tr>
     <td>Description
     <td>Converts four normalized floating point values to 8-bit unsigned integers, and then combines them
@@ -16327,9 +16645,10 @@ Note: For packing snorm values, the normalized floating point values are in the 
 <table class='data builtin'>
   <tr algorithm="packing 2x16snorm">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn pack2x16snorm(e: vec2<f32>) -> u32
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn pack2x16snorm(e: vec2<f32>) -> u32
+      </xmp>
   <tr>
     <td>Description
     <td>Converts two normalized floating point values to 16-bit signed integers, and then combines them
@@ -16344,9 +16663,10 @@ Note: For packing snorm values, the normalized floating point values are in the 
 <table class='data builtin'>
   <tr algorithm="packing 2x16unorm">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn pack2x16unorm(e: vec2<f32>) -> u32
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn pack2x16unorm(e: vec2<f32>) -> u32
+      </xmp>
   <tr>
     <td>Description
     <td>Converts two normalized floating point values to 16-bit unsigned integers, and then combines them
@@ -16361,9 +16681,10 @@ Note: For packing snorm values, the normalized floating point values are in the 
 <table class='data builtin'>
   <tr algorithm="packing 2x16float">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn pack2x16float(e: vec2<f32>) -> u32
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn pack2x16float(e: vec2<f32>) -> u32
+      </xmp>
   <tr>
     <td>Description
     <td>Converts two floating point values to half-precision floating point numbers, and then combines
@@ -16397,9 +16718,10 @@ Note: For unpacking snorm values, the normalized floating point result is in the
 <table class='data builtin'>
   <tr algorithm="unpacking 4x8snorm">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn unpack4x8snorm(e: u32) -> vec4<f32>
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn unpack4x8snorm(e: u32) -> vec4<f32>
+      </xmp>
   <tr>
     <td>Description
     <td>Decomposes a 32-bit value into four 8-bit chunks, then reinterprets
@@ -16412,9 +16734,10 @@ Note: For unpacking snorm values, the normalized floating point result is in the
 <table class='data builtin'>
   <tr algorithm="unpacking 4x8unorm">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn unpack4x8unorm(e: u32) -> vec4<f32>
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn unpack4x8unorm(e: u32) -> vec4<f32>
+      </xmp>
   <tr>
     <td>Description
     <td>Decomposes a 32-bit value into four 8-bit chunks, then reinterprets
@@ -16427,9 +16750,10 @@ Note: For unpacking snorm values, the normalized floating point result is in the
 <table class='data builtin'>
   <tr algorithm="unpacking 2x16snorm">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn unpack2x16snorm(e: u32) -> vec2<f32>
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn unpack2x16snorm(e: u32) -> vec2<f32>
+      </xmp>
   <tr>
     <td>Description
     <td>Decomposes a 32-bit value into two 16-bit chunks, then reinterprets
@@ -16442,9 +16766,10 @@ Note: For unpacking snorm values, the normalized floating point result is in the
 <table class='data builtin'>
   <tr algorithm="unpacking 2x16unorm">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn unpack2x16unorm(e: u32) -> vec2<f32>
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn unpack2x16unorm(e: u32) -> vec2<f32>
+      </xmp>
   <tr>
     <td>Description
     <td>Decomposes a 32-bit value into two 16-bit chunks, then reinterprets
@@ -16457,9 +16782,10 @@ Note: For unpacking snorm values, the normalized floating point result is in the
 <table class='data builtin'>
   <tr algorithm="unpacking 2x16float">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const @must_use fn unpack2x16float(e: u32) -> vec2<f32>
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @const @must_use fn unpack2x16float(e: u32) -> vec2<f32>
+      </xmp>
   <tr>
     <td>Description
     <td>Decomposes a 32-bit value into two 16-bit chunks, and reinterpets each chunk
@@ -16494,9 +16820,10 @@ All synchronization functions [=shader-creation error|must=] only be invoked in
 <table class='data builtin'>
   <tr algorithm="storageBarrier">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-fn storageBarrier()
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        fn storageBarrier()
+      </xmp>
   <tr>
     <td>Description
     <td>Executes a [=control barrier=] synchronization function that affects
@@ -16509,9 +16836,10 @@ fn storageBarrier()
 <table class='data builtin'>
   <tr algorithm="workgroupBarrier">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-fn workgroupBarrier()
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        fn workgroupBarrier()
+      </xmp>
   <tr>
     <td>Description
     <td>Executes a [=control barrier=] synchronization function that affects
@@ -16524,9 +16852,10 @@ fn workgroupBarrier()
 <table class='data builtin'>
   <tr algorithm="workgroupUniformLoad">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@must_use fn workgroupUniformLoad(p : ptr<workgroup, T>) -> T
-</xmp>
+    <td class="nowrap">
+      <xmp highlight=rust>
+        @must_use fn workgroupUniformLoad(p : ptr<workgroup, T>) -> T
+      </xmp>
   <tr>
     <td>Parameterization
     <td>`T` is a [=type/concrete=] [=plain type=] with a [=fixed footprint=]


### PR DESCRIPTION
Required by new Bikeshed parser.
To go with this, I fixed the indentation of all such `<xmp>` tags. They still seem to render correctly. I did this with a long series of very specific regexes so hopefully I didn't mess up any of the blankspace. I think I got it.

Finally, update non-TR-build version of Bikeshed to the latest 3.11.19, which: Fixes #3995.