### PR TITLE
[editorial] Re-add splat constructors for vectors 

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12212,6 +12212,19 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=rust>
+          @const @must_use fn mat2x2<T>(e : T) -> mat2x2<T>
+          @const @must_use fn mat2x2(e : S) -> mat2x2<S>
+        </xmp>
+  <tr><td>Parameterization
+      <td>`T` is [=f16=] or [=f32=]<br>
+      `S` is [FLOATSCALAR]
+  <tr><td>Description
+      <td>Constructor for a 2x2 column-major [=matrix=] with `e` as all components.
+</table>
+<table class='data builtin'>
+  <tr><td style="width:10%">Overload
+      <td>
+        <xmp highlight=rust>
           @const @must_use fn mat2x2<T>(e : mat2x2<S>) -> mat2x2<T>
           @const @must_use fn mat2x2(e : mat2x2<S>) -> mat2x2<S>
         </xmp>
@@ -12250,6 +12263,19 @@ specify the component type; the component type is inferred from the constructor 
 
 #### `mat2x3` #### {#mat2x3-builtin}
 
+<table class='data builtin'>
+  <tr><td style="width:10%">Overload
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat2x3<T>(e : T) -> mat2x3<T>
+          @const @must_use fn mat2x3(e : S) -> mat2x3<S>
+        </xmp>
+  <tr><td>Parameterization
+      <td>`T` is [=f16=] or [=f32=]<br>
+      `S` is [FLOATSCALAR]
+  <tr><td>Description
+      <td>Constructor for a 2x3 column-major [=matrix=] with `e` as all components.
+</table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12296,6 +12322,19 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=rust>
+          @const @must_use fn mat2x4<T>(e : T) -> mat2x4<T>
+          @const @must_use fn mat2x4(e : S) -> mat2x4<S>
+        </xmp>
+  <tr><td>Parameterization
+      <td>`T` is [=f16=] or [=f32=]<br>
+      `S` is [FLOATSCALAR]
+  <tr><td>Description
+      <td>Constructor for a 2x4 column-major [=matrix=] with `e` as all components.
+</table>
+<table class='data builtin'>
+  <tr><td style="width:10%">Overload
+      <td>
+        <xmp highlight=rust>
           @const @must_use fn mat2x4<T>(e : mat2x4<S>) -> mat2x4<T>
           @const @must_use fn mat2x4(e : mat2x4<S>) -> mat2x4<S>
         </xmp>
@@ -12334,6 +12373,19 @@ specify the component type; the component type is inferred from the constructor 
 
 #### `mat3x2` #### {#mat3x2-builtin}
 
+<table class='data builtin'>
+  <tr><td style="width:10%">Overload
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat3x2<T>(e : T) -> mat3x2<T>
+          @const @must_use fn mat3x2(e : S) -> mat3x2<S>
+        </xmp>
+  <tr><td>Parameterization
+      <td>`T` is [=f16=] or [=f32=]<br>
+      `S` is [FLOATSCALAR]
+  <tr><td>Description
+      <td>Constructor for a 3x2 column-major [=matrix=] with `e` as all components.
+</table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12384,6 +12436,19 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=rust>
+          @const @must_use fn mat3x3<T>(e : T) -> mat3x3<T>
+          @const @must_use fn mat3x3(e : S) -> mat3x3<S>
+        </xmp>
+  <tr><td>Parameterization
+      <td>`T` is [=f16=] or [=f32=]<br>
+      `S` is [FLOATSCALAR]
+  <tr><td>Description
+      <td>Constructor for a 3x3 column-major [=matrix=] with `e` as all components.
+</table>
+<table class='data builtin'>
+  <tr><td style="width:10%">Overload
+      <td>
+        <xmp highlight=rust>
           @const @must_use fn mat3x3<T>(e : mat3x3<S>) -> mat3x3<T>
           @const @must_use fn mat3x3(e : mat3x3<S>) -> mat3x3<S>
         </xmp>
@@ -12430,6 +12495,19 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=rust>
+          @const @must_use fn mat3x4<T>(e : T) -> mat3x4<T>
+          @const @must_use fn mat3x4(e : S) -> mat3x4<S>
+        </xmp>
+  <tr><td>Parameterization
+      <td>`T` is [=f16=] or [=f32=]<br>
+      `S` is [FLOATSCALAR]
+  <tr><td>Description
+      <td>Constructor for a 3x4 column-major [=matrix=] with `e` as all components.
+</table>
+<table class='data builtin'>
+  <tr><td style="width:10%">Overload
+      <td>
+        <xmp highlight=rust>
           @const @must_use fn mat3x4<T>(e : mat3x4<S>) -> mat3x4<T>
           @const @must_use fn mat3x4(e : mat3x4<S>) -> mat3x4<S>
         </xmp>
@@ -12472,6 +12550,19 @@ specify the component type; the component type is inferred from the constructor 
 
 #### `mat4x2` #### {#mat4x2-builtin}
 
+<table class='data builtin'>
+  <tr><td style="width:10%">Overload
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat4x2<T>(e : T) -> mat4x2<T>
+          @const @must_use fn mat4x2(e : S) -> mat4x2<S>
+        </xmp>
+  <tr><td>Parameterization
+      <td>`T` is [=f16=] or [=f32=]<br>
+      `S` is [FLOATSCALAR]
+  <tr><td>Description
+      <td>Constructor for a 4x2 column-major [=matrix=] with `e` as all components.
+</table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12524,6 +12615,19 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=rust>
+          @const @must_use fn mat4x3<T>(e : T) -> mat4x3<T>
+          @const @must_use fn mat4x3(e : S) -> mat4x3<S>
+        </xmp>
+  <tr><td>Parameterization
+      <td>`T` is [=f16=] or [=f32=]<br>
+      `S` is [FLOATSCALAR]
+  <tr><td>Description
+      <td>Constructor for a 4x3 column-major [=matrix=] with `e` as all components.
+</table>
+<table class='data builtin'>
+  <tr><td style="width:10%">Overload
+      <td>
+        <xmp highlight=rust>
           @const @must_use fn mat4x3<T>(e : mat4x3<S>) -> mat4x3<T>
           @const @must_use fn mat4x3(e : mat4x3<S>) -> mat4x3<S>
         </xmp>
@@ -12568,6 +12672,19 @@ specify the component type; the component type is inferred from the constructor 
 
 #### `mat4x4` #### {#mat4x4-builtin}
 
+<table class='data builtin'>
+  <tr><td style="width:10%">Overload
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn mat4x4<T>(e : T) -> mat4x4<T>
+          @const @must_use fn mat4x4(e : S) -> mat4x4<S>
+        </xmp>
+  <tr><td>Parameterization
+      <td>`T` is [=f16=] or [=f32=]<br>
+      `S` is [FLOATSCALAR]
+  <tr><td>Description
+      <td>Constructor for a 4x4 column-major [=matrix=] with `e` as all components.
+</table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12654,6 +12771,19 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=rust>
+          @const @must_use fn vec2<T>(e : T) -> vec2<T>
+          @const @must_use fn vec2(e : S) -> vec2<S>
+        </xmp>
+  <tr><td>Parameterization
+      <td>`T` is a [=type/concrete=] [=scalar=]<br>
+      `S` is [=scalar=]
+  <tr><td>Description
+      <td>Construction of a two-component [=vector=] with `e` as both components.
+</table>
+<table class='data builtin'>
+  <tr><td style="width:10%">Overload
+      <td>
+        <xmp highlight=rust>
           @const @must_use fn vec2<T>(e : vec2<S>) -> vec2<T>
           @const @must_use fn vec2(e : vec2<S>) -> vec2<S>
         </xmp>
@@ -12680,6 +12810,19 @@ specify the component type; the component type is inferred from the constructor 
 
 #### `vec3` #### {#vec3-builtin}
 
+<table class='data builtin'>
+  <tr><td style="width:10%">Overload
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec3<T>(e : T) -> vec3<T>
+          @const @must_use fn vec3(e : S) -> vec3<S>
+        </xmp>
+  <tr><td>Parameterization
+      <td>`T` is a [=type/concrete=] [=scalar=]<br>
+      `S` is [=scalar=]
+  <tr><td>Description
+      <td>Construction of a three-component [=vector=] with `e` as all components.
+</table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12734,6 +12877,19 @@ specify the component type; the component type is inferred from the constructor 
 
 #### `vec4` #### {#vec4-builtin}
 
+<table class='data builtin'>
+  <tr><td style="width:10%">Overload
+      <td>
+        <xmp highlight=rust>
+          @const @must_use fn vec4<T>(e : T) -> vec4<T>
+          @const @must_use fn vec4(e : S) -> vec4<S>
+        </xmp>
+  <tr><td>Parameterization
+      <td>`T` is a [=type/concrete=] [=scalar=]<br>
+      `S` is [=scalar=]
+  <tr><td>Description
+      <td>Construction of a four-component [=vector=] with `e` as all components.
+</table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12212,19 +12212,6 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=rust>
-          @const @must_use fn mat2x2<T>(e : T) -> mat2x2<T>
-          @const @must_use fn mat2x2(e : S) -> mat2x2<S>
-        </xmp>
-  <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
-      `S` is [FLOATSCALAR]
-  <tr><td>Description
-      <td>Constructor for a 2x2 column-major [=matrix=] with `e` as all components.
-</table>
-<table class='data builtin'>
-  <tr><td style="width:10%">Overload
-      <td>
-        <xmp highlight=rust>
           @const @must_use fn mat2x2<T>(e : mat2x2<S>) -> mat2x2<T>
           @const @must_use fn mat2x2(e : mat2x2<S>) -> mat2x2<S>
         </xmp>
@@ -12263,19 +12250,6 @@ specify the component type; the component type is inferred from the constructor 
 
 #### `mat2x3` #### {#mat2x3-builtin}
 
-<table class='data builtin'>
-  <tr><td style="width:10%">Overload
-      <td>
-        <xmp highlight=rust>
-          @const @must_use fn mat2x3<T>(e : T) -> mat2x3<T>
-          @const @must_use fn mat2x3(e : S) -> mat2x3<S>
-        </xmp>
-  <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
-      `S` is [FLOATSCALAR]
-  <tr><td>Description
-      <td>Constructor for a 2x3 column-major [=matrix=] with `e` as all components.
-</table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12322,19 +12296,6 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=rust>
-          @const @must_use fn mat2x4<T>(e : T) -> mat2x4<T>
-          @const @must_use fn mat2x4(e : S) -> mat2x4<S>
-        </xmp>
-  <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
-      `S` is [FLOATSCALAR]
-  <tr><td>Description
-      <td>Constructor for a 2x4 column-major [=matrix=] with `e` as all components.
-</table>
-<table class='data builtin'>
-  <tr><td style="width:10%">Overload
-      <td>
-        <xmp highlight=rust>
           @const @must_use fn mat2x4<T>(e : mat2x4<S>) -> mat2x4<T>
           @const @must_use fn mat2x4(e : mat2x4<S>) -> mat2x4<S>
         </xmp>
@@ -12373,19 +12334,6 @@ specify the component type; the component type is inferred from the constructor 
 
 #### `mat3x2` #### {#mat3x2-builtin}
 
-<table class='data builtin'>
-  <tr><td style="width:10%">Overload
-      <td>
-        <xmp highlight=rust>
-          @const @must_use fn mat3x2<T>(e : T) -> mat3x2<T>
-          @const @must_use fn mat3x2(e : S) -> mat3x2<S>
-        </xmp>
-  <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
-      `S` is [FLOATSCALAR]
-  <tr><td>Description
-      <td>Constructor for a 3x2 column-major [=matrix=] with `e` as all components.
-</table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12436,19 +12384,6 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=rust>
-          @const @must_use fn mat3x3<T>(e : T) -> mat3x3<T>
-          @const @must_use fn mat3x3(e : S) -> mat3x3<S>
-        </xmp>
-  <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
-      `S` is [FLOATSCALAR]
-  <tr><td>Description
-      <td>Constructor for a 3x3 column-major [=matrix=] with `e` as all components.
-</table>
-<table class='data builtin'>
-  <tr><td style="width:10%">Overload
-      <td>
-        <xmp highlight=rust>
           @const @must_use fn mat3x3<T>(e : mat3x3<S>) -> mat3x3<T>
           @const @must_use fn mat3x3(e : mat3x3<S>) -> mat3x3<S>
         </xmp>
@@ -12495,19 +12430,6 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=rust>
-          @const @must_use fn mat3x4<T>(e : T) -> mat3x4<T>
-          @const @must_use fn mat3x4(e : S) -> mat3x4<S>
-        </xmp>
-  <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
-      `S` is [FLOATSCALAR]
-  <tr><td>Description
-      <td>Constructor for a 3x4 column-major [=matrix=] with `e` as all components.
-</table>
-<table class='data builtin'>
-  <tr><td style="width:10%">Overload
-      <td>
-        <xmp highlight=rust>
           @const @must_use fn mat3x4<T>(e : mat3x4<S>) -> mat3x4<T>
           @const @must_use fn mat3x4(e : mat3x4<S>) -> mat3x4<S>
         </xmp>
@@ -12550,19 +12472,6 @@ specify the component type; the component type is inferred from the constructor 
 
 #### `mat4x2` #### {#mat4x2-builtin}
 
-<table class='data builtin'>
-  <tr><td style="width:10%">Overload
-      <td>
-        <xmp highlight=rust>
-          @const @must_use fn mat4x2<T>(e : T) -> mat4x2<T>
-          @const @must_use fn mat4x2(e : S) -> mat4x2<S>
-        </xmp>
-  <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
-      `S` is [FLOATSCALAR]
-  <tr><td>Description
-      <td>Constructor for a 4x2 column-major [=matrix=] with `e` as all components.
-</table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12615,19 +12524,6 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=rust>
-          @const @must_use fn mat4x3<T>(e : T) -> mat4x3<T>
-          @const @must_use fn mat4x3(e : S) -> mat4x3<S>
-        </xmp>
-  <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
-      `S` is [FLOATSCALAR]
-  <tr><td>Description
-      <td>Constructor for a 4x3 column-major [=matrix=] with `e` as all components.
-</table>
-<table class='data builtin'>
-  <tr><td style="width:10%">Overload
-      <td>
-        <xmp highlight=rust>
           @const @must_use fn mat4x3<T>(e : mat4x3<S>) -> mat4x3<T>
           @const @must_use fn mat4x3(e : mat4x3<S>) -> mat4x3<S>
         </xmp>
@@ -12672,19 +12568,6 @@ specify the component type; the component type is inferred from the constructor 
 
 #### `mat4x4` #### {#mat4x4-builtin}
 
-<table class='data builtin'>
-  <tr><td style="width:10%">Overload
-      <td>
-        <xmp highlight=rust>
-          @const @must_use fn mat4x4<T>(e : T) -> mat4x4<T>
-          @const @must_use fn mat4x4(e : S) -> mat4x4<S>
-        </xmp>
-  <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
-      `S` is [FLOATSCALAR]
-  <tr><td>Description
-      <td>Constructor for a 4x4 column-major [=matrix=] with `e` as all components.
-</table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>


### PR DESCRIPTION
These were accidentally omitted from #3853