### PR TITLE
Update workload simulator for recent spec changes

### DIFF
--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -374,7 +374,7 @@ function mouseMove(e) {
     xy[0] = e.pageX;
     xy[1] = e.pageY;
   }
-  if ((e.touches || mouseDown) && !continuousRunning) {
+  if (e.touches || mouseDown) {
     for (let i = 0; i < 2; ++i) {
       position[i] += xy[i] - lastPos[i];
       position[i] = Math.max(0, Math.min(size - imgSize, position[i]));
@@ -644,38 +644,36 @@ async function render(fromRaf, fromPostMessage) {
             errorMessage.textContent = 'Failed to allocate multisample render attachment.';
         }
         let shaderModule = device.createShaderModule({ code: `
-          const pos = array<vec2<f32>, 6>(
-              vec2(-1., 1.),
-              vec2(-1., -1.),
-              vec2(1., -1.),
-              vec2(-1., 1.),
-              vec2(1., -1.),
-              vec2(1., 1.));
+          const pos = array(vec2f(0, 1),
+                            vec2f(0, 0),
+                            vec2f(1, 0),
+                            vec2f(0, 1),
+                            vec2f(1, 0),
+                            vec2f(1, 1));
 
-          @binding(0) @group(0) var<uniform> xy: vec2<f32>;
-          @binding(1) @group(0) var sampler1: sampler;
-          @binding(2) @group(0) var texture1: texture_2d<f32>;
+          @group(0) @binding(0) var<uniform> xy: vec2f;
+          @group(0) @binding(1) var sampler1: sampler;
+          @group(0) @binding(2) var texture1: texture_2d<f32>;
 
           struct Output {
-            @builtin(position) Position : vec4<f32>,
-            @location(0) uv : vec2<f32>,
+            @builtin(position) Position : vec4f,
+            @location(0) uv : vec2f,
           };
           
           @vertex
           fn vs(@builtin(vertex_index) VertexIndex : u32) -> Output {
             var output : Output;
-            output.Position = vec4(pos[VertexIndex] / vec2(2.,2.) + xy, 0.0, 1.0);
-            output.uv = pos[VertexIndex] / vec2(2., -2.) + vec2(.5, .5);
+            output.Position = vec4(pos[VertexIndex] * vec2(1, -1) + vec2(-.5, .5) + xy, 0, 1);
+            output.uv = pos[VertexIndex];
             return output;
           }
 
           @fragment
-          fn fs(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+          fn fs(@location(0) uv: vec2f) -> @location(0) vec4f {
             return textureSample(texture1, sampler1, uv);
           }
           `, });
 
-        if (shaderModule.compilationInfo)
         pipeline = device.createRenderPipeline({
           primitive: { topology: 'triangle-list' },
           layout: pipelineLayout,
@@ -705,7 +703,7 @@ async function render(fromRaf, fromPostMessage) {
             { source: imageBitmap }, { texture }, [256, 256, 1]);
           render();
         };
-        if (img.complete) loadImage(); else img.addEventListener('load', loadImage);
+        if (img.src && img.complete) loadImage(); else img.addEventListener('load', loadImage);
         uniformBuffer = device.createBuffer({
           size: 2 * 4,
           usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
@@ -794,7 +792,6 @@ async function render(fromRaf, fromPostMessage) {
             usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
             mappedAtCreation: true,
           });
-          buffer.size = mapAsyncArray.byteLength;
           mapAsyncBuffersOutstanding++;
           if (mapAsyncBuffersOutstanding > 10) {
             bufferWarning.textContent = ` Warning: mapAsync requests from ${mapAsyncBuffersOutstanding} frames ago have not resolved yet. ${(mapAsync.value * mapAsyncBuffersOutstanding).toFixed(2)} MB of staging buffers allocated.`;
@@ -1008,7 +1005,7 @@ async function render(fromRaf, fromPostMessage) {
       gl.generateMipmap(gl.TEXTURE_2D);
       setTimeout(render, 0);
     };
-    if (img.complete) img.onload();
+    if (img.src && img.complete) img.onload();
 
     function setupProgram(vsSource, fsSource, attribs, uniforms) {
       let prog = gl.createProgram();

--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -655,21 +655,18 @@ async function render(fromRaf, fromPostMessage) {
           @group(0) @binding(1) var sampler1: sampler;
           @group(0) @binding(2) var texture1: texture_2d<f32>;
 
-          struct Output {
+          struct VertexOutput {
             @builtin(position) Position : vec4f,
             @location(0) uv : vec2f,
           };
-          
-          @vertex
-          fn vs(@builtin(vertex_index) VertexIndex : u32) -> Output {
-            var output : Output;
-            output.Position = vec4(pos[VertexIndex] * vec2(1, -1) + vec2(-.5, .5) + xy, 0, 1);
-            output.uv = pos[VertexIndex];
-            return output;
+
+          @vertex fn vs(@builtin(vertex_index) i : u32) -> VertexOutput {
+            return VertexOutput(
+              vec4(pos[i] * vec2(1, -1) + xy, 0, 1),
+              pos[i]);
           }
 
-          @fragment
-          fn fs(@location(0) uv: vec2f) -> @location(0) vec4f {
+          @fragment fn fs(@location(0) uv: vec2f) -> @location(0) vec4f {
             return textureSample(texture1, sampler1, uv);
           }
           `, });
@@ -739,7 +736,7 @@ async function render(fromRaf, fromPostMessage) {
     try {
       const canvasView = canvasContext.getCurrentTexture().createView();
       const commandBuffers = [];
-      device.queue.writeBuffer(uniformBuffer, 0, new Float32Array([position[0]/size*2 - 0.5, -position[1]*2/size + 0.5]));
+      device.queue.writeBuffer(uniformBuffer, 0, new Float32Array([position[0] / size * 2 - 1, 1 - position[1] * 2 / size]));
       let buffer = null;
 
       // Start off by writing a timestamp for the beginning of the frame.


### PR DESCRIPTION
GPUBuffer.size exists now so don't try to set it as an expando property.

Simplify WGSL with type inference and vecNf shorthand.