### PR TITLE
Improve the note about unexpected timestamp values

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13021,7 +13021,10 @@ a {{GPUBuffer}}, using {{GPUCommandEncoder}}.{{GPUCommandEncoder/resolveQuerySet
 
 Timestamp query requires {{GPUFeatureName/"timestamp-query"}} to be [=enabled for=] the device.
 
-Note: The timestamp values may be zero if the physical device reset timestamp counter, please ignore it and the following values.
+Note: The physical device may reset the timestamp counter occasionally, which can result in
+unexpected values such as negative deltas between timestamps that logically should be monotonically
+increasing. These instances should be rare and can safely be ignored. Applications should not be
+written in such a way that unexpected timestamps cause an application failure.
 
 Issue(gpuweb/gpuweb#4069): Write normative text about timestamp value resets.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9922,6 +9922,9 @@ dictionary GPUCommandEncoderDescriptor
     ::
         Writes a timestamp value into a querySet when all previous commands have completed executing.
 
+        Note: Timestamp query values are written in nanoseconds, but how the value is determined is
+        implementation-defined and may not increase monotonically. See [[#timestamp]] for details.
+
         <div algorithm=GPUCommandEncoder.writeTimestamp>
             <div data-timeline=content>
                 **Called on:** {{GPUCommandEncoder}} |this|.
@@ -10518,6 +10521,9 @@ dictionary GPUComputePassTimestampWrites {
         which the timestamp at the end of the compute pass will be written.
 </dl>
 
+Note: Timestamp query values are written in nanoseconds, but how the value is determined is
+implementation-defined and may not increase monotonically. See [[#timestamp]] for details.
+
 <script type=idl>
 dictionary GPUComputePassDescriptor
          : GPUObjectDescriptorBase {
@@ -10878,6 +10884,9 @@ dictionary GPURenderPassTimestampWrites {
         If defined, indicates the query index in {{GPURenderPassTimestampWrites/querySet}} into
         which the timestamp at the end of the render pass will be written.
 </dl>
+
+Note: Timestamp query values are written in nanoseconds, but how the value is determined is
+implementation-defined and may not increase monotonically. See [[#timestamp]] for details.
 
 <script type=idl>
 dictionary GPURenderPassDescriptor
@@ -13019,13 +13028,11 @@ Timestamp queries allow applications to write timestamps to a {{GPUQuerySet}}, u
 and then resolve timestamp values (in nanoseconds as a 64-bit unsigned integer) into
 a {{GPUBuffer}}, using {{GPUCommandEncoder}}.{{GPUCommandEncoder/resolveQuerySet()}}.
 
-While the timestamp is given in nanoseconds it's value is implementation defined and may not
-increase monotonically. The physical device may reset the timestamp counter occasionally, which can
-result in unexpected values such as negative deltas between timestamps that logically should be
-monotonically increasing. These instances should be rare and can safely be ignored. Applications
-should not be written in such a way that unexpected timestamps cause an application failure.
-
-Timestamp query requires {{GPUFeatureName/"timestamp-query"}} to be [=enabled for=] the device.
+Timestamp values are implementation defined and may not increase monotonically. The physical device
+may reset the timestamp counter occasionally, which can result in unexpected values such as negative
+deltas between timestamps that logically should be monotonically increasing. These instances should
+be rare and can safely be ignored. Applications should not be written in such a way that unexpected
+timestamps cause an application failure.
 
 <p tracking-vector>
 Timestamp queries can provide high-resolution GPU timing.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13019,14 +13019,13 @@ Timestamp queries allow applications to write timestamps to a {{GPUQuerySet}}, u
 and then resolve timestamp values (in nanoseconds as a 64-bit unsigned integer) into
 a {{GPUBuffer}}, using {{GPUCommandEncoder}}.{{GPUCommandEncoder/resolveQuerySet()}}.
 
+While the timestamp is given in nanoseconds it's value is implementation defined and may not
+increase monotonically. The physical device may reset the timestamp counter occasionally, which can
+result in unexpected values such as negative deltas between timestamps that logically should be
+monotonically increasing. These instances should be rare and can safely be ignored. Applications
+should not be written in such a way that unexpected timestamps cause an application failure.
+
 Timestamp query requires {{GPUFeatureName/"timestamp-query"}} to be [=enabled for=] the device.
-
-Note: The physical device may reset the timestamp counter occasionally, which can result in
-unexpected values such as negative deltas between timestamps that logically should be monotonically
-increasing. These instances should be rare and can safely be ignored. Applications should not be
-written in such a way that unexpected timestamps cause an application failure.
-
-Issue(gpuweb/gpuweb#4069): Write normative text about timestamp value resets.
 
 <p tracking-vector>
 Timestamp queries can provide high-resolution GPU timing.


### PR DESCRIPTION
Fixes #4069

Removes the reference to timestamps being zeroed out and instead encourages developers to be aware of occasional nonsensical values.