### PR TITLE
Remove maxFragmentCombinedOutputResources

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1626,14 +1626,6 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
         which are uniform buffers.
         See [=Exceeds the binding slot limits=].
 
-    <tr><td><dfn>maxFragmentCombinedOutputResources</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8
-    <tr class=row-continuation><td colspan=4>
-        The maximum total number of
-        {{GPUShaderStage/FRAGMENT}}-stage storage buffers,
-        {{GPUShaderStage/FRAGMENT}}-stage storage textures,
-        and color attachments in a {{GPURenderPipelineDescriptor}}.
-
     <tr><td><dfn>maxUniformBufferBindingSize</dfn>
         <td>{{GPUSize64}} <td>[=limit class/maximum=] <td>65536 bytes
     <tr class=row-continuation><td colspan=4>
@@ -1783,7 +1775,6 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxStorageBuffersPerShaderStage;
     readonly attribute unsigned long maxStorageTexturesPerShaderStage;
     readonly attribute unsigned long maxUniformBuffersPerShaderStage;
-    readonly attribute unsigned long maxFragmentCombinedOutputResources;
     readonly attribute unsigned long long maxUniformBufferBindingSize;
     readonly attribute unsigned long long maxStorageBufferBindingSize;
     readonly attribute unsigned long minUniformBufferOffsetAlignment;
@@ -2382,7 +2373,6 @@ Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the followi
     implementations should raise it to conform to this requirement, rather than lowering the
     other limits.
 
-- {{supported limits/maxColorAttachments}} must be &le; {{supported limits/maxFragmentCombinedOutputResources}}.
 - {{supported limits/minUniformBufferOffsetAlignment}} and
     {{supported limits/minStorageBufferOffsetAlignment}} must both be &ge; 32 bytes.
 
@@ -8089,8 +8079,6 @@ dictionary GPUFragmentState : GPUProgrammableStage {
 
     - |descriptor|.{{GPUFragmentState/targets}}.length must be &le;
         |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
-    - The [=total number of fragment output resources=] must be &le;
-        |device|.{{device/[[limits]]}}.{{supported limits/maxFragmentCombinedOutputResources}}.
     - [=list/For each=] |index| of the [=list/indices=] of |descriptor|.{{GPUFragmentState/targets}}
         containing a non-`null` value |colorState|:
         - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
@@ -8119,15 +8107,6 @@ dictionary GPUFragmentState : GPUProgrammableStage {
 
             - |colorState|.{{GPUColorTargetState/writeMask}} must be 0.
     - [$Validating GPUFragmentState's color attachment bytes per sample$](|device|, |descriptor|.{{GPUFragmentState/targets}}) succeeds.
-</div>
-
-<div algorithm>
-    The <dfn dfn>total number of fragment output resources</dfn> for a
-    {{GPUFragmentState}} |descriptor| is the sum of:
-
-    - the number of non-null elements in |descriptor|.{{GPUFragmentState/targets}}
-    - the number of storage buffers and storage textures (of any access mode)
-        [=statically used=] by |descriptor|
 </div>
 
 <div algorithm>


### PR DESCRIPTION
Fixes #4018, (non-cleanly) reverts #3829 (and its two followup commits)