### PR TITLE
Pin tree-sitter version more strictly

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -743,11 +743,11 @@ def flow_build(options):
         pass
     else:
         subprocess.run(["npm", "install"], cwd=options.grammar_dir, check=True)
-    subprocess.run(["npx", "tree-sitter-cli@0.20.7", "generate"],
+    subprocess.run(["npx", "tree-sitter@0.20.1", "generate"],
                    cwd=options.grammar_dir, check=True)
     # Following are commented for future reference to expose playground
     # Remove "--docker" if local environment matches with the container
-    # subprocess.run(["npx", "tree-sitter-cli@0.20.7", "build-wasm", "--docker"],
+    # subprocess.run(["npx", "tree-sitter@0.20.1", "build-wasm", "--docker"],
     #                cwd=options.grammar_dir, check=True)
 
 

--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -702,7 +702,7 @@ def flow_extract(options, scan_result):
         grammar_package.write('        "nan": "^2.15.0"\n')
         grammar_package.write('    },\n')
         grammar_package.write('    "devDependencies": {\n')
-        grammar_package.write('        "tree-sitter-cli": "^0.20.7"\n')
+        grammar_package.write('        "tree-sitter-cli": "0.20.7"\n')
         grammar_package.write('    },\n')
         grammar_package.write('    "main": "bindings/node"\n')
         grammar_package.write('}\n')
@@ -743,11 +743,11 @@ def flow_build(options):
         pass
     else:
         subprocess.run(["npm", "install"], cwd=options.grammar_dir, check=True)
-    subprocess.run(["npx", "tree-sitter", "generate"],
+    subprocess.run(["npx", "tree-sitter-cli@0.20.7", "generate"],
                    cwd=options.grammar_dir, check=True)
     # Following are commented for future reference to expose playground
     # Remove "--docker" if local environment matches with the container
-    # subprocess.run(["npx", "tree-sitter", "build-wasm", "--docker"],
+    # subprocess.run(["npx", "tree-sitter-cli@0.20.7", "build-wasm", "--docker"],
     #                cwd=options.grammar_dir, check=True)
 
 


### PR DESCRIPTION
I'm merging ASAP to enable outstanding PR workflows to build. This should be strict anyways. Thank you!