### PR TITLE
Update to bikeshed 3.11.21

### DIFF
--- a/tools/install-dependencies.sh
+++ b/tools/install-dependencies.sh
@@ -5,7 +5,7 @@ code=1
 for opt in "$@"; do
     case "$opt" in
         bikeshed)
-            pip3 install bikeshed==3.11.19
+            pip3 install bikeshed==3.11.21
             bikeshed update
             code=0
             ;;


### PR DESCRIPTION
Fixes:
- Layout of argumentdef tables (see also #4046)
- WebIDL blocks indirectly included by `<pre class=include>` (the ones in `copies.bs`, like GPUImageDataLayout.
    ```
    dictionary GPUImageDataLayout {    GPUSize64 offset = 0;    GPUSize32 bytesPerRow;    GPUSize32 rowsPerImage;};
    ```
    vs
    ```
    dictionary GPUImageDataLayout {
        GPUSize64 offset = 0;
        GPUSize32 bytesPerRow;
        GPUSize32 rowsPerImage;
    };
    ```