### PR TITLE
Fix description of fragment/RasterizationPoint depth

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14239,7 +14239,8 @@ Rasterization produces a list of <dfn dfn>RasterizationPoint</dfn>s, each contai
     : <dfn dfn>perspectiveDivisor</dfn>
     :: refers to interpolated 1.0 &divide; W across the primitive
     : <dfn dfn>depth</dfn>
-    :: refers to the depth in [=NDC=]
+    :: refers to the depth in viewport coordinates,
+        i.e. between the {{RenderState/[[viewport]]}} `minDepth` and `maxDepth`.
     : <dfn dfn>primitiveVertices</dfn>
     :: refers to the list of vertex outputs forming the primitive
     : <dfn dfn>barycentricCoordinates</dfn>
@@ -14269,17 +14270,19 @@ Rasterization produces a list of <dfn dfn>RasterizationPoint</dfn>s, each contai
         ndc(|p|) = vector(|p|.x &divide; |p|.w, |p|.y &divide; |p|.w, |p|.z &divide; |p|.w)
 
     1. Let |vp| be |state|.{{RenderState/[[viewport]]}}.
-        Then the [=NDC=] coordinates |n| are converted into [=framebuffer=] coordinates,
-        based on the size of the render targets:
+        Map the [=NDC=] coordinates |n| into viewport space:
+        * Compute [=framebuffer=] coordinates from the render target offset and size:
 
-        framebufferCoords(|n|) = vector(|vp|.`x` &plus; 0.5 &times; (|n|.x &plus; 1) &times; |vp|.`width`, |vp|.`y` &plus; .5 &times; (|n|.y &plus; 1) &times; |vp|.`height`)
+            framebufferCoords(|n|) = vector(|vp|.`x` &plus; 0.5 &times; (|n|.x &plus; 1) &times; |vp|.`width`, |vp|.`y` &plus; .5 &times; (|n|.y &plus; 1) &times; |vp|.`height`)
 
-        <p class="note editorial">Editorial: specify the depth translation into viewport as well
+        * Compute depth by linearly mapping [0,1] to the viewport depth range:
+
+            depth(|n|) = |vp|.`minDepth` &plus; |n|.`z` &times; ( |vp|.`maxDepth` - |vp|.`minDepth` )
 
     1. Let |rasterizationPoints| be an empty list.
 
-        <p class="note editorial">Editorial: specify that each rasterization point gets assigned an interpolated `divisor(p)`
-        and `framebufferCoords(n)`, as well as the other attributes.
+        <p class="note editorial">Editorial: specify that each rasterization point gets assigned an interpolated `divisor(p)`,
+        `framebufferCoords(n)`, `depth(n)`, as well as the other attributes.
 
     1. Proceed with a specific rasterization algorithm,
         depending on {{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}}:
@@ -14439,7 +14442,8 @@ This stage produces a <dfn dfn>Fragment</dfn> for each [=RasterizationPoint=]:
 <div algorithm="Fragment accessors" dfn-for=Fragment>
     - <dfn dfn>destination</dfn> refers to [=FragmentDestination=].
     - <dfn dfn>coverageMask</dfn> refers to multisample coverage mask (see [[#sample-masking]]).
-    - <dfn dfn>depth</dfn> refers to the depth in [=NDC=] coordinates.
+    - <dfn dfn>depth</dfn> refers to the depth in viewport coordinates,
+        i.e. between the {{RenderState/[[viewport]]}} `minDepth` and `maxDepth`.
     - <dfn dfn>colors</dfn> refers to the list of color values,
         one for each target in {{GPURenderPassDescriptor/colorAttachments}}.
 </div>


### PR DESCRIPTION
They are in viewport coordinates, spanning viewport minDepth to maxDepth