### PR TITLE
Position inheritance clauses on separate lines for readability

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2701,7 +2701,8 @@ interface GPUAdapter {
 {{GPUDeviceDescriptor}} describes a device request.
 
 <script type=idl>
-dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
+dictionary GPUDeviceDescriptor
+         : GPUObjectDescriptorBase {
     sequence<GPUFeatureName> requiredFeatures = [];
     record<DOMString, GPUSize64> requiredLimits = {};
     GPUQueueDescriptor defaultQueue = {};
@@ -3177,7 +3178,8 @@ extends [=internal object=] with the following [=device timeline slots=]:
 ### {{GPUBufferDescriptor}} ### {#GPUBufferDescriptor}
 
 <script type=idl>
-dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
+dictionary GPUBufferDescriptor
+         : GPUObjectDescriptorBase {
     required GPUSize64 size;
     required GPUBufferUsageFlags usage;
     boolean mappedAtCreation = false;
@@ -3972,7 +3974,8 @@ to form complete [=texel blocks=] in the [=texture=]. It is calculated by this p
 {{GPUTexture}}s are created via {{GPUDevice/createTexture()}}.
 
 <script type=idl>
-dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
+dictionary GPUTextureDescriptor
+         : GPUObjectDescriptorBase {
     required GPUExtent3D size;
     GPUIntegerCoordinate mipLevelCount = 1;
     GPUSize32 sampleCount = 1;
@@ -4351,7 +4354,8 @@ GPUTextureView includes GPUObjectBase;
 ### Texture View Creation ### {#texture-view-creation}
 
 <script type=idl>
-dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
+dictionary GPUTextureViewDescriptor
+         : GPUObjectDescriptorBase {
     GPUTextureFormat format;
     GPUTextureViewDimension dimension;
     GPUTextureAspect aspect = "all";
@@ -5012,7 +5016,8 @@ If the same object is returned again, it will compare equal, and {{GPUBindGroup}
 {{GPURenderBundle}}s, etc. referencing the previous object can still be used.
 
 <script type=idl>
-dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
+dictionary GPUExternalTextureDescriptor
+         : GPUObjectDescriptorBase {
     required HTMLVideoElement source;
     PredefinedColorSpace colorSpace = "srgb";
 };
@@ -5203,7 +5208,8 @@ GPUSampler includes GPUObjectBase;
 A {{GPUSamplerDescriptor}} specifies the options to use to create a {{GPUSampler}}.
 
 <script type=idl>
-dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
+dictionary GPUSamplerDescriptor
+         : GPUObjectDescriptorBase {
     GPUAddressMode addressModeU = "clamp-to-edge";
     GPUAddressMode addressModeV = "clamp-to-edge";
     GPUAddressMode addressModeW = "clamp-to-edge";
@@ -5469,7 +5475,8 @@ GPUBindGroupLayout includes GPUObjectBase;
 A {{GPUBindGroupLayout}} is created via {{GPUDevice/createBindGroupLayout()|GPUDevice.createBindGroupLayout()}}.
 
 <script type=idl>
-dictionary GPUBindGroupLayoutDescriptor : GPUObjectDescriptorBase {
+dictionary GPUBindGroupLayoutDescriptor
+         : GPUObjectDescriptorBase {
     required sequence<GPUBindGroupLayoutEntry> entries;
 };
 </script>
@@ -5959,7 +5966,8 @@ A {{GPUBindGroup}} object has the following internal slots:
 A {{GPUBindGroup}} is created via {{GPUDevice/createBindGroup()|GPUDevice.createBindGroup()}}.
 
 <script type=idl>
-dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
+dictionary GPUBindGroupDescriptor
+         : GPUObjectDescriptorBase {
     required GPUBindGroupLayout layout;
     required sequence<GPUBindGroupEntry> entries;
 };
@@ -6248,7 +6256,8 @@ Note: the expected usage of the {{GPUPipelineLayout}} is placing the most common
 A {{GPUPipelineLayout}} is created via {{GPUDevice/createPipelineLayout()|GPUDevice.createPipelineLayout()}}.
 
 <script type=idl>
-dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
+dictionary GPUPipelineLayoutDescriptor
+         : GPUObjectDescriptorBase {
     required sequence<GPUBindGroupLayout> bindGroupLayouts;
 };
 </script>
@@ -6378,7 +6387,8 @@ GPUShaderModule includes GPUObjectBase;
 ### Shader Module Creation ### {#shader-module-creation}
 
 <script type=idl>
-dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
+dictionary GPUShaderModuleDescriptor
+         : GPUObjectDescriptorBase {
     required USVString code;
     object sourceMap;
     record<USVString, GPUShaderModuleCompilationHint> hints;
@@ -6847,7 +6857,8 @@ enum GPUAutoLayoutMode {
     "auto"
 };
 
-dictionary GPUPipelineDescriptorBase : GPUObjectDescriptorBase {
+dictionary GPUPipelineDescriptorBase
+         : GPUObjectDescriptorBase {
     required (GPUPipelineLayout or GPUAutoLayoutMode) layout;
 };
 
@@ -7386,7 +7397,8 @@ A {{GPUComputePipelineDescriptor}} describes a compute [=pipeline=]. See
 [[#computing-operations]] for additional details.
 
 <script type=idl>
-dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
+dictionary GPUComputePipelineDescriptor
+         : GPUPipelineDescriptorBase {
     required GPUProgrammableStage compute;
 };
 </script>
@@ -7593,7 +7605,8 @@ A {{GPURenderPipelineDescriptor}} describes a render [=pipeline=] by configuring
 of the [=render stages=]. See [[#rendering-operations]] for additional details.
 
 <script type=idl>
-dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
+dictionary GPURenderPipelineDescriptor
+         : GPUPipelineDescriptorBase {
     required GPUVertexState vertex;
     GPUPrimitiveState primitive = {};
     GPUDepthStencilState depthStencil;
@@ -8074,7 +8087,8 @@ interacts with a render pass's multisampled attachments.
 ### Fragment State ### {#fragment-state}
 
 <script type=idl>
-dictionary GPUFragmentState : GPUProgrammableStage {
+dictionary GPUFragmentState
+         : GPUProgrammableStage {
     required sequence<GPUColorTargetState?> targets;
 };
 </script>
@@ -8904,7 +8918,8 @@ current vertex or instance index:
 </dl>
 
 <script type=idl>
-dictionary GPUVertexState : GPUProgrammableStage {
+dictionary GPUVertexState
+         : GPUProgrammableStage {
     sequence<GPUVertexBufferLayout?> buffers = [];
 };
 </script>
@@ -9075,7 +9090,8 @@ GPUCommandBuffer includes GPUObjectBase;
 ### Command Buffer Creation ### {#command-buffer-creation}
 
 <script type=idl>
-dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
+dictionary GPUCommandBufferDescriptor
+         : GPUObjectDescriptorBase {
 };
 </script>
 
@@ -9211,7 +9227,8 @@ GPUCommandEncoder includes GPUDebugCommandsMixin;
 ### Command Encoder Creation ### {#command-encoder-creation}
 
 <script type=idl>
-dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
+dictionary GPUCommandEncoderDescriptor
+         : GPUObjectDescriptorBase {
 };
 </script>
 
@@ -10292,7 +10309,8 @@ dictionary GPUComputePassTimestampWrite {
 
 typedef sequence<GPUComputePassTimestampWrite> GPUComputePassTimestampWrites;
 
-dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
+dictionary GPUComputePassDescriptor
+         : GPUObjectDescriptorBase {
     GPUComputePassTimestampWrites timestampWrites = [];
 };
 </script>
@@ -10643,7 +10661,8 @@ dictionary GPURenderPassTimestampWrite {
 
 typedef sequence<GPURenderPassTimestampWrite> GPURenderPassTimestampWrites;
 
-dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
+dictionary GPURenderPassDescriptor
+         : GPUObjectDescriptorBase {
     required sequence<GPURenderPassColorAttachment?> colorAttachments;
     GPURenderPassDepthStencilAttachment depthStencilAttachment;
     GPUQuerySet occlusionQuerySet;
@@ -11011,7 +11030,8 @@ enum GPUStoreOp {
 which determines the compatibility of the pass with render pipelines.
 
 <script type=idl>
-dictionary GPURenderPassLayout : GPUObjectDescriptorBase {
+dictionary GPURenderPassLayout
+         : GPUObjectDescriptorBase {
     required sequence<GPUTextureFormat?> colorFormats;
     GPUTextureFormat depthStencilFormat;
     GPUSize32 sampleCount = 1;
@@ -12039,7 +12059,8 @@ GPURenderBundle includes GPUObjectBase;
 ### Render Bundle Creation ### {#render-bundle-creation}
 
 <script type=idl>
-dictionary GPURenderBundleDescriptor : GPUObjectDescriptorBase {
+dictionary GPURenderBundleDescriptor
+         : GPUObjectDescriptorBase {
 };
 </script>
 
@@ -12122,7 +12143,8 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
 ### Encoding ### {#render-bundle-encoding}
 
 <script type=idl>
-dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
+dictionary GPURenderBundleEncoderDescriptor
+         : GPURenderPassLayout {
     boolean depthReadOnly = false;
     boolean stencilReadOnly = false;
 };
@@ -12186,7 +12208,8 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
 {{GPUQueueDescriptor}} describes a queue request.
 
 <script type=idl>
-dictionary GPUQueueDescriptor : GPUObjectDescriptorBase {
+dictionary GPUQueueDescriptor
+         : GPUObjectDescriptorBase {
 };
 </script>
 
@@ -12598,7 +12621,8 @@ which is one of the following:
 A {{GPUQuerySetDescriptor}} specifies the options to use in creating a {{GPUQuerySet}}.
 
 <script type=idl>
-dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
+dictionary GPUQuerySetDescriptor
+         : GPUObjectDescriptorBase {
     required GPUQueryType type;
     required GPUSize32 count;
 };
@@ -13401,7 +13425,8 @@ JSON, for a debug report).
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
-interface GPUValidationError : GPUError {
+interface GPUValidationError
+        : GPUError {
     constructor(DOMString message);
 };
 </script>
@@ -13425,7 +13450,8 @@ error, and is expected to fail the same way across all devices assuming the same
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
-interface GPUOutOfMemoryError : GPUError {
+interface GPUOutOfMemoryError
+        : GPUError {
     constructor(DOMString message);
 };
 </script>
@@ -13449,7 +13475,8 @@ resources is released first.
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
-interface GPUInternalError : GPUError {
+interface GPUInternalError
+        : GPUError {
     constructor(DOMString message);
 };
 </script>

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -97,7 +97,8 @@ In an [=image copy=] operation, {{GPUImageCopyBuffer}} defines a {{GPUBuffer}} a
 the `copySize`, how image data is laid out in the buffer's memory (see {{GPUImageDataLayout}}).
 
 <script type=idl>
-dictionary GPUImageCopyBuffer : GPUImageDataLayout {
+dictionary GPUImageCopyBuffer
+         : GPUImageDataLayout {
     required GPUBuffer buffer;
 };
 </script>
@@ -200,7 +201,8 @@ This metadata affects only the semantics of the {{GPUQueue/copyExternalImageToTe
 operation, not the semantics of the destination texture.
 
 <script type=idl>
-dictionary GPUImageCopyTextureTagged : GPUImageCopyTexture {
+dictionary GPUImageCopyTextureTagged
+         : GPUImageCopyTexture {
     PredefinedColorSpace colorSpace = "srgb";
     boolean premultipliedAlpha = false;
 };


### PR DESCRIPTION
I think this will (slightly) help with the common readability issue of not being able to figure out where things like "label" or "module"/"entryPoint" are defined.