### PR TITLE
Revert "[AllowShared] ArrayBuffer or [AllowShared] ArrayBufferView"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12232,13 +12232,13 @@ interface GPUQueue {
     undefined writeBuffer(
         GPUBuffer buffer,
         GPUSize64 bufferOffset,
-        ([AllowShared] ArrayBuffer or [AllowShared] ArrayBufferView) data,
+        [AllowShared] BufferSource data,
         optional GPUSize64 dataOffset = 0,
         optional GPUSize64 size);
 
     undefined writeTexture(
         GPUImageCopyTexture destination,
-        ([AllowShared] ArrayBuffer or [AllowShared] ArrayBufferView) data,
+        [AllowShared] BufferSource data,
         GPUImageDataLayout dataLayout,
         GPUExtent3D size);
 


### PR DESCRIPTION
Reverts gpuweb/gpuweb#4045

I did a little more looking at that WebIDL issue https://github.com/whatwg/webidl/issues/961. Given `[AllowShared] BufferSource` is used:
- In the WebIDL spec in example code
- In WebGL and probably others
- And some tooling (chromium) doesn't support `[AllowShared] BufferSource` while other tooling (dawn-node) doesn't support `[AllowShared] ArrayBuffer or [AllowShared] ArrayBufferView` so implementations are going to have to deal with this anyway (as they already do in WebGL)

I'm proposing we just revert this and leave it the way we wanted it originally. Once WebIDL has a fix, if it turns out to be different, I'm sure they'll be reaching out to all of the specs that use `[AllowShared] BufferSource` to fix it.

Closes #4055