### PR TITLE
Fix argumentdef layout

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -335,26 +335,13 @@ div.algorithm > div[data-timeline] {
     max-width: 4ch;
     word-wrap: break-word;
 }
-.algorithm .argumentdef tr > :nth-child(3),
-.algorithm .argumentdef tr > :nth-child(4) {
-    padding-left: .5em;
-    padding-right: 0;
-}
 
 /* Wrap Parameter and Type onto separate rows. */
-.algorithm .argumentdef > thead > tr > th:nth-child(1),
-.algorithm .argumentdef > tbody > tr > td:nth-child(1) {
-    padding-right: .5em;
-    float: left;
-}
-.algorithm .argumentdef > thead > tr > th:nth-child(2),
-.algorithm .argumentdef > tbody > tr > td:nth-child(2) {
-    padding-left: .5em;
-    float: right;
-}
-.algorithm .argumentdef > thead > tr > th {
-    vertical-align: top;
-}
+.algorithm .argumentdef tr > :nth-child(1) { float: left; }
+.algorithm .argumentdef tr > :nth-child(2) { float: right; }
+.algorithm .argumentdef > thead > tr > th { vertical-align: top; }
+.algorithm .argumentdef > tbody > tr > td { vertical-align: middle; }
+.algorithm .argumentdef > thead > tr > th:nth-child(5) { width: 40%; }
 
 /*
  * Add vertical lines to demarcate multi-column cells.


### PR DESCRIPTION
I think something changed in the upstream stylesheets for argumentdef tables and that made the Description column really narrow in our spec. This fixes that (and simplifies the stylesheet too).

I checked all the tables and they all look good now (even after #4045)