### PR TITLE
[editorial] Suppress unused dfns using noexport

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8881,7 +8881,7 @@ dictionary GPUVertexState : GPUProgrammableStage {
 };
 </script>
 
-A <dfn dfn>vertex buffer</dfn> is, conceptually, a view into buffer memory as an *array of structures*.
+A <dfn dfn noexport>vertex buffer</dfn> is, conceptually, a view into buffer memory as an *array of structures*.
 {{GPUVertexBufferLayout/arrayStride}} is the stride, in bytes, between *elements* of that array.
 Each element of a vertex buffer is like a *structure* with a memory layout defined by its
 {{GPUVertexBufferLayout/attributes}}, which describe the *members* of the structure.
@@ -14529,16 +14529,16 @@ integers and single-precision floats.
 <div algorithm="GPUColor accessors" dfn-for=GPUColor>
     For a given {{GPUColor}} value |color|, depending on its type, the syntax:
 
-    - |color|.<dfn dfn>r</dfn> refers to
+    - |color|.<dfn dfn noexport>r</dfn> refers to
         either {{GPUColorDict}}.{{GPUColorDict/r}}
         or the first item of the sequence ([=assert|asserting=] there is such an item).
-    - |color|.<dfn dfn>g</dfn> refers to
+    - |color|.<dfn dfn noexport>g</dfn> refers to
         either {{GPUColorDict}}.{{GPUColorDict/g}}
         or the second item of the sequence ([=assert|asserting=] there is such an item).
-    - |color|.<dfn dfn>b</dfn> refers to
+    - |color|.<dfn dfn noexport>b</dfn> refers to
         either {{GPUColorDict}}.{{GPUColorDict/b}}
         or the third item of the sequence ([=assert|asserting=] there is such an item).
-    - |color|.<dfn dfn>a</dfn> refers to
+    - |color|.<dfn dfn noexport>a</dfn> refers to
         either {{GPUColorDict}}.{{GPUColorDict/a}}
         or the fourth item of the sequence ([=assert|asserting=] there is such an item).
 </div>
@@ -14565,10 +14565,10 @@ typedef (sequence<GPUIntegerCoordinate> or GPUOrigin2DDict) GPUOrigin2D;
 <div algorithm="GPUOrigin2D accessors" dfn-for=GPUOrigin2D>
     For a given {{GPUOrigin2D}} value |origin|, depending on its type, the syntax:
 
-    - |origin|.<dfn dfn>x</dfn> refers to
+    - |origin|.<dfn dfn noexport>x</dfn> refers to
         either {{GPUOrigin2DDict}}.{{GPUOrigin2DDict/x}}
         or the first item of the sequence (0 if not present).
-    - |origin|.<dfn dfn>y</dfn> refers to
+    - |origin|.<dfn dfn noexport>y</dfn> refers to
         either {{GPUOrigin2DDict}}.{{GPUOrigin2DDict/y}}
         or the second item of the sequence (0 if not present).
 </div>
@@ -15515,18 +15515,6 @@ The [=texel block memory cost=] of each of these formats is the same as its
     <tr>
         <td>{{GPUTextureFormat/astc-12x12-unorm-srgb}}
 </table>
-
-## Temporary usages of non-exported dfns ## {#temp-dfn-usages}
-
-Eventually all of these should disappear but they are useful to avoid warning while building the specification.
-
-[=GPUOrigin2D/x=] [=GPUOrigin2D/y=]
-[=vertex buffer=]
-[=buffer internals/state=]
-[=buffer internals/state/available=]
-[=buffer internals/state/unavailable=]
-[=buffer internals/state/destroyed=]
-[=GPUColor/r=] [=GPUColor/g=] [=GPUColor/b=] [=GPUColor/a=]
 
 <script>
 // Small script to collect all xrefs that refer to different timelines and highlight


### PR DESCRIPTION
dneto0 taught me that we can suppress unused dfn warnings using noexport instead of having this user-visible "temporary usages of non-exported dfns" section at the bottom of the spec. I was just looking at getting rid of that the other day and I wasn't sure how. This is much better!