### PR TITLE
Define and use "clip space coordinates"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1050,7 +1050,7 @@ Rendering operations use the following coordinate systems:
     * Clip space coordinates are used for the the [=clip position=] of a vertex (i.e. the [=position builtin|position=] output of a vertex shader),
         and for the [=clip volume=].
     * [=NDC|Normalized device coordinates=] and clip space coordinates are related as follows:
-        If point *p = (p.x, p.y, p.z, p.w)* is in the [=clip volume=], then its normalized device coordinates are (*p.x* / *p.w*, *p.y* / *p.w*, *p.z* / *p.w*).
+        If point *p = (p.x, p.y, p.z, p.w)* is in the [=clip volume=], then its normalized device coordinates are (*p.x* &divide; *p.w*, *p.y* &divide; *p.w*, *p.z* &divide; *p.w*).
 * <dfn noexport>Framebuffer coordinates</dfn> address the pixels in the [=framebuffer=]
     * They have two dimensions.
     * Each pixel extends 1 unit in x and y dimensions.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -88,6 +88,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: shader stage output; url: shader-stage-output
         text: shader stage input; url: shader-stage-input
         text: builtin; url: built-in-values
+        text: position builtin; url: built-in-values-position
         text: channel formats; url: channel-formats
         text: invalid memory reference; url: invalid-memory-reference
         text: shader module creation; url: shader-module-creation
@@ -1045,6 +1046,11 @@ Rendering operations use the following coordinate systems:
     * -1.0 &leq; y &leq; 1.0
     * 0.0 &leq; z &leq; 1.0
     * The bottom-left corner is at (-1.0, -1.0, z).
+* <dfn noexport>Clip space coordinates</dfn> have four dimensions: (x, y, z, w)
+    * Clip space coordinates are used for the the [=clip position=] of a vertex (i.e. the [=position builtin|position=] output of a vertex shader),
+        and for the [=clip volume=].
+    * [=NDC|Normalized device coordinates=] and clip space coordinates are related as follows:
+        If point *p = (p.x, p.y, p.z, p.w)* is in the [=clip volume=], then its normalized device coordinates are (*p.x* / *p.w*, *p.y* / *p.w*, *p.z* / *p.w*).
 * <dfn noexport>Framebuffer coordinates</dfn> address the pixels in the [=framebuffer=]
     * They have two dimensions.
     * Each pixel extends 1 unit in x and y dimensions.
@@ -14456,10 +14462,8 @@ Primitives are assembled by a fixed-function stage of GPUs.
 
 ### Primitive Clipping ### {#primitive-clipping}
 
-Vertex shaders have to produce a built-in "position" (of type `vec4<f32>`),
+Vertex shaders have to produce a built-in [=position builtin|position=] (of type `vec4<f32>`),
 which denotes the <dfn dfn>clip position</dfn> of a vertex.
-
-<p class="note editorial">Editorial: link to WGSL built-ins
 
 Primitives are clipped to the <dfn dfn>clip volume</dfn>, which, for any [=clip position=] |p|
 inside a primitive, is defined by the following inequalities:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -262,6 +262,7 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
         text: shader-output mask; url: shader-output-mask
         text: framebuffer; url: framebuffer
         text: normalized device coordinates; url: ndc
+        text: clip space coordinates; url: clip-space-coordinates
         text: clip position; url: clip-position
         text: viewport; url: dom-renderstate-viewport-slot
         text: rasterizationpoint-destination; url: rasterizationpoint-destination
@@ -11441,7 +11442,8 @@ See [[#builtin-inputs-outputs]] for how to specify that a pipeline input or outp
       <td>vertex
       <td>output
       <td>vec4&lt;f32&gt;
-      <td style="width:50%">The [=clip position=] of the current vertex.
+      <td style="width:50%">The [=clip position=] of the current vertex,
+      in [=clip space coordinates=].
 
       An output value (*x*,*y*,*z*,*w*)
       [=behavioral requirement|will=] map to (*x*/*w*, *y*/*w*, *z*/*w*) in


### PR DESCRIPTION
Also, cross-reference to WGSL 'position' builtin.

Fixes: #4127