### PR TITLE
wgsl/analyzer/Grammar now understands Treesitter "REPEAT" node

### DIFF
--- a/wgsl/analyze/Grammar.py
+++ b/wgsl/analyze/Grammar.py
@@ -938,6 +938,11 @@ def json_hook(grammar,memo,tokens_only,dct):
                     result = grammar.MakeSeq(dct["members"])
                 elif  type_entry == "REPEAT1":
                     result = grammar.MakeRepeat1([dct["content"]])
+                elif  type_entry == "REPEAT":
+                    # This node type was introduced in a later version of treesitter.
+                    # REPEAT { X } is the same as CHOICE { REPEAT1 {X} | BLANK }
+                    result = grammar.MakeRepeat1([dct["content"]])
+                    result = grammar.MakeChoice([result, grammar.empty])
                 elif  type_entry == "SYMBOL":
                     result = memoize(memo,dct["name"],grammar.MakeSymbolName(dct["name"]))
     return result

--- a/wgsl/analyze/test.py
+++ b/wgsl/analyze/test.py
@@ -536,11 +536,19 @@ def _rep1(content):
         {}
     }}""".format(content)
 
+def _rep(content):
+    return """
+    {{
+      "type": "REPEAT",
+      "content":
+        {}
+    }}""".format(content)
+
 def _optional(content):
     return _choice(content,_empty())
 
 def _star(content): # Kleene star
-    return _choice(_rep1(content),_empty())
+    return _rep(content)
 
 def _g(*args):
     pre = """


### PR DESCRIPTION
The REPEAT {X} node is the Kleene-star operator, which used to only be expressed as CHOICE ( REPEAT1 {X} | BLANK ).

Translate REPEAT into that equivalence.  This is the shortest path to supporting some changes in #4027