### PR TITLE
Allow reading storage buffers in vertex shaders (#4132).

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5968,6 +5968,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 {{GPUShaderStage/VERTEX}}:
                                 - |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
                                     must not be {{GPUBufferBindingType/"storage"}}.
+                                    Note that {{GPUBufferBindingType/"read-only-storage"}} is allowed.
                                 - |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}?.{{GPUStorageTextureBindingLayout/access}}
                                     must not be {{GPUStorageTextureAccess/"write-only"}}.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4464,7 +4464,7 @@ effective-value-type.
 4. [=Override-declarations=] are part of the shader interface, but are not
     bound resources.
 5. [=Storage buffers=] and [=type/storage textures=] cannot be [=statically accessed=]
-    in a [=vertex shader stage=].
+    in a [=vertex shader stage=] unless their access mode is [=access/read=].
     See WebGPU {{GPUDevice/createBindGroupLayout()}}.
 6. [=Atomic types=] can only appear in mutable storage buffers or workgroup
     variables.
@@ -8912,8 +8912,9 @@ WGSL [=predeclared|predeclares=] an [=enumerant=] for each address space, except
 shader stage=].
 
 [=Variables=] in the [=address spaces/storage=] address space ([=storage
-buffers=]) and variables whose [=store type=] is a
-[=type/storage texture=] cannot be [=statically accessed=] by a [=vertex shader stage=].
+buffers=]) and variables whose [=store type=] is a [=type/storage texture=]
+can be [=statically accessed=] by a [=vertex shader stage=] only if the 
+access mode is [=access/read=].
 See WebGPU {{GPUDevice/createBindGroupLayout()}}.
 
 Note: Each address space may have different performance characteristics.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8912,9 +8912,9 @@ WGSL [=predeclared|predeclares=] an [=enumerant=] for each address space, except
 shader stage=].
 
 [=Variables=] in the [=address spaces/storage=] address space ([=storage
-buffers=]) and variables whose [=store type=] is a [=type/storage texture=]
-can be [=statically accessed=] by a [=vertex shader stage=] only if the 
-access mode is [=access/read=].
+buffers=]) can only be [=statically accessed=] by a [=vertex shader stage=] if the access mode is [=access/read=]. 
+Variables whose [=store type=] is a [=type/storage texture=]
+cannot be [=statically accessed=] by a [=vertex shader stage=].
 See WebGPU {{GPUDevice/createBindGroupLayout()}}.
 
 Note: Each address space may have different performance characteristics.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4388,7 +4388,7 @@ effective-value-type.
 
 <tr><td class="nowrap">
         [=variable|var=]&lt;[=address spaces/storage=], read&gt;<br>
-        [=variable|var=]&lt;[=address spaces/storage=]&gt;<sup>5</sup>
+        [=variable|var=]&lt;[=address spaces/storage=]&gt;
     <td>Immutable
     <td>[=module scope|Module=]
     <td>[=type/concrete|Concrete=] [=host-shareable=]
@@ -4463,8 +4463,9 @@ effective-value-type.
     creation|pipeline-creation time=].
 4. [=Override-declarations=] are part of the shader interface, but are not
     bound resources.
-5. [=Storage buffers=] and [=type/storage textures=] cannot be [=statically accessed=]
-    in a [=vertex shader stage=] unless their access mode is [=access/read=].
+5. [=Storage buffers=] with a [=access/read_write=] acces mode and 
+    [=type/storage textures=] cannot be [=statically accessed=]
+    in a [=vertex shader stage=].
     See WebGPU {{GPUDevice/createBindGroupLayout()}}.
 6. [=Atomic types=] can only appear in mutable storage buffers or workgroup
     variables.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4463,7 +4463,7 @@ effective-value-type.
     creation|pipeline-creation time=].
 4. [=Override-declarations=] are part of the shader interface, but are not
     bound resources.
-5. [=Storage buffers=] with a [=access/read_write=] acces mode and 
+5. [=Storage buffers=] with an access mode other than [=access/read=] and 
     [=type/storage textures=] cannot be [=statically accessed=]
     in a [=vertex shader stage=].
     See WebGPU {{GPUDevice/createBindGroupLayout()}}.


### PR DESCRIPTION
I hope my wording is correct and unambiguous - I'm very new to WebGPU and have only read parts of the spec.

cf https://github.com/gpuweb/gpuweb/issues/4132