### PR TITLE
Clarify that the second argument of getContext() is ignored

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12768,6 +12768,12 @@ instance by passing the string literal `'webgpu'` as its `contextType` argument.
     </pre>
 </div>
 
+Unlike WebGL or 2D context creation, The second argument of
+{{HTMLCanvasElement/getContext()}}, |context attributes| for context configuration,
+is ignored. {{GPUCanvasContext/configure()}} should be used instead.
+
+Note: The user agent may show a warning if |context attributes| are provided.
+
 ## GPUCanvasContext ## {#canvas-context}
 
 <script type=idl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12749,16 +12749,6 @@ A {{GPUCanvasContext}} object is [$create a 'webgpu' context on a canvas|created
 via the {{HTMLCanvasElement/getContext()}} method of an {{HTMLCanvasElement}}
 instance by passing the string literal `'webgpu'` as its `contextType` argument.
 
-<div algorithm>
-    To <dfn abstract-op>create a 'webgpu' context on a canvas</dfn>
-    ({{HTMLCanvasElement}} or {{OffscreenCanvas}}) |canvas|:
-
-    1. Let |context| be a new {{GPUCanvasContext}}.
-    1. Set |context|.{{GPUCanvasContext/canvas}} to |canvas|.
-    1. [$Replace the drawing buffer$] of |context|.
-    1. Return |context|.
-</div>
-
 <div class=example>
     Get a {{GPUCanvasContext}} from an offscreen {{HTMLCanvasElement}}:
 
@@ -12768,11 +12758,26 @@ instance by passing the string literal `'webgpu'` as its `contextType` argument.
     </pre>
 </div>
 
-Unlike WebGL or 2D context creation, The second argument of
-{{HTMLCanvasElement/getContext()}}, |context attributes| for context configuration,
-is ignored. {{GPUCanvasContext/configure()}} should be used instead.
+Unlike WebGL or 2D context creation, the second argument of
+{{HTMLCanvasElement/getContext()|HTMLCanvasElement.getContext()}} or
+{{OffscreenCanvas/getContext()|OffscreenCanvas.getContext()}},
+the context creation attribute dictionary `options`, is ignored.
+Instead, use {{GPUCanvasContext/configure()|GPUCanvasContext.configure()}},
+which allows changing the canvas configuration without replacing the canvas.
 
-Note: The user agent may show a warning if |context attributes| are provided.
+<div algorithm>
+    To <dfn abstract-op>create a 'webgpu' context on a canvas</dfn>
+    ({{HTMLCanvasElement}} or {{OffscreenCanvas}}) |canvas|:
+
+    1. Let |context| be a new {{GPUCanvasContext}}.
+    1. Set |context|.{{GPUCanvasContext/canvas}} to |canvas|.
+    1. [$Replace the drawing buffer$] of |context|.
+    1. Return |context|.
+    
+    Note: User agents should consider issuing developer-visible warnings when
+    an ignored `options` argument is provided when calling `getContext()`
+    to get a WebGPU canvas context.
+</div>
 
 ## GPUCanvasContext ## {#canvas-context}
 


### PR DESCRIPTION
From the discussion in WebGPU Matrix.

This commit clarifies that the second argument of `HTMLCanvasElement.getContext()` is ignored for WebGPU.