### PR TITLE
Account for dynamic offsets in binding aliasing validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10161,23 +10161,23 @@ It must only be included by interfaces which also include those mixins.
             1. For each ({{GPUBindGroupLayoutEntry}} |bindGroupLayoutEntry|,
                 {{GPUBufferBinding}} |resource|) in |bufferRanges|, in which
                 |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/visibility}} contains |stage|:
-                    1. Let |resourceWritable| be (|bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} == {{GPUBufferBindingType/"storage"}}).
-                    1. For each pair ({{GPUBufferBinding}} |pastResource|, `boolean` |pastResourceWritable|) in |bufferBindings|:
-                        1. If (|resourceWritable| or |pastResourceWritable|) is true, and
-                            |pastResource| and |resource| are [=buffer-binding-aliasing=], return `true`.
-                    1. [=list/append|Append=] (|resource|, |resourceWritable|) to |bufferBindings|.
+                1. Let |resourceWritable| be (|bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} == {{GPUBufferBindingType/"storage"}}).
+                1. For each pair ({{GPUBufferBinding}} |pastResource|, `boolean` |pastResourceWritable|) in |bufferBindings|:
+                    1. If (|resourceWritable| or |pastResourceWritable|) is true, and
+                        |pastResource| and |resource| are [=buffer-binding-aliasing=], return `true`.
+                1. [=list/append|Append=] (|resource|, |resourceWritable|) to |bufferBindings|.
             1. For each {{GPUBindGroupLayoutEntry}} |bindGroupLayoutEntry| in
                 |bindGroupLayoutEntries|, and corresponding {{GPUTextureView}} |resource|
                 in |bindGroup|, in which
                 |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/visibility}} contains |stage|:
-                    1. Let |resourceWritable| be whether
-                        |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}}
-                        is a writable access mode.
-                    1. If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not [=map/exist|provided=], **continue**.
-                    1. For each pair ({{GPUTextureView}} |pastResource|, `boolean` |pastResourceWritable|) in |textureViews|,
-                        1. If (|resourceWritable| or |pastResourceWritable|) is true, and
-                            |pastResource| and |resource| is [=texture-view-aliasing=], return `true`.
-                    1. [=list/append|Append=] (|resource|, |resourceWritable|) to |textureViews|.
+                1. Let |resourceWritable| be whether
+                    |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}}
+                    is a writable access mode.
+                1. If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not [=map/exist|provided=], **continue**.
+                1. For each pair ({{GPUTextureView}} |pastResource|, `boolean` |pastResourceWritable|) in |textureViews|,
+                    1. If (|resourceWritable| or |pastResourceWritable|) is true, and
+                        |pastResource| and |resource| is [=texture-view-aliasing=], return `true`.
+                1. [=list/append|Append=] (|resource|, |resourceWritable|) to |textureViews|.
     1. Return `false`.
 
     Note:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5976,6 +5976,28 @@ A {{GPUBindGroup}} object has the following internal slots:
         associated with lists of the [=internal usage=] flags.
 </dl>
 
+<div algorithm>
+    The <dfn for=GPUBindGroup>bound buffer ranges</dfn> of a {{GPUBindGroup}} |bindGroup|,
+    given [=list=]&lt;GPUBufferDynamicOffset&gt; |dynamicOffsets|, are computed as follows:
+
+    1. Let |result| be a new [=set=]&lt;({{GPUBindGroupLayoutEntry}}, {{GPUBufferBinding}})&gt;.
+    1. Let |dynamicOffsetIndex| be 0.
+    1. For each {{GPUBindGroupEntry}} |bindGroupEntry| in |bindGroup|.{{GPUBindGroup/[[entries]]}},
+        sorted by |bindGroupEntry|.{{GPUBindGroupEntry/binding}}:
+        1. Let |bindGroupLayoutEntry| be
+            |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[entryMap]]}}[|bindGroupEntry|.{{GPUBindGroupEntry/binding}}].
+        1. If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}} is not
+            [=map/exists|provided=], **continue**.
+        1. Let |bound| be a copy of |bindGroupEntry|.{{GPUBindGroupEntry/resource}}.
+        1. [=Assert=] |bound| is a {{GPUBufferBinding}}.
+        1. If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}:
+            1. Increment |bound|.{{GPUBufferBinding/offset}} by
+                |dynamicOffsets|[|dynamicOffsetIndex|].
+            1. Increment |dynamicOffsetIndex| by 1.
+        1. [=set/Append=] (|bindGroupLayoutEntry|, |bound|) to |result|.
+    1. Return |result|.
+</div>
+
 ### Bind Group Creation ### {#bind-group-creation}
 
 A {{GPUBindGroup}} is created via {{GPUDevice/createBindGroup()|GPUDevice.createBindGroup()}}.
@@ -6213,9 +6235,11 @@ following members:
 
     - |a|.{{GPUBufferBinding/buffer}} == |b|.{{GPUBufferBinding/buffer}}
     - The range formed by |a|.{{GPUBufferBinding/offset}} and |a|.{{GPUBufferBinding/size}} intersects
-        the range formed by |b|.{{GPUBufferBinding/offset}} and |b|.{{GPUBufferBinding/size}}.
+        the range formed by |b|.{{GPUBufferBinding/offset}} and |b|.{{GPUBufferBinding/size}},
+        where if a {{GPUBufferBinding/size}} is [=map/exists|unspecified=],
+        the range goes to the end of the buffer.
 
-    Issue: Define how a range is formed by offset/size when size can be undefined.
+    Note: When doing this calculation, any dynamic offsets have already been applied to the ranges.
 </div>
 
 <h3 id=gpupipelinelayout data-dfn-type=interface>`GPUPipelineLayout`
@@ -9923,7 +9947,7 @@ It must only be included by interfaces which also include those mixins.
     ::
         The current {{GPUBindGroup}} for each index, initially empty.
 
-    : <dfn>\[[dynamic_offsets]]</dfn>, of type [=ordered map=]&lt;{{GPUIndex32}}, [=sequence=]&gt;{{GPUBufferDynamicOffset}}>&gt;
+    : <dfn>\[[dynamic_offsets]]</dfn>, of type [=ordered map=]&lt;{{GPUIndex32}}, [=list=]&lt;{{GPUBufferDynamicOffset}}&gt; &gt;
     ::
         The current dynamic offsets for each {{GPUBindingCommandsMixin/[[bind_groups]]}} entry, initially empty.
 </dl>
@@ -10125,37 +10149,35 @@ It must only be included by interfaces which also include those mixins.
             where the latter indicates whether the resource was used as writable.
         1. Let |textureViews| be a [=list=] of ({{GPUTextureView}}, `boolean`) pairs,
             where the latter indicates whether the resource was used as writable.
-        1. For each pair of ({{GPUIndex32}} |index|, {{GPUBindGroupLayout}} |bindGroupLayout|) in
+        1. For each pair of ({{GPUIndex32}} |bindGroupIndex|, {{GPUBindGroupLayout}} |bindGroupLayout|) in
             |pipeline|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}:
-            1. Let |bindGroupEntries| be
-                |encoder|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|index|].{{GPUBindGroupDescriptor/entries}}.
+            1. Let |bindGroup| be
+                |encoder|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|bindGroupIndex|].
             1. Let |bindGroupLayoutEntries| be
                 |bindGroupLayout|.{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}.
-            1. For each {{GPUBindGroupEntry}} |bindGroupLayoutEntry| in |bindGroupLayoutEntries|
-                for which |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/visibility}} contains |stage|:
-                1. Let |bindGroupEntry| be the {{GPUBindGroupEntry}} in |bindGroupEntries| for which
-                    |bindGroupEntry|.{{GPUBindGroupEntry/binding}} is equal to
-                    |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/binding}}.
-                1. If |bindGroupEntry|.{{GPUBindGroupEntry/resource}} is a {{GPUBufferBinding}}:
-
-                    1. Let {{GPUBufferBinding}} |resource| be |bindGroupEntry|.{{GPUBindGroupEntry/resource}}.
+            1. Let |bufferRanges| be the [=GPUBindGroup/bound buffer ranges=] of |bindGroup|,
+                given dynamic offsets
+                |encoder|.{{GPUBindingCommandsMixin/[[dynamic_offsets]]}}[|bindGroupIndex|]
+            1. For each ({{GPUBindGroupLayoutEntry}} |bindGroupLayoutEntry|,
+                {{GPUBufferBinding}} |resource|) in |bufferRanges|, in which
+                |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/visibility}} contains |stage|:
                     1. Let |resourceWritable| be (|bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} == {{GPUBufferBindingType/"storage"}}).
                     1. For each pair ({{GPUBufferBinding}} |pastResource|, `boolean` |pastResourceWritable|) in |bufferBindings|:
                         1. If (|resourceWritable| or |pastResourceWritable|) is true, and
                             |pastResource| and |resource| are [=buffer-binding-aliasing=], return `true`.
-                    1. [=list/append|Append=] ([|resource|], |resourceWritable|) to |bufferBindings|.
-
-                    Otherwise, if |bindGroupEntry|.{{GPUBindGroupEntry/resource}} is a {{GPUTextureView}}:
-
-                    1. Let {{GPUTextureView}} |resource| be |bindGroupEntry|.{{GPUBindGroupEntry/resource}}.
-                    1. Let |resourceWritable| be (|bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}} == {{GPUStorageTextureAccess/"write-only"}}).
+                    1. [=list/append|Append=] (|resource|, |resourceWritable|) to |bufferBindings|.
+            1. For each {{GPUBindGroupLayoutEntry}} |bindGroupLayoutEntry| in
+                |bindGroupLayoutEntries|, and corresponding {{GPUTextureView}} |resource|
+                in |bindGroup|, in which
+                |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/visibility}} contains |stage|:
+                    1. Let |resourceWritable| be whether
+                        |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}}
+                        is a writable access mode.
                     1. If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not [=map/exist|provided=], **continue**.
                     1. For each pair ({{GPUTextureView}} |pastResource|, `boolean` |pastResourceWritable|) in |textureViews|,
                         1. If (|resourceWritable| or |pastResourceWritable|) is true, and
                             |pastResource| and |resource| is [=texture-view-aliasing=], return `true`.
-                    1. [=list/append|Append=] ([|resource|], |resourceWritable|) to |textureViews|.
-
-                    Otherwise, continue.
+                    1. [=list/append|Append=] (|resource|, |resourceWritable|) to |textureViews|.
     1. Return `false`.
 
     Note:


### PR DESCRIPTION
(Can be viewed as two commits for better diff)

Fixes #3802