### PR TITLE
Implementation should always issue a warning on device loss

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1416,6 +1416,14 @@ If an operation fails with side effects that would observably change the state
 of objects on the device or potentially corrupt internal implementation/driver state,
 the device **should** be lost to prevent these changes from being observable.
 
+Note:
+For all device losses not initiated by the application (via {{GPUDevice/destroy()}},
+user agents should consider issuing developer-visible warnings *unconditionally*,
+even if the {{GPUDevice/lost}} promise is handled.
+These scenarios should be rare, and the signal is vital to developers because most of the WebGPU
+API tries to behave like nothing is wrong to avoid interrupting the runtime flow of the application:
+no validation errors are raised, most promises resolve normally, etc.
+
 <div algorithm data-timeline=device>
     To <dfn dfn>lose the device</dfn>(|device|, |reason|):
 


### PR DESCRIPTION
One of the last two things to complete #1629