### PR TITLE
Expose namespaces only in secure contexts, like interfaces.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8131,7 +8131,7 @@ dictionary GPUBlendState {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUColorWriteFlags;
-[Exposed=(Window, DedicatedWorker)]
+[Exposed=(Window, DedicatedWorker), SecureContext]
 namespace GPUColorWrite {
     const GPUFlagsConstant RED   = 0x1;
     const GPUFlagsConstant GREEN = 0x2;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3202,7 +3202,7 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
-[Exposed=(Window, DedicatedWorker)]
+[Exposed=(Window, DedicatedWorker), SecureContext]
 namespace GPUBufferUsage {
     const GPUFlagsConstant MAP_READ      = 0x0001;
     const GPUFlagsConstant MAP_WRITE     = 0x0002;
@@ -3438,7 +3438,7 @@ only be unmapped and destroyed on the worker on which it was mapped. Likewise
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUMapModeFlags;
-[Exposed=(Window, DedicatedWorker)]
+[Exposed=(Window, DedicatedWorker), SecureContext]
 namespace GPUMapMode {
     const GPUFlagsConstant READ  = 0x0001;
     const GPUFlagsConstant WRITE = 0x0002;
@@ -4047,7 +4047,7 @@ enum GPUTextureDimension {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
-[Exposed=(Window, DedicatedWorker)]
+[Exposed=(Window, DedicatedWorker), SecureContext]
 namespace GPUTextureUsage {
     const GPUFlagsConstant COPY_SRC          = 0x01;
     const GPUFlagsConstant COPY_DST          = 0x02;
@@ -5510,7 +5510,7 @@ dictionary GPUBindGroupLayoutEntry {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
-[Exposed=(Window, DedicatedWorker)]
+[Exposed=(Window, DedicatedWorker), SecureContext]
 namespace GPUShaderStage {
     const GPUFlagsConstant VERTEX   = 0x1;
     const GPUFlagsConstant FRAGMENT = 0x2;


### PR DESCRIPTION
Since all the interfaces have the WebIDL `[SecureContext]` extended attribute, it seems to me that the namespaces ought to as well.

But perhaps there's something I'm missing, since the `[SecureContext]` changes did already go through two iterations. Anyway, please take a look.
