### PR TITLE
Add definitions to a bunch of dictionaries that were missing them

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2267,7 +2267,7 @@ WorkerNavigator includes NavigatorGPU;
 <dl dfn-type=attribute dfn-for=NavigatorGPU>
     : <dfn>gpu</dfn>
     ::
-        Provides access to interfaces related to WebGPU.
+        A global singleton providing top-level entry points like {{GPU/requestAdapter()}}.
 </dl>
 
 ## GPU ## {#gpu-interface}
@@ -6950,7 +6950,7 @@ dictionary GPUPipelineDescriptorBase
 <dl dfn-type=dict-member dfn-for=GPUPipelineDescriptorBase>
     : <dfn>layout</dfn>
     ::
-        The {{GPUPipelineLayout}} for this pipeline or {{GPUAutoLayoutMode/"auto"}}, to generate
+        The {{GPUPipelineLayout}} for this pipeline, or {{GPUAutoLayoutMode/"auto"}} to generate
         the pipeline layout automatically.
 
         Note: If {{GPUAutoLayoutMode/"auto"}} is used the pipeline cannot share {{GPUBindGroup}}s
@@ -8286,7 +8286,7 @@ dictionary GPUColorTargetState {
     : <dfn>format</dfn>
     ::
         The {{GPUTextureFormat}} of this color target. The pipeline will only be compatible with
-        {{GPURenderPassEncoder}}s which use a {{GPUTextureView}} of the same format in the
+        {{GPURenderPassEncoder}}s which use a {{GPUTextureView}} of this format in the
         corresponding color attachment.
 
     : <dfn>blend</dfn>
@@ -9070,8 +9070,8 @@ dictionary GPUVertexState
 <dl dfn-type=dict-member dfn-for=GPUVertexState>
     : <dfn>buffers</dfn>
     ::
-        A list of {{GPUVertexBufferLayout}}s defining the layout of the vertex attribute data in the
-        vertex buffers used by this pipeline.
+        A list of {{GPUVertexBufferLayout}}s, each defining the layout of vertex attribute data in a
+        vertex buffer used by this pipeline.
 </dl>
 
 A <dfn dfn noexport>vertex buffer</dfn> is, conceptually, a view into buffer memory as an *array of structures*.
@@ -10498,12 +10498,12 @@ dictionary GPUComputePassTimestampWrites {
 
     : <dfn>beginningOfPassWriteIndex</dfn>
     ::
-        If defined indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
+        If defined, indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
         which the timestamp at the beginning of the compute pass will be written.
 
     : <dfn>endOfPassWriteIndex</dfn>
     ::
-        If defined indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
+        If defined, indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
         which the timestamp at the end of the compute pass will be written.
 </dl>
 
@@ -10859,12 +10859,12 @@ dictionary GPURenderPassTimestampWrites {
 
     : <dfn>beginningOfPassWriteIndex</dfn>
     ::
-        If defined indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
+        If defined, indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
         which the timestamp at the beginning of the render pass will be written.
 
     : <dfn>endOfPassWriteIndex</dfn>
     ::
-        If defined indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
+        If defined, indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
         which the timestamp at the end of the render pass will be written.
 </dl>
 
@@ -11232,8 +11232,11 @@ enum GPUStoreOp {
 
 #### Render Pass Layout #### {#render-pass-layout}
 
-{{GPURenderPassLayout}} contains the layout of the render targets for the current pass or render
-bundle, which determines the compatibility of the pass or bundle with render pipelines.
+{{GPURenderPassLayout}} declares the layout of the render targets of a {{GPURenderBundle}}.
+It is also used internally to describe
+{{GPURenderPass}} [$derive render targets layout from pass|layouts$] and
+{{GPURenderPipeline}} [$derive render targets layout from pipeline|layouts$].
+It determines compatibility between render passes, render bundles, and render pipelines.
 
 <script type=idl>
 dictionary GPURenderPassLayout
@@ -14903,19 +14906,19 @@ integers and single-precision floats.
 <dl dfn-type=dict-member dfn-for=GPUColorDict>
     : <dfn>r</dfn>
     ::
-        The red channel value
+        The red channel value.
 
     : <dfn>g</dfn>
     ::
-        The green channel value
+        The green channel value.
 
     : <dfn>b</dfn>
     ::
-        The blue channel value
+        The blue channel value.
 
     : <dfn>a</dfn>
     ::
-        The alpha channel value
+        The alpha channel value.
 </dl>
 
 <div algorithm="GPUColor accessors" dfn-for=GPUColor>
@@ -15022,11 +15025,11 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 <dl dfn-type=dict-member dfn-for=GPUExtent3DDict>
     : <dfn>width</dfn>
     ::
-        The width of the extent
+        The width of the extent.
 
     : <dfn>height</dfn>
     ::
-        The height of the extent
+        The height of the extent.
 
     : <dfn>depthOrArrayLayers</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2262,6 +2262,14 @@ Navigator includes NavigatorGPU;
 WorkerNavigator includes NavigatorGPU;
 </script>
 
+{{NavigatorGPU}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for=NavigatorGPU>
+    : <dfn>gpu</dfn>
+    ::
+        Provides access to interfaces related to WebGPU.
+</dl>
+
 ## GPU ## {#gpu-interface}
 
 <dfn interface>GPU</dfn> is the entry point to WebGPU.
@@ -6937,7 +6945,19 @@ dictionary GPUPipelineDescriptorBase
          : GPUObjectDescriptorBase {
     required (GPUPipelineLayout or GPUAutoLayoutMode) layout;
 };
+</script>
 
+<dl dfn-type=dict-member dfn-for=GPUPipelineDescriptorBase>
+    : <dfn>layout</dfn>
+    ::
+        The {{GPUPipelineLayout}} for this pipeline or {{GPUAutoLayoutMode/"auto"}}, to generate
+        the pipeline layout automatically.
+
+        Note: If {{GPUAutoLayoutMode/"auto"}} is used the pipeline cannot share {{GPUBindGroup}}s
+        with any other pipelines.
+</dl>
+
+<script type=idl>
 interface mixin GPUPipelineBase {
     [NewObject] GPUBindGroupLayout getBindGroupLayout(unsigned long index);
 };
@@ -7163,7 +7183,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
 
 {{GPUProgrammableStage}} has the following members:
 
-<dl dfn-for=GPUProgrammableStage dfn-type=dict-member>
+<dl dfn-type=dict-member dfn-for=GPUProgrammableStage>
     : <dfn>module</dfn>
     ::
         The {{GPUShaderModule}} containing the code that this programmable stage will execute.
@@ -8184,6 +8204,13 @@ dictionary GPUFragmentState
 };
 </script>
 
+<dl dfn-type=dict-member dfn-for=GPUFragmentState>
+    : <dfn>targets</dfn>
+    ::
+        A list of {{GPUColorTargetState}} defining the formats and behaviors of the color targets
+        this pipeline writes to.
+</dl>
+
 <div algorithm>
     <dfn abstract-op>validating GPUFragmentState</dfn>({{GPUDevice}} |device|, {{GPUFragmentState}} |descriptor|)
 
@@ -8255,12 +8282,39 @@ dictionary GPUColorTargetState {
 };
 </script>
 
+<dl dfn-type=dict-member dfn-for=GPUColorTargetState>
+    : <dfn>format</dfn>
+    ::
+        The {{GPUTextureFormat}} of this color target. The pipeline will only be compatible with
+        {{GPURenderPassEncoder}}s which use a {{GPUTextureView}} of the same format in the
+        corresponding color attachment.
+
+    : <dfn>blend</dfn>
+    ::
+        The blending behavior for this color target. If left undefined, disables blending for this
+        color target.
+
+    : <dfn>writeMask</dfn>
+    ::
+        Bitmask controlling which channels are are written to when drawing to this color target.
+</dl>
+
 <script type=idl>
 dictionary GPUBlendState {
     required GPUBlendComponent color;
     required GPUBlendComponent alpha;
 };
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPUBlendState>
+    : <dfn>color</dfn>
+    ::
+        Defines the blending behavior of the corresponding render target for color channels.
+
+    : <dfn>alpha</dfn>
+    ::
+        Defines the blending behavior of the corresponding render target for the alpha channel.
+</dl>
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUColorWriteFlags;
@@ -9012,6 +9066,13 @@ dictionary GPUVertexState
     sequence<GPUVertexBufferLayout?> buffers = [];
 };
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPUVertexState>
+    : <dfn>buffers</dfn>
+    ::
+        A list of {{GPUVertexBufferLayout}}s defining the layout of the vertex attribute data in the
+        vertex buffers used by this pipeline.
+</dl>
 
 A <dfn dfn noexport>vertex buffer</dfn> is, conceptually, a view into buffer memory as an *array of structures*.
 {{GPUVertexBufferLayout/arrayStride}} is the stride, in bytes, between *elements* of that array.
@@ -10429,6 +10490,23 @@ dictionary GPUComputePassTimestampWrites {
 };
 </script>
 
+<dl dfn-type=dict-member dfn-for=GPUComputePassTimestampWrites>
+    : <dfn>querySet</dfn>
+    ::
+        The {{GPUQuerySet}}, of type {{GPUQueryType/"timestamp"}}, that the query results will be
+        written to.
+
+    : <dfn>beginningOfPassWriteIndex</dfn>
+    ::
+        If defined indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
+        which the timestamp at the beginning of the compute pass will be written.
+
+    : <dfn>endOfPassWriteIndex</dfn>
+    ::
+        If defined indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
+        which the timestamp at the end of the compute pass will be written.
+</dl>
+
 <script type=idl>
 dictionary GPUComputePassDescriptor
          : GPUObjectDescriptorBase {
@@ -10772,6 +10850,23 @@ dictionary GPURenderPassTimestampWrites {
     GPUSize32 endOfPassWriteIndex;
 };
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPURenderPassTimestampWrites>
+    : <dfn>querySet</dfn>
+    ::
+        The {{GPUQuerySet}}, of type {{GPUQueryType/"timestamp"}}, that the query results will be
+        written to.
+
+    : <dfn>beginningOfPassWriteIndex</dfn>
+    ::
+        If defined indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
+        which the timestamp at the beginning of the render pass will be written.
+
+    : <dfn>endOfPassWriteIndex</dfn>
+    ::
+        If defined indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
+        which the timestamp at the end of the render pass will be written.
+</dl>
 
 <script type=idl>
 dictionary GPURenderPassDescriptor
@@ -11137,8 +11232,8 @@ enum GPUStoreOp {
 
 #### Render Pass Layout #### {#render-pass-layout}
 
-{{GPURenderPassLayout}} contains the layout of the render targets for the current pass,
-which determines the compatibility of the pass with render pipelines.
+{{GPURenderPassLayout}} contains the layout of the render targets for the current pass or render
+bundle, which determines the compatibility of the pass or bundle with render pipelines.
 
 <script type=idl>
 dictionary GPURenderPassLayout
@@ -11148,6 +11243,20 @@ dictionary GPURenderPassLayout
     GPUSize32 sampleCount = 1;
 };
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPURenderPassLayout>
+    : <dfn>colorFormats</dfn>
+    ::
+        A list of the {{GPUTextureFormat}}s of the color attachments for this pass or bundle.
+
+    : <dfn>depthStencilFormat</dfn>
+    ::
+        The {{GPUTextureFormat}} of the depth/stencil attachment for this pass or bundle.
+
+    : <dfn>sampleCount</dfn>
+    ::
+        Number of samples per pixel in the attachments for this pass or bundle.
+</dl>
 
 <div algorithm=gpurenderpasslayout-equal>
     Two {{GPURenderPassLayout}} values are <dfn dfn for="render pass layout" lt="equals|equal">equal</dfn> if:
@@ -12150,6 +12259,11 @@ attachments used by this encoder.
 
 # Bundles # {#bundles}
 
+A bundle is a partial, limited pass that is encoded once and can then be executed multiple times as
+part of future pass encoders without expiring after use like typical command buffers. This can
+reduce the overhead of encoding and submission of commands which are issued repeatedly without
+changing.
+
 <h3 id=gpurenderbundle data-dfn-type=interface>`GPURenderBundle`
 <span id=render-bundle></span>
 </h3>
@@ -12277,6 +12391,20 @@ dictionary GPURenderBundleEncoderDescriptor
     boolean stencilReadOnly = false;
 };
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPURenderBundleEncoderDescriptor>
+    : <dfn>depthReadOnly</dfn>
+    ::
+        If `true`, indicates that the render bundle does not modify the depth component of the
+        {{GPURenderPassDepthStencilAttachment}} of any render pass the render bundle is executed
+        in.
+
+    : <dfn>stencilReadOnly</dfn>
+    ::
+        If `true`, indicates that the render bundle does not modify the stencil component of the
+        {{GPURenderPassDepthStencilAttachment}} of any render pass the render bundle is executed
+        in.
+</dl>
 
 ### Finalization ### {#render-bundle-finalization}
 
@@ -12939,7 +13067,7 @@ which allows changing the canvas configuration without replacing the canvas.
     1. Set |context|.{{GPUCanvasContext/canvas}} to |canvas|.
     1. [$Replace the drawing buffer$] of |context|.
     1. Return |context|.
-    
+
     Note: User agents should consider issuing developer-visible warnings when
     an ignored `options` argument is provided when calling `getContext()`
     to get a WebGPU canvas context.
@@ -14772,6 +14900,24 @@ typedef (sequence<double> or GPUColorDict) GPUColor;
 Note: `double` is large enough to precisely hold 32-bit signed/unsigned
 integers and single-precision floats.
 
+<dl dfn-type=dict-member dfn-for=GPUColorDict>
+    : <dfn>r</dfn>
+    ::
+        The red channel value
+
+    : <dfn>g</dfn>
+    ::
+        The green channel value
+
+    : <dfn>b</dfn>
+    ::
+        The blue channel value
+
+    : <dfn>a</dfn>
+    ::
+        The alpha channel value
+</dl>
+
 <div algorithm="GPUColor accessors" dfn-for=GPUColor>
     For a given {{GPUColor}} value |color|, depending on its type, the syntax:
 
@@ -14872,6 +15018,23 @@ dictionary GPUExtent3DDict {
 };
 typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPUExtent3DDict>
+    : <dfn>width</dfn>
+    ::
+        The width of the extent
+
+    : <dfn>height</dfn>
+    ::
+        The height of the extent
+
+    : <dfn>depthOrArrayLayers</dfn>
+    ::
+        The depth of the extent or the number of array layers it contains.
+        If used with a {{GPUTexture}} with a {{GPUTextureDimension}} of {{GPUTextureDimension/"3d"}}
+        defines the depth of the texture. If used with a {{GPUTexture}} with a {{GPUTextureDimension}}
+        of {{GPUTextureDimension/"2d"}} defines the number of array layers in the texture.
+</dl>
 
 <div algorithm="GPUExtent3D accessors" dfn-for=GPUExtent3D>
     For a given {{GPUExtent3D}} value |extent|, depending on its type, the syntax:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11234,7 +11234,7 @@ enum GPUStoreOp {
 
 {{GPURenderPassLayout}} declares the layout of the render targets of a {{GPURenderBundle}}.
 It is also used internally to describe
-{{GPURenderPass}} [$derive render targets layout from pass|layouts$] and
+{{GPURenderPassEncoder}} [$derive render targets layout from pass|layouts$] and
 {{GPURenderPipeline}} [$derive render targets layout from pipeline|layouts$].
 It determines compatibility between render passes, render bundles, and render pipelines.
 


### PR DESCRIPTION
Was doing a Typescript types update and noticed a lot of types lacked JSDoc comments, which are generated from the spec's dictionary key definitions. Added a bunch of those to help populate the typescript comments, as well as a few other bits of text that felt like they were missing (such as a description of what bundles are.)