### PR TITLE
More promise ordering guarantees

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1028,10 +1028,20 @@ Several operations in WebGPU return promises.
 WebGPU does not make any guarantees about the order in which these promises settle
 (resolve or reject), except for the following:
 
-- <div algorithm="mapAsync-onSubmittedWorkDone ordering">
-        If |p1| = |b|.{{GPUBuffer/mapAsync()}} is called before
+- <div algorithm="onSubmittedWorkDone ordering">
+        For some {{GPUQueue}} |q|,
+        if |p1| = |q|.{{GPUQueue/onSubmittedWorkDone()}} is called before
         |p2| = |q|.{{GPUQueue/onSubmittedWorkDone()}},
-        and |b| was last used exclusively on |q|, then |p2| must not resolve before |p1| resolves.
+        then |p1| must settle before |p2|.
+    </div>
+- <div algorithm="mapAsync-onSubmittedWorkDone ordering">
+        For some {{GPUQueue}} |q| and {{GPUBuffer}} |b| on the same {{GPUDevice}},
+        if |p1| = |b|.{{GPUBuffer/mapAsync()}} is called before
+        |p2| = |q|.{{GPUQueue/onSubmittedWorkDone()}},
+        then |p1| must settle before |p2|.
+
+        <!-- POSTV1(multi-queue):
+        and |b|'s most recent usage was either another mapping or an exclusive usage on |q| -->
     </div>
 
 Applications must not rely on any other promise settlement ordering.


### PR DESCRIPTION
- Between two onSubmittedWorkDone promises
- (Clarification) Between map-just-after-unmap and onSubmittedWorkDone