### PR TITLE
Specify how errors from the WGSL spec are surfaced in the API

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6478,9 +6478,10 @@ dictionary GPUShaderModuleDescriptor
                         - |result| must not be a [=shader-creation error|shader-creation=] [=program error=].
                     </div>
 
-                Issue(gpuweb/gpuweb#2308):
-                Should internal errors ([=uncategorized errors=]) be allowed here or should we
-                force them to be deferred to pipeline creation?
+                    Note: [=Uncategorized errors=] cannot arise from shader module creation.
+                    Implementations which detect such errors during shader module creation
+                    must behave as if the shader module is valid, and defer surfacing the
+                    error until pipeline creation.
 
                 Issue: Describe remaining {{GPUDevice/createShaderModule()}} validation and
                 algorithm steps.
@@ -7187,7 +7188,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     - {{GPUProgrammableStage}} |descriptor|
     - {{GPUPipelineLayout}} |layout|
 
-    Return `true` if all of the following conditions are met:
+    Return `true` if all of the following conditions are met, and `false` otherwise:
 
     - |descriptor|.{{GPUProgrammableStage/module}} must be a [=valid=] {{GPUShaderModule}}.
     - |descriptor|.{{GPUProgrammableStage/module}} must contain
@@ -7212,8 +7213,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         - If the pipeline-overridable constant identified by |key|
             [=pipeline-overridable constant default value|does not have a default value=],
             |descriptor|.{{GPUProgrammableStage/constants}} must [=map/contain=] |key|.
-
-    A return value of `false` corresponds to a [=pipeline-creation error=].
+    - [=pipeline-creation error|Pipeline-creation=] [=program errors=] must not
+        result from the rules of the [[WGSL]] specification.
 </div>
 
 <div algorithm>
@@ -7482,6 +7483,14 @@ dictionary GPUComputePipelineDescriptor
                             |device|.limits.{{supported limits/maxComputeWorkgroupSizeZ}}].
                     </div>
 
+                1. If any [=pipeline-creation error|pipeline-creation=] [=uncategorized errors=]
+                    result from the implementation of pipeline creation,
+                    [$generate an internal error$], make |pipeline| [=invalid=], and stop.
+
+                    Note:
+                    Even if the implementation detected [=uncategorized errors=] in shader module
+                    creation, the error is surfaced here.
+
                 1. Set |pipeline|.{{GPUPipelineBase/[[layout]]}} to |layout|.
             </div>
         </div>
@@ -7703,6 +7712,13 @@ dictionary GPURenderPipelineDescriptor
                             |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}},
                             where |vertexBufferCount| is the maximum index in |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}} that is not `undefined`.
                     </div>
+                1. If any [=pipeline-creation error|pipeline-creation=] [=uncategorized errors=]
+                    result from the implementation of pipeline creation,
+                    [$generate an internal error$], make |pipeline| [=invalid=], and stop.
+
+                    Note:
+                    Even if the implementation detected [=uncategorized errors=] in shader module
+                    creation, the error is surfaced here.
                 1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
                 1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to false.
                 1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to false.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -659,9 +659,8 @@ Triggered diagnostics [=behavioral requirement|will=] be processed as follows:
          * The error is a [=pipeline-creation error=] if the diagnostic was triggered at [=pipeline creation=] time.
 6. If processing during [=shader module creation=] time, the remaining diagnostics populate the
     {{GPUCompilationInfo/messages}} member of the WebGPU {{GPUCompilationInfo}} object.
-7. If processing during [=pipeline creation=], the [=severity/error=] diagnostics are reported
-    in the nearest enclosing WebGPU [=GPU error scope=].
-    Issue: TODO: Adjust for [#3682](https://github.com/gpuweb/gpuweb/issues/3682).
+7. If processing during [=pipeline creation=], [=severity/error=] diagnostics
+    result in WebGPU validation failure when validating {{GPUProgrammableStage}}.
 
 Note: The rules allow an implementation to stop processing a WGSL program as soon as an error is detected.
 Additionally, an analysis for a particular kind of warning can stop on the first warning,


### PR DESCRIPTION
- [x] In this PR, uncategorized errors are never surfaced in `createShaderModule`; they get deferred to `create*Pipeline*`. This is not the only option: we can also allow them to surface in `createShaderModule`; implementations which do backend-driver compilation work in `createShaderModule` have the option of raising the error there (calling them shader-creation uncategorized errors), and implementations which don't can simply raise them later (call them pipeline-creation uncategorized errors).

This is a bit of a bare minimum fix (the piping between WebGPU and WGSL could be a lot more explicit), but I think it sufficiently resolves all ambiguities here.

Fixes #3682