### PR TITLE
Small syntactic fix for the IDLs.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12232,13 +12232,13 @@ interface GPUQueue {
     undefined writeBuffer(
         GPUBuffer buffer,
         GPUSize64 bufferOffset,
-        ([AllowShared] ArrayBuffer or [AllowShared] ArrayBufferView) data,
+        [AllowShared] (ArrayBufferView or ArrayBuffer) data,
         optional GPUSize64 dataOffset = 0,
         optional GPUSize64 size);
 
     undefined writeTexture(
         GPUImageCopyTexture destination,
-        ([AllowShared] ArrayBuffer or [AllowShared] ArrayBufferView) data,
+        [AllowShared] (ArrayBufferView or ArrayBuffer) data,
         GPUImageDataLayout dataLayout,
         GPUExtent3D size);
 


### PR DESCRIPTION
- Needed this because Dawn node generates binding based on the spec and the resulting IDL without this fix was failing parsing in https://github.com/ben-clayton/webidlparser.