### PR TITLE
[editorial] Fill out texture types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3843,7 +3843,7 @@ A texture has the following features:
 : <dfn dfn-for=texture noexport>size</dfn>
 :: The extent of grid coordinates along each dimension. This is a function of [=mip level=].
 : <dfn dfn-for=texture noexport>mip level count</dfn>
-:: The mip level count is at least 1 for sampled textures, and equal to 1 for storage textures.<br>
+:: The mip level count is at least 1 for [=type/sampled textures=] and [=type/depth textures=], and equal to 1 for [=type/storage textures=].<br>
     <dfn>Mip level</dfn> 0 contains a full size version of the texture.
     Each successive mip level contains a filtered version of the previous mip level
     at half the size (within rounding) of the previous mip level.<br>
@@ -3892,7 +3892,7 @@ having a [=formal parameter=] with that texture type.
 
 Note: The handle stored by a texture variable cannot be changed by the shader.
 That is, the variable is read-only, even if the underlying texture to which it provides
-access may be mutable (e.g. a write-only storage texture).
+access may be mutable (e.g. a write-only [=type/storage texture=]).
 
 The <dfn>texture types</dfn> are the set of types defined in:
 * [[#sampled-texture-type]]
@@ -3902,7 +3902,7 @@ The <dfn>texture types</dfn> are the set of types defined in:
 * [[#texture-depth]]
 
 A [=sampler=] is an opaque handle that controls how [=texels=] are accessed
-from a sampled texture.
+from a [=type/sampled texture=] or a [=type/depth texture=].
 
 A WGSL sampler maps to a WebGPU {{GPUSampler}}.
 
@@ -3988,7 +3988,7 @@ The texel formats listed in the
 <dfn lt="storage-texel-formats">Texel Formats for Storage Textures</dfn> table
 correspond to the [[WebGPU#plain-color-formats|WebGPU plain color formats]]
 which support the WebGPU {{GPUTextureUsage/STORAGE_BINDING}} usage.
-These texel formats are used to parameterize the storage texture types defined
+These texel formats are used to parameterize the [=type/storage texture=] types defined
 in [[#texture-storage]].
 
 When the texel format does not have all four channels, then:
@@ -4033,82 +4033,158 @@ WGSL [=predeclared|predeclares=] an [=enumerant=] for each of the texel formats 
 
 ### Sampled Texture Types ### {#sampled-texture-type}
 
-<pre class='def'>
-`texture_1d<type>`
-`texture_2d<type>`
-`texture_2d_array<type>`
-`texture_3d<type>`
-`texture_cube<type>`
-`texture_cube_array<type>`
-</pre>
-* `type` [=shader-creation error|must=] be `f32`, `i32`, or `u32`
+A <dfn noexport dfn-for='type'>sampled texture</dfn> is capable
+of being [=memory access|accessed=] in conjunction with a [=type/sampler=].
+It can also be accessed without the use of a sampler.
+Sampled textures only allow [=read accesses=].
+
+The [=texel format=] of the texture is defined in the {{GPUTextureBindingLayout}}.
+
+<table class='data'>
+  <thead>
+    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/arrayed=]
+  </thead>
+  <tr><td><dfn noexport dfn-for='type'>texture_1d</dfn><*T*>
+      <td>1D
+      <td>No
+  <tr><td><dfn noexport dfn-for='type'>texture_2d</dfn><*T*>
+      <td>2D
+      <td>No
+  <tr><td><dfn noexport dfn-for='type'>texture_2d_array</dfn><*T*>
+      <td>2D
+      <td>Yes
+  <tr><td><dfn noexport dfn-for='type'>texture_3d</dfn><*T*>
+      <td>3D
+      <td>No
+  <tr><td><dfn noexport dfn-for='type'>texture_cube</dfn><*T*>
+      <td>Cube
+      <td>No
+  <tr><td><dfn noexport dfn-for='type'>texture_cube_array</dfn><*T*>
+      <td>Cube
+      <td>Yes
+</table>
+
+* *T* [=shader-creation error|must=] be `f32`, `i32`, or `u32`
 * The parameterized type for the images is the type after conversion from sampling.
     E.g. you can have an image with texels with 8bit unorm components, but when you sample
     them you get a 32-bit float result (or vec-of-f32).
 
 ### Multisampled Texture Types ### {#multisampled-texture-type}
 
-<pre class='def'>
-`texture_multisampled_2d<type>`
-</pre>
-* `type` [=shader-creation error|must=] be `f32`, `i32`, or `u32`
+A <dfn noexport dfn-for='type'>multisampled texture</dfn> has a
+[=texture/sample count=] of 1 or more.
+Despite the name, it cannot be used with a [=sampler=].
+It effectively stores multiple [=texels=] worth of data per
+[=logical texel address=] if the sample index is ignored.
+
+The [=texel format=] of the texture is defined in the {{GPUTextureBindingLayout}}.
+
+<table class='data'>
+  <thead>
+    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/arrayed=]
+  </thead>
+  <tr><td><dfn noexport dfn-for='type'>texture_multisampled_2d</dfn><*T*>
+      <td>2D
+      <td>No
+  <tr><td><dfn noexport dfn-for='type'>texture_depth_multisampled_2d</dfn>
+      <td>2D
+      <td>No
+</table>
+
+* *T* [=shader-creation error|must=] be `f32`, `i32`, or `u32`
 
 ### External Sampled Texture Types ### {#external-texture-type}
 
-<pre class='def'>
-`texture_external`
-</pre>
-
-`texture_external` is an opaque two-dimensional float-sampled texture type similar to `texture_2d<f32>`
-but potentially with a different representation.
-It can be read using [[#textureload|textureLoad]] or [[#textureSampleBaseClampToEdge|textureSampleBaseClampToEdge]] built-in functions,
-which handle these different representations opaquely.
+An <dfn noexport dfn-for='type'>External texture</dfn> is an opaque
+two-dimensional float-[=type/sampled texture=] type similar to `texture_2d<f32>` but
+potentially with a different representation.
+It can be read using [[#textureload|textureLoad]] or
+[[#textureSampleBaseClampToEdge|textureSampleBaseClampToEdge]] built-in
+functions, which handle these different representations opaquely.
 
 See [[WebGPU#gpuexternaltexture]].
 
+<table class='data'>
+  <thead>
+    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/arrayed=]
+  </thead>
+  <tr><td><dfn noexport dfn-for='type'>texture_external</dfn>
+      <td>2D
+      <td>No
+</table>
+
 ### Storage Texture Types ### {#texture-storage}
 
-A <dfn noexport>storage texture</dfn> supports accessing a single texel without the use of a sampler.
+A <dfn noexport dfn-for='type'>storage texture</dfn> supports [=memory access|accessing=] a
+single texel without the use of a sampler.
 
-* A <dfn noexport>write-only storage texture</dfn>
-     supports writing a single texel, with automatic conversion of the shader value to a
+* A <dfn noexport dfn-for='type'>write-only storage texture</dfn>
+     supports [=write access|writing=] a single texel, with automatic conversion of the shader value to a
      stored texel value.
 
 A storage texture type [=shader-creation error|must=] be parameterized by one of the
 [=storage-texel-format|texel formats for storage textures=].
 The texel format determines the conversion function as specified in [[#texel-formats]].
 
-For a write-only storage texture the *inverse* of the conversion function is used to convert the shader value to
-the stored texel.
+For a write-only storage texture the *inverse* of the conversion function is
+used to convert the shader value to the stored texel.
 
-See [[#texture-builtin-functions]].
+<table class='data'>
+  <thead>
+    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/arrayed=]
+  </thead>
+  <tr><td><dfn noexport dfn-for='type'>texture_storage_1d</dfn><*Format*, *Access*>
+      <td>1D
+      <td>No
+  <tr><td><dfn noexport dfn-for='type'>texture_storage_2d</dfn><*Format*, *Access*>
+      <td>2D
+      <td>No
+  <tr><td><dfn noexport dfn-for='type'>texture_storage_2d_array</dfn><*Format*, *Access*>
+      <td>2D
+      <td>Yes
+  <tr><td><dfn noexport dfn-for='type'>texture_storage_3d</dfn><*Format*, *Access*>
+      <td>3D
+      <td>No
+</table>
 
-<pre class='def'>
-`texture_storage_1d<texel_format,access>`
-`texture_storage_2d<texel_format,access>`
-`texture_storage_2d_array<texel_format,access>`
-`texture_storage_3d<texel_format,access>`
-</pre>
-
-* `texel_format` [=shader-creation error|must=] be an [=enumerant=] for one of the [=storage-texel-formats|texel formats for storage textures=]
-* `access` [=shader-creation error|must=] be the [=enumerant=] for [=access/write=] [=access mode=].
+* *Format* [=shader-creation error|must=] be an [=enumerant=] for one of the [=storage-texel-formats|texel formats for storage textures=]
+* *Access* [=shader-creation error|must=] be the [=enumerant=] for [=access/write=] [=access mode=].
 
 ### Depth Texture Types ### {#texture-depth}
-<pre class='def'>
-`texture_depth_2d`
-`texture_depth_2d_array`
-`texture_depth_cube`
-`texture_depth_cube_array`
-`texture_depth_multisampled_2d`
-</pre>
+
+A <dfn noexport dfn-for='type'>depth texture</dfn> is capable
+of being [=memory access|accessed=] in conjunction with a [=type/sampler_comparison=].
+It can also be accessed without the use of a sampler.
+Depth textures only allow [=read accesses=].
+
+The [=texel format=] of the texture is defined in the {{GPUTextureBindingLayout}}.
+
+<table class='data'>
+  <thead>
+    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/arrayed=]
+  </thead>
+  <tr><td><dfn noexport dfn-for='type'>texture_depth_2d</dfn>
+      <td>2D
+      <td>No
+  <tr><td><dfn noexport dfn-for='type'>texture_depth_2d_array</dfn>
+      <td>2D
+      <td>Yes
+  <tr><td><dfn noexport dfn-for='type'>texture_depth_cube</dfn>
+      <td>Cube
+      <td>No
+  <tr><td><dfn noexport dfn-for='type'>texture_depth_cube_array</dfn>
+      <td>Cube
+      <td>Yes
+</table>
 
 ### Sampler Type ### {#sampler-type}
 
-A <dfn>sampler</dfn> mediates access to a sampled texture or a depth texture, by performing a combination of:
+A <dfn>sampler</dfn> mediates access to a [=type/sampled texture=] or a
+[=type/depth texture=], by performing a combination of:
 * coordinate transformation.
 * optionally modifying mip-level selection.
-* for a sampled texture, optionally filtering retrieved texel values.
-* for a depth texture, determining the comparison function applied to the retrieved texel.
+* for a [=type/sampled texture=], optionally filtering retrieved texel values.
+* for a [=type/depth texture=], determining the comparison function applied to the retrieved texel.
 
 A <dfn noexport>sampler types</dfn> are:
 * [=type/sampler=]
@@ -4120,11 +4196,11 @@ A <dfn noexport>sampler types</dfn> are:
   </thead>
   <tr algorithm="sampler type">
     <td><dfn dfn-for="type">sampler</dfn>
-    <td>Sampler. Mediates access to a sampled texture.</td>
+    <td>Sampler. Mediates access to a [=type/sampled texture=].</td>
   <tr algorithm="comparison sampler type">
     <td><dfn dfn-for="type">sampler_comparison</dfn>
     <td>Comparison sampler.
-        Mediates access to a depth texture.</td>
+        Mediates access to a [=type/depth texture=].</td>
 </table>
 
 Samplers are parameterized when created in the WebGPU API.
@@ -4215,12 +4291,12 @@ The [=predeclared=] [=types=] that can be spelled in WGSL source are:
 * [=i32=]
 * [=type/sampler=]
 * [=type/sampler_comparison=]
-* [[#sampled-texture-type|texture_depth_2d]]
-* [[#sampled-texture-type|texture_depth_2d_array]]
-* [[#sampled-texture-type|texture_depth_cube]]
-* [[#sampled-texture-type|texture_depth_cube_array]]
-* [[#multisampled-texture-type|texture_depth_multisampled_2d]]
-* [[#external-texture-type|texture_external]]
+* [=type/texture_depth_2d=]
+* [=type/texture_depth_2d_array=]
+* [=type/texture_depth_cube=]
+* [=type/texture_depth_cube_array=]
+* [=type/texture_depth_multisampled_2d=]
+* [=type/texture_external=]
 * [=u32=]
 
 WGSL also predeclares the return types for the [[#frexp-builtin|frexp]],
@@ -4457,7 +4533,7 @@ effective-value-type.
     creation|pipeline-creation time=].
 4. [=Override-declarations=] are part of the shader interface, but are not
     bound resources.
-5. [=Storage buffers=] and [=storage textures=] cannot be [=statically accessed=]
+5. [=Storage buffers=] and [=type/storage textures=] cannot be [=statically accessed=]
     in a [=vertex shader stage=].
     See WebGPU {{GPUDevice/createBindGroupLayout()}}.
 6. [=Atomic types=] can only appear in mutable storage buffers or workgroup
@@ -4689,7 +4765,7 @@ It is declared at [=module scope=].
 It holds an opaque handle which is used to access the underlying grid of [=texels=] in a [=texture=].
 The handle itself is in the [=address spaces/handle=] address space and is always read-only.
 In many cases the underlying texels are read-only, and we say the texture variable immutable.
-For a write-only [=storage texture=], the underlying texels are write-only, and by convention
+For a [=type/write-only storage texture=], the underlying texels are write-only, and by convention
 we say the texture variable is mutable.
 
 A <dfn>sampler resource</dfn> is a variable whose [=effective-value-type=] is a [=sampler type=].
@@ -8744,16 +8820,18 @@ where compatibility is defined by the following table.
       <td>{{GPUBufferBindingType/"storage"}}
   <tr><td>[=storage buffer=] with [=access/read=] access
       <td>{{GPUBufferBindingType/"read-only-storage"}}
-  <tr><td rowspan=2>sampler
+  <tr><td rowspan=2>[=type/sampler=]
       <td rowspan=3>{{GPUSampler}}
       <td rowspan=3>{{GPUBindGroupLayoutEntry/sampler}}
       <td rowspan=3>GPUSamplerBindingType
       <td>{{GPUSamplerBindingType/"filtering"}}
   <tr>
       <td>{{GPUSamplerBindingType/"non-filtering"}}
-  <tr><td>sampler_comparison
+  <tr><td>[=type/sampler_comparison=]
       <td>{{GPUSamplerBindingType/"comparison"}}
-  <tr><td rowspan=5>sampled texture
+  <tr><td rowspan=5>[=type/sampled texture=],
+                    [=type/depth texture=], or
+                    [=type/multisampled texture=]
       <td rowspan=5>{{GPUTextureView}}
       <td rowspan=5>{{GPUBindGroupLayoutEntry/texture}}
       <td rowspan=5>GPUTextureSampleType
@@ -8766,12 +8844,12 @@ where compatibility is defined by the following table.
       <td>{{GPUTextureSampleType/"uint"}}
   <tr>
       <td>{{GPUTextureSampleType/"depth"}}
-  <tr><td>[=write-only storage texture=]
+  <tr><td>[=type/write-only storage texture=]
       <td>{{GPUTextureView}}
       <td>{{GPUBindGroupLayoutEntry/storageTexture}}
       <td>{{GPUStorageTextureAccess}}
       <td>{{GPUStorageTextureAccess/"write-only"}}
-  <tr><td>[[#external-texture-type|external sampled texture]]
+  <tr><td>[=type/external texture=]
       <td>{{GPUExternalTexture}}
       <td>{{GPUBindGroupLayoutEntry/externalTexture}}
       <td colspan=2>(not applicable)
@@ -9202,7 +9280,7 @@ shader stage=].
 
 [=Variables=] in the [=address spaces/storage=] address space ([=storage
 buffers=]) and variables whose [=store type=] is a
-[=storage texture=] cannot be [=statically accessed=] by a [=vertex shader stage=].
+[=type/storage texture=] cannot be [=statically accessed=] by a [=vertex shader stage=].
 See WebGPU {{GPUDevice/createBindGroupLayout()}}.
 
 Note: Each address space may have different performance characteristics.
@@ -14975,7 +15053,7 @@ computing a four-component vector as follows:
         * Otherwise:
              * Yield 0.0 when `component` is 1 or 2.
              * Yield 1.0 when `component` is 3 (the alpha channel).
-    * For depth textures, yield the texel value. (Depth textures only have one channel.)
+    * For [=type/depth textures=], yield the texel value. (Depth textures only have one channel.)
 * Yield the four-component vector, arranging scalars produced by the previous step into components
     according to the relative coordinates of the texels, as follows:
     * <table>
@@ -15420,9 +15498,11 @@ Reads a single texel from a texture without sampling or filtering.
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [sampled](#sampled-texture-type),
-  [multisampled](#multisampled-texture-type), [depth](#texture-depth),
-  or [external](#external-texture-type) texture.
+  The [=type/sampled texture|sampled=],
+  [=type/multisampled texture|multisampled=],
+  [=type/depth texture|depth=], or
+  [=type/external texture|external=]
+  texture
   <tr><td>`coords`<td>
   The 0-based texel coordinate.
   <tr><td>`array_index`<td>
@@ -15430,7 +15510,7 @@ Reads a single texel from a texture without sampling or filtering.
   <tr><td>`level`<td>
   The [=mip level=], with level 0 containing a full size version of the texture.
   <tr><td>`sample_index`<td>
-  The 0-based sample index of the multisampled texture.
+  The 0-based sample index of the [=type/multisampled texture=].
 </table>
 
 **Returns:**
@@ -15472,9 +15552,9 @@ Returns the number of layers (elements) of an [=texture/arrayed=] texture.
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [sampled](#sampled-texture-type),
-  [depth](#texture-depth) or
-  [storage](#texture-storage) array texture.
+  The [=type/sampled texture|sampled=],
+  [=type/depth texture|depth=], or
+  [=type/storage texture=] array texture.
 </table>
 
 **Returns:**
@@ -15506,7 +15586,7 @@ Returns the number of mip levels of a texture.
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [sampled](#sampled-texture-type) or [depth](#texture-depth) texture.
+  The [=type/sampled texture|sampled=] or [=type/depth texture|depth=] texture.
 </table>
 
 **Returns:**
@@ -15516,7 +15596,7 @@ The [=texture/mip level count=] for the texture.
 
 ### `textureNumSamples` ### {#texturenumsamples}
 
-Returns the number samples per texel in a multisampled texture.
+Returns the number samples per texel in a [=type/multisampled texture=].
 
 <table class='data'>
   <thead>
@@ -15534,12 +15614,12 @@ Returns the number samples per texel in a multisampled texture.
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [multisampled](#multisampled-texture-type) texture.
+  The [=type/multisampled texture=].
 </table>
 
 **Returns:**
 
-The [=texture/sample count=] for the multisampled texture.
+The [=texture/sample count=] for the [=type/multisampled texture=].
 
 
 ### `textureSample` ### {#texturesample}
@@ -15698,10 +15778,10 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [sampled](#sampled-texture-type) or [depth](#texture-depth)
+  The [=type/sampled texture|sampled=] or [=type/depth texture|depth=]
   texture to sample.
   <tr><td>`s`<td>
-  The [sampler type](#sampler-type).
+  The [=sampler=] type.
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
   <tr><td>`array_index`<td>
@@ -15816,9 +15896,9 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [texture](#sampled-texture-type) to sample.
+  The [=type/sampled texture=] to sample.
   <tr><td>`s`<td>
-  The [sampler type](#sampler-type).
+  The [=type/sampler=] type.
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
   <tr><td>`array_index`<td>
@@ -15843,7 +15923,7 @@ An [=indeterminate value=] results if called in [=uniform control flow|non-unifo
 
 ### `textureSampleCompare` ### {#texturesamplecompare}
 
-Samples a depth texture and compares the sampled depth values against a reference value.
+Samples a [=type/depth texture=] and compares the sampled depth values against a reference value.
 
 [=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
 
@@ -15925,9 +16005,9 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [depth](#texture-depth) texture to sample.
+  The [=type/depth texture=] to sample.
   <tr><td>`s`<td>
-  The [sampler comparison](#sampler-type) type.
+  The [=type/sampler_comparison=] type.
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
   <tr><td>`array_index`<td>
@@ -15959,7 +16039,7 @@ An [=indeterminate value=] results if called in [=uniform control flow|non-unifo
 
 ### `textureSampleCompareLevel` ### {#texturesamplecomparelevel}
 
-Samples a depth texture and compares the sampled depth values against a reference value.
+Samples a [=type/depth texture=] and compares the sampled depth values against a reference value.
 
 <table class='data'>
   <thead>
@@ -16036,9 +16116,9 @@ Samples a depth texture and compares the sampled depth values against a referenc
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [depth](#texture-depth) texture to sample.
+  The [=type/depth texture=] to sample.
   <tr><td>`s`<td>
-  The [sampler comparison](#sampler-type) type.
+  The [=type/sampler_comparison=] type.
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
   <tr><td>`array_index`<td>
@@ -16162,9 +16242,9 @@ Samples a texture using explicit gradients.
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [texture](#sampled-texture-type) to sample.
+  The [=type/sampled texture=] to sample.
   <tr><td>`s`<td>
-  The [sampler type](#sampler-type).
+  The [=type/sampler=].
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
   <tr><td>`array_index`<td>
@@ -16344,10 +16424,10 @@ Samples a texture using an explicit mip level.
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [sampled](#sampled-texture-type) or [depth](#texture-depth) texture to
+  The [=type/sampled texture|sampled=] or [=type/depth texture|depth=] texture to
   sample.
   <tr><td>`s`<td>
-  The [sampler type](#sampler-type).
+  The [=sampler=] type.
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
   <tr><td>`array_index`<td>
@@ -16394,9 +16474,9 @@ with texture coordinates clamped to the edge as described below.
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [sampled](#sampled-texture-type) or [external](#external-texture-type) texture to sample.
+  The [=type/sampled texture|sampled=] or [=type/external texture|external=] texture to sample.
   <tr><td>`s`<td>
-  The [sampler type](#sampler-type).
+  The [=type/sampler=] type.
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
 
@@ -16488,7 +16568,7 @@ Writes a single texel to a texture.
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [write-only storage texture](#texture-storage).
+  The [=type/write-only storage texture=]
   <tr><td>`coords`<td>
   The 0-based texel coordinate.<br>
   <tr><td>`array_index`<td>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3840,6 +3840,8 @@ A texture has the following features:
     Cube textures have six square faces, and are sampled with
     a three dimensional coordinate interpreted as a direction vector from the origin toward
     the cube centered on the origin.
+
+    See {{GPUTextureViewDimension}}.
 : <dfn dfn-for=texture noexport>size</dfn>
 :: The extent of grid coordinates along each dimension. This is a function of [=mip level=].
 : <dfn dfn-for=texture noexport>mip level count</dfn>
@@ -4038,33 +4040,40 @@ of being [=memory access|accessed=] in conjunction with a [=type/sampler=].
 It can also be accessed without the use of a sampler.
 Sampled textures only allow [=read accesses=].
 
-The [=texel format=] of the texture is defined in the {{GPUTextureBindingLayout}}.
+The [=texel format=] is the {{GPUTexture/format}} attribute of the
+{{GPUTexture}} bound to the texture variable.
+WebGPU [$validating shader binding|validates$] compatibility between the
+texture, the {{GPUTextureBindingLayout/sampleType}} of the bind group layout,
+and the [=sampled type=] of the texture variable.
+
+The texture is parameterized by a <dfn noexport>sampled type</dfn> and
+[=shader-creation error|must=] be `f32`, `i32`, or `u32`.
 
 <table class='data'>
   <thead>
     <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/Arrayed=]
   </thead>
   <tr><td><dfn noexport dfn-for='type'>texture_1d</dfn><*T*>
-      <td>1D
+      <td>{{GPUTextureViewDimension/"1d"|1D}}
       <td>No
   <tr><td><dfn noexport dfn-for='type'>texture_2d</dfn><*T*>
-      <td>2D
+      <td>{{GPUTextureViewDimension/"2d"|2D}}
       <td>No
   <tr><td><dfn noexport dfn-for='type'>texture_2d_array</dfn><*T*>
-      <td>2D
+      <td>{{GPUTextureViewDimension/"2d-array"|2D}}
       <td>Yes
   <tr><td><dfn noexport dfn-for='type'>texture_3d</dfn><*T*>
-      <td>3D
+      <td>{{GPUTextureViewDimension/"3d"|3D}}
       <td>No
   <tr><td><dfn noexport dfn-for='type'>texture_cube</dfn><*T*>
-      <td>Cube
+      <td>{{GPUTextureViewDimension/"cube"|Cube}}
       <td>No
   <tr><td><dfn noexport dfn-for='type'>texture_cube_array</dfn><*T*>
-      <td>Cube
+      <td>{{GPUTextureViewDimension/"cube-array"|Cube}}
       <td>Yes
 </table>
 
-* *T* [=shader-creation error|must=] be `f32`, `i32`, or `u32`
+* *T* is the [=sampled type=].
 * The parameterized type for the images is the type after conversion from sampling.
     E.g. you can have an image with texels with 8bit unorm components, but when you sample
     them you get a 32-bit float result (or vec-of-f32).
@@ -4077,21 +4086,28 @@ Despite the name, it cannot be used with a [=sampler=].
 It effectively stores multiple [=texels=] worth of data per
 [=logical texel address=] if the sample index is ignored.
 
-The [=texel format=] of the texture is defined in the {{GPUTextureBindingLayout}}.
+The [=texel format=] is the {{GPUTexture/format}} attribute of the
+{{GPUTexture}} bound to the texture variable.
+WebGPU [$validating shader binding|validates$] compatibility between the
+texture, the {{GPUTextureBindingLayout/sampleType}} of the bind group layout,
+and the [=sampled type=] of the texture variable.
+
+The texture is parameterized by a [=sampled type=] and 
+[=shader-creation error|must=] be `f32`, `i32`, or `u32`.
 
 <table class='data'>
   <thead>
     <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/Arrayed=]
   </thead>
   <tr><td><dfn noexport dfn-for='type'>texture_multisampled_2d</dfn><*T*>
-      <td>2D
+      <td>{{GPUTextureViewDimension/"2d"|2D}}
       <td>No
   <tr><td><dfn noexport dfn-for='type'>texture_depth_multisampled_2d</dfn>
-      <td>2D
+      <td>{{GPUTextureViewDimension/"2d"|2D}}
       <td>No
 </table>
 
-* *T* [=shader-creation error|must=] be `f32`, `i32`, or `u32`
+* *T* is the [=sampled type=].
 
 ### External Sampled Texture Types ### {#external-texture-type}
 
@@ -4100,7 +4116,7 @@ two-dimensional float-[=type/sampled texture=] type similar to `texture_2d<f32>`
 potentially with a different representation.
 It can be read using [[#textureload|textureLoad]] or
 [[#textureSampleBaseClampToEdge|textureSampleBaseClampToEdge]] built-in
-functions, which handle these different representations opaquely.
+functions, which handle these different representations.
 
 See [[WebGPU#gpuexternaltexture]].
 
@@ -4109,7 +4125,7 @@ See [[WebGPU#gpuexternaltexture]].
     <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/Arrayed=]
   </thead>
   <tr><td><dfn noexport dfn-for='type'>texture_external</dfn>
-      <td>2D
+      <td>{{GPUTextureViewDimension/"2d"|2D}}
       <td>No
 </table>
 
@@ -4134,16 +4150,16 @@ used to convert the shader value to the stored texel.
     <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/Arrayed=]
   </thead>
   <tr><td><dfn noexport dfn-for='type'>texture_storage_1d</dfn><*Format*, *Access*>
-      <td>1D
+      <td>{{GPUTextureViewDimension/"1d"|1D}}
       <td>No
   <tr><td><dfn noexport dfn-for='type'>texture_storage_2d</dfn><*Format*, *Access*>
-      <td>2D
+      <td>{{GPUTextureViewDimension/"2d"|2D}}
       <td>No
   <tr><td><dfn noexport dfn-for='type'>texture_storage_2d_array</dfn><*Format*, *Access*>
-      <td>2D
+      <td>{{GPUTextureViewDimension/"2d-array"|2D}}
       <td>Yes
   <tr><td><dfn noexport dfn-for='type'>texture_storage_3d</dfn><*Format*, *Access*>
-      <td>3D
+      <td>{{GPUTextureViewDimension/"3d"|3D}}
       <td>No
 </table>
 
@@ -4164,16 +4180,16 @@ The [=texel format=] of the texture is defined in the {{GPUTextureBindingLayout}
     <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/Arrayed=]
   </thead>
   <tr><td><dfn noexport dfn-for='type'>texture_depth_2d</dfn>
-      <td>2D
+      <td>{{GPUTextureViewDimension/"2d"|2D}}
       <td>No
   <tr><td><dfn noexport dfn-for='type'>texture_depth_2d_array</dfn>
-      <td>2D
+      <td>{{GPUTextureViewDimension/"2d-array"|2D}}
       <td>Yes
   <tr><td><dfn noexport dfn-for='type'>texture_depth_cube</dfn>
-      <td>Cube
+      <td>{{GPUTextureViewDimension/"cube"|Cube}}
       <td>No
   <tr><td><dfn noexport dfn-for='type'>texture_depth_cube_array</dfn>
-      <td>Cube
+      <td>{{GPUTextureViewDimension/"cube-array"|Cube}}
       <td>Yes
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4042,7 +4042,7 @@ The [=texel format=] of the texture is defined in the {{GPUTextureBindingLayout}
 
 <table class='data'>
   <thead>
-    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/arrayed=]
+    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/Arrayed=]
   </thead>
   <tr><td><dfn noexport dfn-for='type'>texture_1d</dfn><*T*>
       <td>1D
@@ -4081,7 +4081,7 @@ The [=texel format=] of the texture is defined in the {{GPUTextureBindingLayout}
 
 <table class='data'>
   <thead>
-    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/arrayed=]
+    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/Arrayed=]
   </thead>
   <tr><td><dfn noexport dfn-for='type'>texture_multisampled_2d</dfn><*T*>
       <td>2D
@@ -4106,7 +4106,7 @@ See [[WebGPU#gpuexternaltexture]].
 
 <table class='data'>
   <thead>
-    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/arrayed=]
+    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/Arrayed=]
   </thead>
   <tr><td><dfn noexport dfn-for='type'>texture_external</dfn>
       <td>2D
@@ -4131,7 +4131,7 @@ used to convert the shader value to the stored texel.
 
 <table class='data'>
   <thead>
-    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/arrayed=]
+    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/Arrayed=]
   </thead>
   <tr><td><dfn noexport dfn-for='type'>texture_storage_1d</dfn><*Format*, *Access*>
       <td>1D
@@ -4161,7 +4161,7 @@ The [=texel format=] of the texture is defined in the {{GPUTextureBindingLayout}
 
 <table class='data'>
   <thead>
-    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/arrayed=]
+    <tr><th>Type<th>[=texture/Dimensionality=]<th>[=texture/Arrayed=]
   </thead>
   <tr><td><dfn noexport dfn-for='type'>texture_depth_2d</dfn>
       <td>2D


### PR DESCRIPTION
Fixes #3824

* Fill out the texture types with more description.
* Add definitions for both categories of types and individual types
  * add many links