### PR TITLE
Clarify zero cases of occlusion queries

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11982,7 +11982,9 @@ attachments used by this encoder.
 
                 1. Let |passingFragments| be non-zero if any fragment samples passed all per-fragment
                     tests since the corresponding {{GPURenderPassEncoder/beginOcclusionQuery()}}
-                    command was executed.
+                    command was executed, and zero otherwise.
+
+                    Note: If no draw calls occurred, |passingFragments| is zero.
                 1. Write |passingFragments| into
                     |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} at index
                     |renderState|.{{RenderState/[[occlusionQueryIndex]]}}.


### PR DESCRIPTION
Fixes #3895

note: already tested https://gpuweb.github.io/cts/standalone/?q=webgpu:api,operation,command_buffer,queries,occlusionQuery:occlusion_query,empty:*