### PR TITLE
[editorial] Reorganize WGSL spec sections

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1525,6 +1525,156 @@ path: syntax/template_arg_comma_list.syntax.bs.include
 path: syntax/template_arg_expression.syntax.bs.include
 </pre>
 
+# Directives # {#directives}
+
+A <dfn noexport>directive</dfn> is a [=token=] sequence which modifies how a WGSL
+program is processed by a WebGPU implementation.
+
+Directives are optional.
+If present, all directives [=shader-creation error|must=] appear before any [=declarations=] or [[#const-assert-statement|const assertions]].
+
+<pre class=include>
+path: syntax/global_directive.syntax.bs.include
+</pre>
+
+## Extensions ## {#extensions}
+
+WGSL is expected to evolve over time.
+
+An <dfn noexport>extension</dfn> is a named grouping of a coherent
+set of modifications to the WGSL specification, consisting of any combination of:
+* Addition of new concepts and behaviors via new syntax, including:
+    * declarations, statements, attributes, and built-in functions.
+* Removal of restrictions in the current specification or in previously published extensions.
+* Syntax for reducing the set of permissible behaviors.
+* Syntax for limiting the features available to a part of the program.
+* A description of how the extension interacts with the existing specification, and optionally with other extensions.
+
+Hypothetically, extensions could:
+* Add numeric scalar types, such as different bit width integers.
+* Add syntax to constrain floating point rounding mode.
+* Add syntax to signal that a shader does not use atomic types.
+* Add new kinds of statements.
+* Add new built-in functions.
+* Add syntax to constrain how shader invocations execute.
+* Add new shader stages.
+
+There are two kinds of extensions: [=enable-extensions=] and [=language extensions=].
+
+### Enable Extensions ### {#enable-extensions-sec}
+
+An <dfn noexport>enable-extension</dfn> is an [=extension=] whose functionality is available only if:
+* The implementation supports it, and
+* The shader explicitly requests it via an [=enable directive=], and
+* The corresponding WebGPU {{GPUFeatureName}} was one of the required features requested when creating the {{GPUDevice}}.
+
+[=Enable-extensions=] are intended to expose hardware functionality that is not universally available.
+
+An <dfn noexport>enable directive</dfn> is a [=directive=] that turns on support for one or more enable-extensions.
+A [=shader-creation error=] results if the implementation does not support all the listed enable-extensions.
+
+<pre class=include>
+path: syntax/enable_directive.syntax.bs.include
+</pre>
+<pre class=include>
+path: syntax/enable_extension_list.syntax.bs.include
+</pre>
+
+Like other directives, if an [=enable directive=] is present, it must appear before all [=declarations=] and [[#const-assert-statement|const assertions]].
+Extension names are not [=identifiers=]: they do not [=resolve=] to [=declarations=].
+
+The valid [=enable-extensions=] are listed in the following table.
+<table class='data'>
+  <caption>Enable-extensions</caption>
+  <thead>
+    <tr><th>WGSL enable-extension
+        <th>WebGPU {{GPUFeatureName}}
+        <th>Description
+  </thead>
+  <tr><td><dfn noexport dfn-for="extension">`f16`</dfn>
+      <td>`"shader-f16"`
+      <td>The [=f16=] type is valid to use in the WGSL module. Otherwise, using [=f16=] (directly or indirectly) will result in a [=shader-creation error=].
+</table>
+
+<div class='example wgsl using extensions expect-error' heading="Using hypothetical enable-extensions">
+  <xmp highlight=wgsl>
+    // Enable a hypothetical extension for arbitrary precision floating point types.
+    enable arbitrary_precision_float;
+    enable arbitrary_precision_float; // A redundant enable directive is ok.
+
+    // Enable a hypothetical extension to control the rounding mode.
+    enable rounding_mode;
+
+    // Assuming arbitrary_precision_float enables use of:
+    //    - a type f<E,M>
+    //    - as a type in function return, formal parameters and let-declarations
+    //    - as a value constructor from AbstractFloat
+    //    - operands to division operator: /
+    // Assuming @rounding_mode attribute is enabled by the rounding_mode enable directive.
+    @rounding_mode(round_to_even)
+    fn halve_it(x : f<8, 7>) -> f<8, 7> {
+      let two = f<8, 7>(2);
+      return x / 2; // uses round to even rounding mode.
+    }
+  </xmp>
+</div>
+
+### Language Extensions ### {#language-extensions-sec}
+
+A <dfn noexport>language extension</dfn> is an [=extension=] which is automatically available if the implementation supports it.
+The program does not have to explicitly request it.
+
+[=Language extensions=] embody functionality which could reasonably be supported on any WebGPU implementation.
+If the feature is not universally available, that it is because some WebGPU implementation has not yet implemented it.
+
+Note: For example, do-while loops could be a language extension.
+
+The {{GPU/wgslLanguageFeatures}} member of the WebGPU {{GPU}} object lists the set of
+[=language extensions=] supported by the implementation.
+
+A <dfn noexport>requires-directive</dfn> is a [=directive=] that *documents* the program's use of one or more [=language extensions=].
+It does not change the functionality exposed by the implementation.
+A [=shader-creation error=] results if the implementation does not support one of the required extensions.
+
+A WGSL module *can* use a [=requires-directive=] to signal the potential for non-portability,
+and to signal the *intended* minimum bar for portability.
+
+Note: Tooling outside of a WebGPU implementation could check whether all the [=language extensions=] used by a
+program are covered by [=requires-directives=] in the program.
+
+<pre class=include>
+path: syntax/requires_directive.syntax.bs.include
+</pre>
+<pre class=include>
+path: syntax/software_extension_list.syntax.bs.include
+</pre>
+
+Like other directives, if a [=requires-directive=] is present, it must appear before all [=declarations=] and [[#const-assert-statement|const assertions]].
+Extension names are not [=identifiers=]: they do not [=resolves|resolve=] to [=declarations=].
+
+<table class='data'>
+  <caption>Language extensions</caption>
+  <thead>
+    <tr><th style="width:30%">WGSL language extension
+        <th>Description
+    <tr><td colspan=2 class=note><span class="marker">Note:</span> No [=language extensions=] are currently defined.
+  </thead>
+</table>
+
+Note: The intent is that, over time, WGSL will define language extensions embodying all functionality in language extensions commonly supported at that time.
+In a [=requires-directive=], these serve as a shorthand for listing all those common features.
+They represent progressively increasing sets of functionality, and can be thought of as language versions, of a sort.
+
+## Global Diagnostic Filter ## {#global-diagnostic-directive}
+
+A <dfn noexport>global diagnostic filter</dfn> is a diagnostic filter whose [=affected range=] is the whole WGSL module.
+It is a [=directive=], thus appearing before any [=module scope|module-scope=] declarations.
+It is spelled like the attribute form, but without the leading `@` (U+0040) code point, and with a terminating semicolon.
+
+<pre class=include>
+path: syntax/diagnostic_directive.syntax.bs.include
+</pre>
+
 # Declaration and Scope # {#declaration-and-scope}
 
 A <dfn noexport>declaration</dfn> associates an [=identifier=] with one of
@@ -8101,156 +8251,6 @@ path: syntax/attrib_end.syntax.bs.include
 </pre>
 <pre class=include>
 path: syntax/diagnostic_control.syntax.bs.include
-</pre>
-
-# Directives # {#directives}
-
-A <dfn noexport>directive</dfn> is a [=token=] sequence which modifies how a WGSL
-program is processed by a WebGPU implementation.
-
-Directives are optional.
-If present, all directives [=shader-creation error|must=] appear before any [=declarations=] or [[#const-assert-statement|const assertions]].
-
-<pre class=include>
-path: syntax/global_directive.syntax.bs.include
-</pre>
-
-## Extensions ## {#extensions}
-
-WGSL is expected to evolve over time.
-
-An <dfn noexport>extension</dfn> is a named grouping of a coherent
-set of modifications to the WGSL specification, consisting of any combination of:
-* Addition of new concepts and behaviors via new syntax, including:
-    * declarations, statements, attributes, and built-in functions.
-* Removal of restrictions in the current specification or in previously published extensions.
-* Syntax for reducing the set of permissible behaviors.
-* Syntax for limiting the features available to a part of the program.
-* A description of how the extension interacts with the existing specification, and optionally with other extensions.
-
-Hypothetically, extensions could:
-* Add numeric scalar types, such as different bit width integers.
-* Add syntax to constrain floating point rounding mode.
-* Add syntax to signal that a shader does not use atomic types.
-* Add new kinds of statements.
-* Add new built-in functions.
-* Add syntax to constrain how shader invocations execute.
-* Add new shader stages.
-
-There are two kinds of extensions: [=enable-extensions=] and [=language extensions=].
-
-### Enable Extensions ### {#enable-extensions-sec}
-
-An <dfn noexport>enable-extension</dfn> is an [=extension=] whose functionality is available only if:
-* The implementation supports it, and
-* The shader explicitly requests it via an [=enable directive=], and
-* The corresponding WebGPU {{GPUFeatureName}} was one of the required features requested when creating the {{GPUDevice}}.
-
-[=Enable-extensions=] are intended to expose hardware functionality that is not universally available.
-
-An <dfn noexport>enable directive</dfn> is a [=directive=] that turns on support for one or more enable-extensions.
-A [=shader-creation error=] results if the implementation does not support all the listed enable-extensions.
-
-<pre class=include>
-path: syntax/enable_directive.syntax.bs.include
-</pre>
-<pre class=include>
-path: syntax/enable_extension_list.syntax.bs.include
-</pre>
-
-Like other directives, if an [=enable directive=] is present, it must appear before all [=declarations=] and [[#const-assert-statement|const assertions]].
-Extension names are not [=identifiers=]: they do not [=resolve=] to [=declarations=].
-
-The valid [=enable-extensions=] are listed in the following table.
-<table class='data'>
-  <caption>Enable-extensions</caption>
-  <thead>
-    <tr><th>WGSL enable-extension
-        <th>WebGPU {{GPUFeatureName}}
-        <th>Description
-  </thead>
-  <tr><td><dfn noexport dfn-for="extension">`f16`</dfn>
-      <td>`"shader-f16"`
-      <td>The [=f16=] type is valid to use in the WGSL module. Otherwise, using [=f16=] (directly or indirectly) will result in a [=shader-creation error=].
-</table>
-
-<div class='example wgsl using extensions expect-error' heading="Using hypothetical enable-extensions">
-  <xmp highlight=wgsl>
-    // Enable a hypothetical extension for arbitrary precision floating point types.
-    enable arbitrary_precision_float;
-    enable arbitrary_precision_float; // A redundant enable directive is ok.
-
-    // Enable a hypothetical extension to control the rounding mode.
-    enable rounding_mode;
-
-    // Assuming arbitrary_precision_float enables use of:
-    //    - a type f<E,M>
-    //    - as a type in function return, formal parameters and let-declarations
-    //    - as a value constructor from AbstractFloat
-    //    - operands to division operator: /
-    // Assuming @rounding_mode attribute is enabled by the rounding_mode enable directive.
-    @rounding_mode(round_to_even)
-    fn halve_it(x : f<8, 7>) -> f<8, 7> {
-      let two = f<8, 7>(2);
-      return x / 2; // uses round to even rounding mode.
-    }
-  </xmp>
-</div>
-
-### Language Extensions ### {#language-extensions-sec}
-
-A <dfn noexport>language extension</dfn> is an [=extension=] which is automatically available if the implementation supports it.
-The program does not have to explicitly request it.
-
-[=Language extensions=] embody functionality which could reasonably be supported on any WebGPU implementation.
-If the feature is not universally available, that it is because some WebGPU implementation has not yet implemented it.
-
-Note: For example, do-while loops could be a language extension.
-
-The {{GPU/wgslLanguageFeatures}} member of the WebGPU {{GPU}} object lists the set of
-[=language extensions=] supported by the implementation.
-
-A <dfn noexport>requires-directive</dfn> is a [=directive=] that *documents* the program's use of one or more [=language extensions=].
-It does not change the functionality exposed by the implementation.
-A [=shader-creation error=] results if the implementation does not support one of the required extensions.
-
-A WGSL module *can* use a [=requires-directive=] to signal the potential for non-portability,
-and to signal the *intended* minimum bar for portability.
-
-Note: Tooling outside of a WebGPU implementation could check whether all the [=language extensions=] used by a
-program are covered by [=requires-directives=] in the program.
-
-<pre class=include>
-path: syntax/requires_directive.syntax.bs.include
-</pre>
-<pre class=include>
-path: syntax/software_extension_list.syntax.bs.include
-</pre>
-
-Like other directives, if a [=requires-directive=] is present, it must appear before all [=declarations=] and [[#const-assert-statement|const assertions]].
-Extension names are not [=identifiers=]: they do not [=resolves|resolve=] to [=declarations=].
-
-<table class='data'>
-  <caption>Language extensions</caption>
-  <thead>
-    <tr><th style="width:30%">WGSL language extension
-        <th>Description
-    <tr><td colspan=2 class=note><span class="marker">Note:</span> No [=language extensions=] are currently defined.
-  </thead>
-</table>
-
-Note: The intent is that, over time, WGSL will define language extensions embodying all functionality in language extensions commonly supported at that time.
-In a [=requires-directive=], these serve as a shorthand for listing all those common features.
-They represent progressively increasing sets of functionality, and can be thought of as language versions, of a sort.
-
-## Global Diagnostic Filter ## {#global-diagnostic-directive}
-
-A <dfn noexport>global diagnostic filter</dfn> is a diagnostic filter whose [=affected range=] is the whole WGSL module.
-It is a [=directive=], thus appearing before any [=module scope|module-scope=] declarations.
-It is spelled like the attribute form, but without the leading `@` (U+0040) code point, and with a terminating semicolon.
-
-<pre class=include>
-path: syntax/diagnostic_directive.syntax.bs.include
 </pre>
 
 # Entry Points # {#entry-points}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -344,7 +344,7 @@ that run on the GPU.
   </xmp>
 </div>
 
-## Technical Overview ## {#technical-overview}
+## Overview ## {#overview}
 
 WebGPU issues a unit of work to the GPU in the form of a [=GPU command=].
 WGSL is concerned with two kinds of GPU commands:
@@ -389,6 +389,8 @@ A WGSL program is organized into:
     * A set of values.
     * Constraints on supported expressions.
     * The semantics of those expressions.
+
+Note: A WGSL program is currently composed of a single [[#wgsl-module|WGSL module]].
 
 WGSL is an imperative language: behavior is specified as a sequence of statements to execute.
 Statements can:
@@ -519,7 +521,36 @@ The <dfn noexport>transpose</dfn> of an |c|-column |r|-row matrix |A| is the |r|
 The transpose of a column vector is defined by interpreting the column vector as a 1-row matrix.
 Similarly, the transpose of a row vector is defined by interpreting the row vector as a 1-column matrix.
 
-# Shader Lifecycle # {#shader-lifecycle}
+# WGSL Module # {#wgsl-module}
+
+A WGSL program is composed of a single WGSL module.
+
+A module is a sequence of optional [=directives=] followed by [=module scope=] [=declarations=] and [[#const-assert-statement|const_assert statements]].
+A module is organized into:
+* [[#directives|Directives]], which specify module-level behavior controls.
+* [[#functions|Functions]], which specify execution behavior.
+* [[#statements|Statements]], which are declarations or units of executable behavior.
+* [[#literals|Literals]], which are text representations for pure mathematical values.
+* [[#var-decls|Variables]], each providing a name for memory holding a value.
+* [[#value-decls|Constants]], each providing a name for a value computed at a specific time.
+* [[#expressions|Expressions]], each of which combines a set of values to produce a result value.
+* [[#types|Types]], each of which describes:
+    * A set of values.
+    * Constraints on supported expressions.
+    * The semantics of those expressions.
+* [[#attributes|Attributes]], which modify an object to specify extra information such as:
+    * Specifying the [[#shader-interface|interfaces]] to [[#entry-points|entry points]].
+    * Specifying [[#diagnostic-filtering|diagnostic filters]].
+
+<pre class=include>
+path: syntax/translation_unit.syntax.bs.include
+</pre>
+
+<pre class=include>
+path: syntax/global_decl.syntax.bs.include
+</pre>
+
+## Shader Lifecycle ## {#shader-lifecycle}
 
 There are four key events in the lifecycle of a WGSL program and the shaders it may contain.
 The first two correspond to the WebGPU API methods used to prepare a WGSL program
@@ -555,7 +586,7 @@ The events are ordered due to:
 *  data dependencies: shader execution requires a pipeline, and a pipeline requires a shader module.
 *  causality: the shader must start executing before it can finish executing.
 
-## Processing Errors ## {#processing-errors}
+## Errors ## {#errors}
 
 A WebGPU implementation may fail to process a shader for two reasons:
 
@@ -573,14 +604,14 @@ A processing error may occur during three phases in the shader lifecycle:
 
 * A <dfn export>shader-creation error</dfn>
     is an error feasibly detectable at [=shader module creation=] time.
-    Detection relies only on the WGSL program source text
+    Detection relies only on the WGSL module source text
     and other information available to the `createShaderModule` API method.
     Statements in this specification that describe something the program *must*
     do generally produce a shader-creation error if those assertions are violated.
 
 * A <dfn export>pipeline-creation error</dfn>
     is an error detectable at [=pipeline creation=] time.
-    Detection relies on the WGSL program source text
+    Detection relies on the WGSL module source text
     and other information available to the particular pipeline creation API method.
 
 * A <dfn export>dynamic error</dfn> is an error occurring during shader execution.
@@ -599,15 +630,15 @@ whether failure to meet a particular requirement
 results in a shader-creation, pipeline-creation, or dynamic error.
 
 The consequences of an error are as follows:
-* A WGSL program with a [=shader-creation error=] or [=pipeline-creation error=] error will not be incorporated
+* A WGSL module with a [=shader-creation error=] or [=pipeline-creation error=] error will not be incorporated
     into a [=pipeline=] and hence will not be executed.
 * Detectable errors [=behavioral requirement|will=] [=triggered|trigger=] a [=diagnostic=].
 * If a [=dynamic error=] occurs:
     * [=Memory accesses=] [=behavioral requirement|will=] be restricted to:
         * [=shader stage inputs=],
         * [=shader stage outputs=],
-        * any part of a [=resource=] bound to a variable in the WGSL program, and
-        * other variables declared in the WGSL program.
+        * any part of a [=resource=] bound to a variable in the WGSL module, and
+        * other variables declared in the WGSL module.
     * Otherwise, the program may not behave as described in the rest of this specification.
         Note: These effects may be non-local.
 
@@ -667,11 +698,11 @@ Triggered diagnostics [=behavioral requirement|will=] be processed as follows:
 7. If processing during [=pipeline creation=], [=severity/error=] diagnostics
     result in WebGPU validation failure when validating {{GPUProgrammableStage}}.
 
-Note: The rules allow an implementation to stop processing a WGSL program as soon as an error is detected.
+Note: The rules allow an implementation to stop processing a WGSL module as soon as an error is detected.
 Additionally, an analysis for a particular kind of warning can stop on the first warning,
 and an analysis for a particular kind of info diagnostic can stop on the first occurrence.
 WGSL does not specify the order to perform different kinds of analyses, or an ordering within a single analysis.
-Therefore, for the same WGSL program, different implementations may report different instances of diagnostics with the same severity.
+Therefore, for the same WGSL module, different implementations may report different instances of diagnostics with the same severity.
 
 ### Filterable Triggering Rules ### {#filterable-triggering-rules}
 
@@ -770,9 +801,7 @@ and the bodies of [=syntax/if_clause=], [=syntax/else_if_clause=], and [=syntax/
   </xmp>
 </div>
 
-A <dfn noexport>global diagnostic filter</dfn> is a diagnostic filter whose [=affected range=] is the whole WGSL program.
-It is a [=directive=], thus appearing before any [=module scope|module-scope=] declarations.
-It is spelled like the attribute form, but without the leading `@` (U+0040) code point, and with a terminating semicolon.
+A [=global diagnostic filter=] can be used to apply a diagnostic filter to the entire WGSL module.
 
 <div class='example wgsl global-scope' heading='Global diagnostic filter for derivative uniformity'>
   <xmp highlight=wgsl>
@@ -794,11 +823,6 @@ It is spelled like the attribute form, but without the leading `@` (U+0040) code
   </xmp>
 </div>
 
-
-<pre class=include>
-path: syntax/diagnostic_directive.syntax.bs.include
-</pre>
-
 Two [=diagnostic filters=] *DF*(*AR1*,*NS1*,*TR1*) and *DF*(*AR2*,*NS2*,*TR2*) <dfn dfn-for="diagnostic">conflict</dfn> when:
 * (*AR1* &equals; *AR2*), and
 * (*TR1* &equals; *TR2*), and
@@ -817,14 +841,54 @@ if one exists, is the diagnostic filter *DF(AR,NS,TR)* where:
 
 Because affected ranges nest, the nearest enclosing diagnostic is unique, or does not exist.
 
+## Limits ## {#limits}
+
+A WGSL implementation [=behavioral requirement|will=] support shaders that
+satisfy the following limits.
+A WGSL implementation may support shaders that go beyond the specified limits.
+
+Note: A WGSL implementation should issue an error if it does not support a
+shader that goes beyond the specified limits.
+
+<table class='data'>
+  <caption>Quantifiable shader complexity limits</caption>
+  <thead>
+    <tr><th>Limit<th>Minimum supported value
+  </thead>
+    <tr><td>Maximum number of members in a [=structure=] type<td>16383
+    <tr><td>Maximum [=nesting depth=] of a [=composite=] type<td>255
+    <tr><td>Maximum nesting depth of brace-enclosed statements in a function<td>127
+    <tr><td>Maximum number of [=formal parameter|parameters=] for a function<td>255
+    <tr><td>Maximum number of case selector values in a [=statement/switch=] statement<td>16383
+    <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
+            [=address spaces/function=] or [=address spaces/private=] address spaces
+
+            For the purposes of this limit, [=bool=] has a size of 1 byte.
+        <td>65535
+    <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
+            [=address spaces/workgroup=] address space.
+
+            For the purposes of this limit, [=bool=] has a size of 1 byte and a
+            [=fixed footprint|fixed-footprint=] array is treated as a [=creation-fixed
+            footprint=] array when substituting the override value.
+
+            This maps the WebGPU [=supported limits/maxComputeWorkgroupStorageSize=] limit
+            into a standalone WGSL limit.
+
+            Note: Several workgroup variables that individually
+            satisfy this limit can still combine to exceed the API limit.
+        <td>[=supported limits/maxComputeWorkgroupStorageSize|16384=]
+    <tr><td>Maximum number of elements in [=const-expression=] of [=array=] type<td>65535
+</table>
+
 # Textual Structure # {#textual-structure}
 
-The `text/wgsl` media type is used to identify content as a WGSL program.
+The `text/wgsl` media type is used to identify content as a WGSL module.
 See [[#text-wgsl-media-type]].
 
-A WGSL program is Unicode text using the UTF-8 encoding, with no byte order mark (BOM).
+A WGSL module is Unicode text using the UTF-8 encoding, with no byte order mark (BOM).
 
-WGSL program text consists of a sequence of Unicode [=code points=], grouped into contiguous non-empty sets forming:
+WGSL module text consists of a sequence of Unicode [=code points=], grouped into contiguous non-empty sets forming:
 * [=comments=]
 * [=tokens=]
 * [=blankspaces=]
@@ -833,7 +897,7 @@ The program text [=shader-creation error|must not=] include a null code point (`
 
 ## Parsing ## {#parsing}
 
-To parse a WGSL program:
+To parse a WGSL module:
 <blockquote>
 1. Remove [=comments=]:
     * Replace the first comment with a space code point (`U+0020`).
@@ -1209,7 +1273,7 @@ Values that are visually and semantically identical but use different Unicode ch
 Content authors are advised to use the same encoding sequence consistently or to avoid potentially troublesome
 characters when choosing values. For more information, see [[CHARMOD-NORM]].
 
-Note: A user agent should issue developer-visible warnings when the meaning of a WGSL program would change if
+Note: A user agent should issue developer-visible warnings when the meaning of a WGSL module would change if
 all instances of an identifier are replaced with one of that identifier's homographs.
 (A homoglyph is a sequence of code points that may appear the same to a reader as another sequence of code points.
 Examples of mappings to detect homoglyphs are the transformations, mappings, and matching algorithms mentioned in
@@ -1461,248 +1525,6 @@ path: syntax/template_arg_comma_list.syntax.bs.include
 path: syntax/template_arg_expression.syntax.bs.include
 </pre>
 
-## Attributes ## {#attributes}
-
-An <dfn noexport>attribute</dfn> modifies an object.
-WGSL provides a unified syntax for applying attributes.
-Attributes are used for a variety of purposes such as specifying the interface with the API.
-
-Generally speaking, from the language's point-of-view, attributes can be
-ignored for the purposes of type and semantic checking.
-Additionally, the attribute name is a [=context-dependent name=], and
-some attribute parameters are also context-dependent names.
-
-Unless explicitly permitted below, an attribute [=shader-creation error|must not=] be specified more than once per object or type.
-
-<table class='data'>
-  <caption>Attributes defined in WGSL</caption>
-  <thead>
-    <tr><th>Attribute<th>Valid Values<th>Description
-  </thead>
-
-  <tr><td><dfn noexport dfn-for="attribute">`align`</dfn>
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
-        [=shader-creation error|Must=] be positive.
-    <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
-
-    [=shader-creation error|Must=] be a power of 2.
-
-    Note: This attribute influences how a value of the enclosing structure type can appear in memory:
-    at which byte addresses the structure itself and its component members can appear.
-    In particular, the rules in [[#memory-layouts]] combine to imply the following constraint:
-
-    <p class="note" algorithm="implied constraint on align attribute">
-    If `align(`|n|`)` is applied to a member of |S|
-    with type |T|, and |S| is the [=store type=]
-    or contained in the store type for a variable in address space |C|,
-    then |n| [=shader-creation error|must=] satisfy:
-    |n|&nbsp;=&nbsp;|k|&nbsp;&times;&nbsp;[=RequiredAlignOf=](|T|,|C|)
-    for some positive integer |k|.
-    </p>
-
-  <tr><td><dfn noexport dfn-for="attribute">`binding`</dfn>
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
-        [=shader-creation error|Must=] be non-negative.
-    <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
-
-    Specifies the binding number of the resource in a bind [=attribute/group=].
-    See [[#resource-interface]].
-
-  <tr><td><dfn noexport dfn-for="attribute">`builtin`</dfn>
-    <td>[=shader-creation error|Must=] be an [=enumerant=] for a [=built-in value=].
-    <td>[=shader-creation error|Must=] only be applied to an entry point
-    function parameter, entry point return type, or member of a [=structure=].
-
-    Specifies that the associated object is a built-in value, as denoted by the specified [=enumerant=].
-    See [[#builtin-values]].
-
-  <tr><td><dfn noexport dfn-for="attribute">`const`</dfn>
-    <td>*None*
-    <td>Must only be applied to function declarations.
-
-    Specifies that the function can be used as a [=const-function=].
-    This attribute [=shader-creation error|must not=] be applied to a
-    user-defined function.
-
-    Note: This attribute is used as a notational convention to describe which
-    built-in functions can be used in [=const-expressions=].
-
-  <tr><td><dfn noexport dfn-for="attribute">`diagnostic`</dfn>
-    <td>Two parameters.
-
-        The first parameter is a [=syntax/severity_control_name=].
-
-        The second parameter is a [=syntax/diagnostic_rule_name=] token
-        specifying a [=diagnostic/triggering rule=].
-
-    <td>Specifies a [=range diagnostic filter=].  See [[#diagnostics]].
-
-        More than one [=attribute/diagnostic=] attribute may be specified on a syntactic form,
-        but they [=shader-creation error|must=] specify different [=diagnostic/triggering rules=].
-
-  <tr><td><dfn noexport dfn-for="attribute">`group`</dfn>
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
-        [=shader-creation error|Must=] be non-negative.
-    <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
-
-    Specifies the binding group of the resource.
-    See [[#resource-interface]].
-
-  <tr><td><dfn noexport dfn-for="attribute">`id`</dfn>
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
-        [=shader-creation error|Must=] be non-negative.
-    <td>[=shader-creation error|Must=] only be applied to an [=override-declaration=] of [=scalar=] type.
-
-    Specifies a numeric identifier as an alternate name for a
-    [=pipeline-overridable=] constant.
-
-  <tr><td><dfn noexport dfn-for="attribute">`interpolate`</dfn>
-    <td>One or two parameters.
-
-    The first parameter [=shader-creation error|must=] be an [=enumerant=] for an [=interpolation type=].
-
-    The second parameter, if present, [=shader-creation error|must=] be
-    an [=enumerant=] for the [=interpolation sampling=].
-
-    <td>[=shader-creation error|Must=] only be applied to a declaration that
-    has a [=attribute/location=] attribute applied.
-
-    Specifies how the user-defined IO [=shader-creation error|must=] be interpolated.
-    The attribute is only significant on user-defined [=vertex=] outputs
-    and [=fragment=] inputs.
-    See [[#interpolation]].
-
-  <tr><td><dfn noexport dfn-for="attribute">`invariant`</dfn>
-    <td>*None*
-    <td>[=shader-creation error|Must=] only be applied to the [=built-in values/position=] built-in value.
-
-    When applied to the [=built-in values/position=] [=built-in output value=] of a vertex
-    shader, the computation of the result is invariant across different
-    programs and different invocations of the same entry point.
-    That is, if the data and control flow match for two `position` outputs in
-    different entry points, then the result values are guaranteed to be the
-    same.
-    There is no affect on a `position` [=built-in input value=].
-
-    Note: This attribute maps to the `precise` qualifier in HLSL, and the
-    `invariant` qualifier in GLSL.
-
-  <tr><td><dfn noexport dfn-for="attribute">`location`</dfn>
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
-        [=shader-creation error|Must=] be non-negative.
-    <td>[=shader-creation error|Must=] only be applied to an entry point function parameter, entry point
-    return type, or member of a [=structure=] type.
-    [=shader-creation error|Must=] only be applied to declarations of objects with [=numeric scalar=]
-    or [=numeric vector=] type.
-    [=shader-creation error|Must not=] be used with the [=compute=] shader stage.
-
-    Specifies a part of the user-defined IO of an entry point.
-    See [[#input-output-locations]].
-
-  <tr><td><dfn noexport dfn-for="attribute">`must_use`</dfn>
-    <td>*None*
-    <td>[=shader-creation error|Must=] only be applied to the declaration of a [=function/function=] with a [=return type=].
-
-        Specifies that a [=function call|call=] to this function [=shader-creation error|must=] be used as an [=expression=].
-        That is, a call to this function [=shader-creation error|must=] not be the entirety of a [[#function-call-statement|function call statement]].
-
-        Note: Many functions return a value and do not have side effects.
-        It is often a programming defect to call such a function as the only thing in a function call statement.
-        Built-in functions with these properties are declared as `@must_use`.
-        User-defined functions can also have the `@must_use` attribute.
-
-        Note: To deliberately work around the `@must_use` rule, use a [=phony assignment=]
-        or [=value declaration|declare a value=] using the function call as the initializer.
-
-  <tr><td><dfn noexport dfn-for="attribute">`size`</dfn>
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
-        [=shader-creation error|Must=] be positive.
-    <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
-    The member type [=shader-creation error|must=] have [=creation-fixed footprint=].
-
-    The number of bytes reserved in the struct for this member.
-
-    This number [=shader-creation error|must=] be at least the [=byte-size=] of the type of the member:
-    <p algorithm="byte-size constraint">
-    If `size(`|n|`)` is applied to a member with type |T|, then [=SizeOf=](|T|)&nbsp;&leq;&nbsp;|n|.
-    </p>
-
-    See [[#memory-layouts]]
-
-  <tr><td><dfn noexport dfn-for="attribute">`workgroup_size`</dfn>
-    <td>One, two or three parameters.
-
-    Each parameter [=shader-creation error|must=] be a [=const-expression=] or an [=override-expression=].
-    All parameters [=shader-creation error|must=] be the same type, either [=i32=] or [=u32=].
-
-    A [=shader-creation error=] results if any specified parameter is a
-    [=const-expression=] that evaluates to a non-positive value.
-
-    A [=pipeline-creation error=] results if any specified parameter evaluates
-    to a non-positive value or exceeds an upper bound specified by the WebGPU
-    API, or if the product of the parameter values exceeds the upper bound
-    specified by the WebGPU API (see [[WebGPU#limits]]).
-    <td>[=shader-creation error|Must=] be applied to a [=compute shader stage|compute shader=] entry point function.
-    [=shader-creation error|Must not=] be applied to any other object.
-
-    Specifies the x, y, and z dimensions of the [=workgroup grid=] for the compute shader.
-
-    The first parameter specifies the x dimension.
-    The second parameter, if provided, specifies the y dimension, otherwise is assumed to be 1.
-    The third parameter, if provided, specifies the z dimension, otherwise is assumed to be 1.
-
-</table>
-
-The <dfn noexport>shader stage attributes</dfn> below
-designate a function as an [=entry point=] for a particular [=shader stage=].
-These attributes [=shader-creation error|must=] only be applied to [=function declarations=],
-and at most one may be present on a given function.
-They take no parameters.
-
-<table class='data'>
-  <caption>Shader Stage Attributes</caption>
-  <thead>
-    <tr><th>Attribute<th>Description
-  </thead>
-
-  <tr><td><dfn noexport dfn-for="attribute">`vertex`</dfn><br>
-    <td>Declares the function to be an [=entry point=] for the [=vertex shader stage=]
-    of a [=GPURenderPipeline|render pipeline=].
-
-  <tr><td><dfn noexport dfn-for="attribute">`fragment`</dfn><br>
-    <td>Declares the function to be an [=entry point=] for the [=fragment shader stage=]
-    of a [=GPURenderPipeline|render pipeline=].
-
-  <tr><td><dfn noexport dfn-for="attribute">`compute`</dfn><br>
-    <td>Declares the function to be an [=entry point=] for the [=compute shader stage=]
-    of a [=GPUComputePipeline|compute pipeline=].
-
-</table>
-
-<pre class=include>
-path: syntax/attribute.syntax.bs.include
-</pre>
-<pre class=include>
-path: syntax/attrib_end.syntax.bs.include
-</pre>
-<pre class=include>
-path: syntax/diagnostic_control.syntax.bs.include
-</pre>
-
-## Directives ## {#directives}
-
-A <dfn noexport>directive</dfn> is a [=token=] sequence which modifies how a WGSL
-program is processed by a WebGPU implementation.
-
-Directives are optional.
-If present, all directives [=shader-creation error|must=] appear before any [=declarations=] or [[#const-assert-statement|const assertions]].
-
-See [[#diagnostic-filtering]], [[#enable-extensions-sec]], and [[#language-extensions-sec]].
-
-<pre class=include>
-path: syntax/global_directive.syntax.bs.include
-</pre>
-
 # Declaration and Scope # {#declaration-and-scope}
 
 A <dfn noexport>declaration</dfn> associates an [=identifier=] with one of
@@ -1728,7 +1550,7 @@ Those contained declarations are therefore not at module-scope.
 Note: The only kind of declaration that contain another declaration is a [=function declaration=].
 
 Certain objects are provided by the WebGPU implementation, and are treated as
-if they have been declared before the start of the WGSL program source.
+if they have been declared before the start of the WGSL module source.
 We say such objects are <dfn noexport>predeclared</dfn>.
 For example, WGSL predeclares:
 * [=built-in functions=],
@@ -1903,14 +1725,14 @@ We distinguish between the *concept* of a type and the *syntax* in WGSL to denot
 In many cases the spelling of a type in this specification is the same as its WGSL syntax.
 For example:
 * the set of 32-bit unsigned integer values is spelled `u32` in this specification,
-    and also in a WGSL program.
+    and also in a WGSL module.
 * the spelling is different for structure types, or types containing structures.
 
 Some WGSL types are only used for analyzing a source program and
 for determining the program's runtime behavior.
 This specification will describe such types, but they do not appear in WGSL source text.
 
-Note: [=Reference types=] are not written in WGSL programs. See [[#ref-ptr-types]].
+Note: [=Reference types=] are not written in WGSL modules. See [[#ref-ptr-types]].
 
 ## Type Checking ## {#type-checking-section}
 
@@ -1951,7 +1773,7 @@ For example:
 * In a `let` declaration with an explicit type specified, the initializer
       expression [=shader-creation error|must=] evaluate to that type.
 
-<dfn noexport>Type checking</dfn> a successfully parsed WGSL program is the process of mapping
+<dfn noexport>Type checking</dfn> a successfully parsed WGSL module is the process of mapping
 each expression to its static type,
 and verifying that type requirements of each statement are satisfied.
 If type checking fails, a special case of a [=shader-creation error=], called a <dfn noexport>type error</dfn>, results.
@@ -2062,10 +1884,10 @@ A WGSL source program is <dfn noexport>well-typed</dfn> when:
 * The static type can be determined for each expression in the program by applying the type rules, and
 * The type requirements for each statement are satisfied.
 
-Otherwise there is a [=type error=] and the source program is not a valid WGSL program.
+Otherwise there is a [=type error=] and the source program is not a valid WGSL module.
 
 WGSL is a <dfn noexport>statically typed language</dfn>
-because type checking a WGSL program [=behavioral requirement|will=] either succeed or
+because type checking a WGSL module [=behavioral requirement|will=] either succeed or
 discover a type error, while only having to inspect the program source text.
 
 ### Type Rule Tables ### {#typing-tables-section}
@@ -3086,7 +2908,7 @@ The enumeration types exist, but cannot be spelled in WGSL source.
   <tr><td>[=access/read_write=]
   <tr><td rowspan=5>[=address space=]
 
-      Note: The `handle` address space is never written in a WGSL program source.
+      Note: The `handle` address space is never written in a WGSL source.
       <td>[=address spaces/function=]
   <tr><td>[=address spaces/private=]
   <tr><td>[=address spaces/workgroup=]
@@ -3213,8 +3035,8 @@ WGSL has two kinds of types for representing [=memory views=]:
 
         Here, |T| is the [=store type=].
 
-        Reference types are not written in WGSL program source;
-        instead they are used to analyze a WGSL program.
+        Reference types are not written in WGSL source;
+        instead they are used to analyze a WGSL module.
   <tr algorithm="pointer type">
     <td>|AS| is an [=address space=],<br>|T| is a [=storable=] type,<br>|AM| is an [=access mode=]
     <td>ptr&lt;|AS|,|T|,|AM|&gt;
@@ -3224,12 +3046,12 @@ WGSL has two kinds of types for representing [=memory views=]:
 
         Here, |T| is the [=store type=].
 
-        Pointer types may appear in WGSL program source.
+        Pointer types may appear in WGSL source.
 </table>
 
 Two pointer types are the same if and only if they have the same address space, store type, and access mode.
 
-When *analyzing* a WGSL program, reference and pointer types are fully parameterized by
+When *analyzing* a WGSL module, reference and pointer types are fully parameterized by
 an address space, a storable type, and an access mode.
 In code examples in this specification, the comments show this fully parameterized form.
 
@@ -3859,7 +3681,7 @@ Texel access is controlled via several properties of the sampler:
 : max anisotropy
 :: Controls the maximum anisotropy value used by the sampler.
 
-Samplers cannot be created in WGSL programs and their state (e.g. the
+Samplers cannot be created in WGSL modules and their state (e.g. the
 properties listed above) are immutable within a shader and can only be set by
 the WebGPU API.
 
@@ -4150,7 +3972,7 @@ A <dfn noexport>sampler types</dfn> are:
 </table>
 
 Samplers are parameterized when created in the WebGPU API.
-They cannot be modified by a WGSL program.
+They cannot be modified by a WGSL module.
 
 Samplers can only be used by the [[#texture-builtin-functions|texture built-in functions]].
 
@@ -4491,7 +4313,7 @@ effective-value-type.
 
 ## Variables vs Values ## {#var-vs-value}
 
-[=Variable declarations=] are the only mutable data in a WGSL program.
+[=Variable declarations=] are the only mutable data in a WGSL module.
 [=Value declarations=] are always immutable.
 Variables can be the basis of [=reference type|reference=] and [=pointer
 type|pointer=] values because variables have associated [=memory locations=],
@@ -5141,7 +4963,7 @@ The index value |i| of an [=indexing expression=] is an <dfn noexport>in-bounds 
     * |N| is [=NRuntime=] for the base, when the base is a reference to a [=runtime-sized=] array.
 
 The index value is an <dfn noexport>out-of-bounds index</dfn> when it is not an [=in-bounds index=].
-An out-of-bounds index is often a programming defect, and will often cause a [[#processing-errors|processing error]].
+An out-of-bounds index is often a programming defect, and will often cause a [[#errors|error]].
 See below for details.
 </div>
 
@@ -7689,9 +7511,9 @@ A function is invoked in one of the following ways:
 
 There are two kinds of functions:
 * A [=built-in function=] is provided by the WGSL implementation,
-    and is always available to a WGSL program.
+    and is always available to a WGSL module.
     See [[#builtin-functions]].
-* A <dfn noexport>user-defined function</dfn> is declared in a WGSL program.
+* A <dfn noexport>user-defined function</dfn> is declared in a WGSL module.
 
 ## Declaring a User-defined Function ## {#function-declaration-sec}
 
@@ -7974,7 +7796,7 @@ found as follows:
 #### Aliasing #### {#aliasing}
 
 While the [=originating variable=] of a [=root identifier=] is a dynamic concept that
-depends on the [=call sites=] for the function, WGSL programs can be
+depends on the [=call sites=] for the function, WGSL modules can be
 statically analyzed to determine the set of all possible [=originating
 variables=] for each root identifier.
 
@@ -8052,6 +7874,384 @@ of the following occur:
     }
   </xmp>
 </div>
+
+# Attributes # {#attributes}
+
+An <dfn noexport>attribute</dfn> modifies an object.
+WGSL provides a unified syntax for applying attributes.
+Attributes are used for a variety of purposes such as specifying the interface with the API.
+
+Generally speaking, from the language's point-of-view, attributes can be
+ignored for the purposes of type and semantic checking.
+Additionally, the attribute name is a [=context-dependent name=], and
+some attribute parameters are also context-dependent names.
+
+Unless explicitly permitted below, an attribute [=shader-creation error|must not=] be specified more than once per object or type.
+
+<table class='data'>
+  <caption>Attributes defined in WGSL</caption>
+  <thead>
+    <tr><th>Attribute<th>Valid Values<th>Description
+  </thead>
+
+  <tr><td><dfn noexport dfn-for="attribute">`align`</dfn>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
+        [=shader-creation error|Must=] be positive.
+    <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
+
+    [=shader-creation error|Must=] be a power of 2.
+
+    Note: This attribute influences how a value of the enclosing structure type can appear in memory:
+    at which byte addresses the structure itself and its component members can appear.
+    In particular, the rules in [[#memory-layouts]] combine to imply the following constraint:
+
+    <p class="note" algorithm="implied constraint on align attribute">
+    If `align(`|n|`)` is applied to a member of |S|
+    with type |T|, and |S| is the [=store type=]
+    or contained in the store type for a variable in address space |C|,
+    then |n| [=shader-creation error|must=] satisfy:
+    |n|&nbsp;=&nbsp;|k|&nbsp;&times;&nbsp;[=RequiredAlignOf=](|T|,|C|)
+    for some positive integer |k|.
+    </p>
+
+  <tr><td><dfn noexport dfn-for="attribute">`binding`</dfn>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
+        [=shader-creation error|Must=] be non-negative.
+    <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
+
+    Specifies the binding number of the resource in a bind [=attribute/group=].
+    See [[#resource-interface]].
+
+  <tr><td><dfn noexport dfn-for="attribute">`builtin`</dfn>
+    <td>[=shader-creation error|Must=] be an [=enumerant=] for a [=built-in value=].
+    <td>[=shader-creation error|Must=] only be applied to an entry point
+    function parameter, entry point return type, or member of a [=structure=].
+
+    Specifies that the associated object is a built-in value, as denoted by the specified [=enumerant=].
+    See [[#builtin-values]].
+
+  <tr><td><dfn noexport dfn-for="attribute">`const`</dfn>
+    <td>*None*
+    <td>Must only be applied to function declarations.
+
+    Specifies that the function can be used as a [=const-function=].
+    This attribute [=shader-creation error|must not=] be applied to a
+    user-defined function.
+
+    Note: This attribute is used as a notational convention to describe which
+    built-in functions can be used in [=const-expressions=].
+
+  <tr><td><dfn noexport dfn-for="attribute">`diagnostic`</dfn>
+    <td>Two parameters.
+
+        The first parameter is a [=syntax/severity_control_name=].
+
+        The second parameter is a [=syntax/diagnostic_rule_name=] token
+        specifying a [=diagnostic/triggering rule=].
+
+    <td>Specifies a [=range diagnostic filter=].  See [[#diagnostics]].
+
+        More than one [=attribute/diagnostic=] attribute may be specified on a syntactic form,
+        but they [=shader-creation error|must=] specify different [=diagnostic/triggering rules=].
+
+  <tr><td><dfn noexport dfn-for="attribute">`group`</dfn>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
+        [=shader-creation error|Must=] be non-negative.
+    <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
+
+    Specifies the binding group of the resource.
+    See [[#resource-interface]].
+
+  <tr><td><dfn noexport dfn-for="attribute">`id`</dfn>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
+        [=shader-creation error|Must=] be non-negative.
+    <td>[=shader-creation error|Must=] only be applied to an [=override-declaration=] of [=scalar=] type.
+
+    Specifies a numeric identifier as an alternate name for a
+    [=pipeline-overridable=] constant.
+
+  <tr><td><dfn noexport dfn-for="attribute">`interpolate`</dfn>
+    <td>One or two parameters.
+
+    The first parameter [=shader-creation error|must=] be an [=enumerant=] for an [=interpolation type=].
+
+    The second parameter, if present, [=shader-creation error|must=] be
+    an [=enumerant=] for the [=interpolation sampling=].
+
+    <td>[=shader-creation error|Must=] only be applied to a declaration that
+    has a [=attribute/location=] attribute applied.
+
+    Specifies how the user-defined IO [=shader-creation error|must=] be interpolated.
+    The attribute is only significant on user-defined [=vertex=] outputs
+    and [=fragment=] inputs.
+    See [[#interpolation]].
+
+  <tr><td><dfn noexport dfn-for="attribute">`invariant`</dfn>
+    <td>*None*
+    <td>[=shader-creation error|Must=] only be applied to the [=built-in values/position=] built-in value.
+
+    When applied to the [=built-in values/position=] [=built-in output value=] of a vertex
+    shader, the computation of the result is invariant across different
+    programs and different invocations of the same entry point.
+    That is, if the data and control flow match for two `position` outputs in
+    different entry points, then the result values are guaranteed to be the
+    same.
+    There is no affect on a `position` [=built-in input value=].
+
+    Note: This attribute maps to the `precise` qualifier in HLSL, and the
+    `invariant` qualifier in GLSL.
+
+  <tr><td><dfn noexport dfn-for="attribute">`location`</dfn>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
+        [=shader-creation error|Must=] be non-negative.
+    <td>[=shader-creation error|Must=] only be applied to an entry point function parameter, entry point
+    return type, or member of a [=structure=] type.
+    [=shader-creation error|Must=] only be applied to declarations of objects with [=numeric scalar=]
+    or [=numeric vector=] type.
+    [=shader-creation error|Must not=] be used with the [=compute=] shader stage.
+
+    Specifies a part of the user-defined IO of an entry point.
+    See [[#input-output-locations]].
+
+  <tr><td><dfn noexport dfn-for="attribute">`must_use`</dfn>
+    <td>*None*
+    <td>[=shader-creation error|Must=] only be applied to the declaration of a [=function/function=] with a [=return type=].
+
+        Specifies that a [=function call|call=] to this function [=shader-creation error|must=] be used as an [=expression=].
+        That is, a call to this function [=shader-creation error|must=] not be the entirety of a [[#function-call-statement|function call statement]].
+
+        Note: Many functions return a value and do not have side effects.
+        It is often a programming defect to call such a function as the only thing in a function call statement.
+        Built-in functions with these properties are declared as `@must_use`.
+        User-defined functions can also have the `@must_use` attribute.
+
+        Note: To deliberately work around the `@must_use` rule, use a [=phony assignment=]
+        or [=value declaration|declare a value=] using the function call as the initializer.
+
+  <tr><td><dfn noexport dfn-for="attribute">`size`</dfn>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
+        [=shader-creation error|Must=] be positive.
+    <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
+    The member type [=shader-creation error|must=] have [=creation-fixed footprint=].
+
+    The number of bytes reserved in the struct for this member.
+
+    This number [=shader-creation error|must=] be at least the [=byte-size=] of the type of the member:
+    <p algorithm="byte-size constraint">
+    If `size(`|n|`)` is applied to a member with type |T|, then [=SizeOf=](|T|)&nbsp;&leq;&nbsp;|n|.
+    </p>
+
+    See [[#memory-layouts]]
+
+  <tr><td><dfn noexport dfn-for="attribute">`workgroup_size`</dfn>
+    <td>One, two or three parameters.
+
+    Each parameter [=shader-creation error|must=] be a [=const-expression=] or an [=override-expression=].
+    All parameters [=shader-creation error|must=] be the same type, either [=i32=] or [=u32=].
+
+    A [=shader-creation error=] results if any specified parameter is a
+    [=const-expression=] that evaluates to a non-positive value.
+
+    A [=pipeline-creation error=] results if any specified parameter evaluates
+    to a non-positive value or exceeds an upper bound specified by the WebGPU
+    API, or if the product of the parameter values exceeds the upper bound
+    specified by the WebGPU API (see [[WebGPU#limits]]).
+    <td>[=shader-creation error|Must=] be applied to a [=compute shader stage|compute shader=] entry point function.
+    [=shader-creation error|Must not=] be applied to any other object.
+
+    Specifies the x, y, and z dimensions of the [=workgroup grid=] for the compute shader.
+
+    The first parameter specifies the x dimension.
+    The second parameter, if provided, specifies the y dimension, otherwise is assumed to be 1.
+    The third parameter, if provided, specifies the z dimension, otherwise is assumed to be 1.
+
+</table>
+
+The <dfn noexport>shader stage attributes</dfn> below
+designate a function as an [=entry point=] for a particular [=shader stage=].
+These attributes [=shader-creation error|must=] only be applied to [=function declarations=],
+and at most one may be present on a given function.
+They take no parameters.
+
+<table class='data'>
+  <caption>Shader Stage Attributes</caption>
+  <thead>
+    <tr><th>Attribute<th>Description
+  </thead>
+
+  <tr><td><dfn noexport dfn-for="attribute">`vertex`</dfn><br>
+    <td>Declares the function to be an [=entry point=] for the [=vertex shader stage=]
+    of a [=GPURenderPipeline|render pipeline=].
+
+  <tr><td><dfn noexport dfn-for="attribute">`fragment`</dfn><br>
+    <td>Declares the function to be an [=entry point=] for the [=fragment shader stage=]
+    of a [=GPURenderPipeline|render pipeline=].
+
+  <tr><td><dfn noexport dfn-for="attribute">`compute`</dfn><br>
+    <td>Declares the function to be an [=entry point=] for the [=compute shader stage=]
+    of a [=GPUComputePipeline|compute pipeline=].
+
+</table>
+
+<pre class=include>
+path: syntax/attribute.syntax.bs.include
+</pre>
+<pre class=include>
+path: syntax/attrib_end.syntax.bs.include
+</pre>
+<pre class=include>
+path: syntax/diagnostic_control.syntax.bs.include
+</pre>
+
+# Directives # {#directives}
+
+A <dfn noexport>directive</dfn> is a [=token=] sequence which modifies how a WGSL
+program is processed by a WebGPU implementation.
+
+Directives are optional.
+If present, all directives [=shader-creation error|must=] appear before any [=declarations=] or [[#const-assert-statement|const assertions]].
+
+<pre class=include>
+path: syntax/global_directive.syntax.bs.include
+</pre>
+
+## Extensions ## {#extensions}
+
+WGSL is expected to evolve over time.
+
+An <dfn noexport>extension</dfn> is a named grouping of a coherent
+set of modifications to the WGSL specification, consisting of any combination of:
+* Addition of new concepts and behaviors via new syntax, including:
+    * declarations, statements, attributes, and built-in functions.
+* Removal of restrictions in the current specification or in previously published extensions.
+* Syntax for reducing the set of permissible behaviors.
+* Syntax for limiting the features available to a part of the program.
+* A description of how the extension interacts with the existing specification, and optionally with other extensions.
+
+Hypothetically, extensions could:
+* Add numeric scalar types, such as different bit width integers.
+* Add syntax to constrain floating point rounding mode.
+* Add syntax to signal that a shader does not use atomic types.
+* Add new kinds of statements.
+* Add new built-in functions.
+* Add syntax to constrain how shader invocations execute.
+* Add new shader stages.
+
+There are two kinds of extensions: [=enable-extensions=] and [=language extensions=].
+
+### Enable Extensions ### {#enable-extensions-sec}
+
+An <dfn noexport>enable-extension</dfn> is an [=extension=] whose functionality is available only if:
+* The implementation supports it, and
+* The shader explicitly requests it via an [=enable directive=], and
+* The corresponding WebGPU {{GPUFeatureName}} was one of the required features requested when creating the {{GPUDevice}}.
+
+[=Enable-extensions=] are intended to expose hardware functionality that is not universally available.
+
+An <dfn noexport>enable directive</dfn> is a [=directive=] that turns on support for one or more enable-extensions.
+A [=shader-creation error=] results if the implementation does not support all the listed enable-extensions.
+
+<pre class=include>
+path: syntax/enable_directive.syntax.bs.include
+</pre>
+<pre class=include>
+path: syntax/enable_extension_list.syntax.bs.include
+</pre>
+
+Like other directives, if an [=enable directive=] is present, it must appear before all [=declarations=] and [[#const-assert-statement|const assertions]].
+Extension names are not [=identifiers=]: they do not [=resolve=] to [=declarations=].
+
+The valid [=enable-extensions=] are listed in the following table.
+<table class='data'>
+  <caption>Enable-extensions</caption>
+  <thead>
+    <tr><th>WGSL enable-extension
+        <th>WebGPU {{GPUFeatureName}}
+        <th>Description
+  </thead>
+  <tr><td><dfn noexport dfn-for="extension">`f16`</dfn>
+      <td>`"shader-f16"`
+      <td>The [=f16=] type is valid to use in the WGSL module. Otherwise, using [=f16=] (directly or indirectly) will result in a [=shader-creation error=].
+</table>
+
+<div class='example wgsl using extensions expect-error' heading="Using hypothetical enable-extensions">
+  <xmp highlight=wgsl>
+    // Enable a hypothetical extension for arbitrary precision floating point types.
+    enable arbitrary_precision_float;
+    enable arbitrary_precision_float; // A redundant enable directive is ok.
+
+    // Enable a hypothetical extension to control the rounding mode.
+    enable rounding_mode;
+
+    // Assuming arbitrary_precision_float enables use of:
+    //    - a type f<E,M>
+    //    - as a type in function return, formal parameters and let-declarations
+    //    - as a value constructor from AbstractFloat
+    //    - operands to division operator: /
+    // Assuming @rounding_mode attribute is enabled by the rounding_mode enable directive.
+    @rounding_mode(round_to_even)
+    fn halve_it(x : f<8, 7>) -> f<8, 7> {
+      let two = f<8, 7>(2);
+      return x / 2; // uses round to even rounding mode.
+    }
+  </xmp>
+</div>
+
+### Language Extensions ### {#language-extensions-sec}
+
+A <dfn noexport>language extension</dfn> is an [=extension=] which is automatically available if the implementation supports it.
+The program does not have to explicitly request it.
+
+[=Language extensions=] embody functionality which could reasonably be supported on any WebGPU implementation.
+If the feature is not universally available, that it is because some WebGPU implementation has not yet implemented it.
+
+Note: For example, do-while loops could be a language extension.
+
+The {{GPU/wgslLanguageFeatures}} member of the WebGPU {{GPU}} object lists the set of
+[=language extensions=] supported by the implementation.
+
+A <dfn noexport>requires-directive</dfn> is a [=directive=] that *documents* the program's use of one or more [=language extensions=].
+It does not change the functionality exposed by the implementation.
+A [=shader-creation error=] results if the implementation does not support one of the required extensions.
+
+A WGSL module *can* use a [=requires-directive=] to signal the potential for non-portability,
+and to signal the *intended* minimum bar for portability.
+
+Note: Tooling outside of a WebGPU implementation could check whether all the [=language extensions=] used by a
+program are covered by [=requires-directives=] in the program.
+
+<pre class=include>
+path: syntax/requires_directive.syntax.bs.include
+</pre>
+<pre class=include>
+path: syntax/software_extension_list.syntax.bs.include
+</pre>
+
+Like other directives, if a [=requires-directive=] is present, it must appear before all [=declarations=] and [[#const-assert-statement|const assertions]].
+Extension names are not [=identifiers=]: they do not [=resolves|resolve=] to [=declarations=].
+
+<table class='data'>
+  <caption>Language extensions</caption>
+  <thead>
+    <tr><th style="width:30%">WGSL language extension
+        <th>Description
+    <tr><td colspan=2 class=note><span class="marker">Note:</span> No [=language extensions=] are currently defined.
+  </thead>
+</table>
+
+Note: The intent is that, over time, WGSL will define language extensions embodying all functionality in language extensions commonly supported at that time.
+In a [=requires-directive=], these serve as a shorthand for listing all those common features.
+They represent progressively increasing sets of functionality, and can be thought of as language versions, of a sort.
+
+## Global Diagnostic Filter ## {#global-diagnostic-directive}
+
+A <dfn noexport>global diagnostic filter</dfn> is a diagnostic filter whose [=affected range=] is the whole WGSL module.
+It is a [=directive=], thus appearing before any [=module scope|module-scope=] declarations.
+It is spelled like the attribute form, but without the leading `@` (U+0040) code point, and with a terminating semicolon.
+
+<pre class=include>
+path: syntax/diagnostic_directive.syntax.bs.include
+</pre>
 
 # Entry Points # {#entry-points}
 
@@ -8266,6 +8466,217 @@ the corresponding builtin [=shader-creation error|must=] be an output for the en
 Note: The [=built-in values/position=] built-in is both an output of a vertex shader, and an input to the fragment shader.
 
 Collectively, built-in input and built-in output values are known as <dfn noexport>built-in values</dfn>.
+
+##### Built-in Values ##### {#builtin-values}
+
+The following table lists the available [=built-in values=].
+Each is a [=predeclared=] [=enumerant=].
+
+See [[#builtin-inputs-outputs]] for how to specify that a pipeline input or output is a built-in value.
+
+<table class='data'>
+  <caption>Built-in input and output values</caption>
+  <thead>
+    <tr><th>Predeclared Name<th>Stage<th>Input or Output<th>Type<th>Description
+  </thead>
+
+  <tr><td><dfn noexport dfn-for="built-in values">vertex_index</dfn>
+      <td>vertex
+      <td>input
+      <td>u32
+      <td style="width:50%">Index of the current vertex within the current API-level draw command,
+         independent of draw instancing.
+
+         For a non-indexed draw, the first vertex has an index equal to the `firstVertex` argument
+         of the draw, whether provided directly or indirectly.
+         The index is incremented by one for each additional vertex in the draw instance.
+
+         For an indexed draw, the index is equal to the index buffer entry for the
+         vertex, plus the `baseVertex` argument of the draw, whether provided directly or indirectly.
+
+  <tr><td><dfn noexport dfn-for="built-in values">instance_index</dfn>
+      <td>vertex
+      <td>input
+      <td>u32
+      <td style="width:50%">Instance index of the current vertex within the current API-level draw command.
+
+         The first instance has an index equal to the `firstInstance` argument of the draw,
+         whether provided directly or indirectly.
+         The index is incremented by one for each additional instance in the draw.
+
+  <tr><td rowspan=2><dfn noexport dfn-for="built-in values">position</dfn>
+      <td>vertex
+      <td>output
+      <td>vec4&lt;f32&gt;
+      <td style="width:50%">The [=clip position=] of the current vertex,
+      in [=clip space coordinates=].
+
+      An output value (*x*,*y*,*z*,*w*)
+      [=behavioral requirement|will=] map to (*x*/*w*, *y*/*w*, *z*/*w*) in
+      WebGPU [=normalized device coordinates=].
+
+      See [[WebGPU#coordinate-systems]] and [[WebGPU#primitive-clipping]].
+
+  <tr>
+      <td>fragment
+      <td>input
+      <td>vec4&lt;f32&gt;
+      <td style="width:50%">
+      <div algorithm="fragment position calculation">
+      Input position of the current fragment.
+
+      Let |fp| be the input position of the fragment.<br>
+      Let |rp| be the [=RasterizationPoint=] for the fragment.<br>
+      Let |vp| be the {{RenderState/[[viewport]]}} in effect for the draw command.
+
+      Then schematically:
+      <blockquote>
+      |fp|.xy = |rp|.[=rasterizationpoint-destination|destination=].[=fragmentdestination-position|position=]<br>
+      |fp|.z = |rp|.[=rasterizationpoint-depth|depth=]<br>
+      |fp|.w = |rp|.[=rasterizationpoint-perspectivedivisor|perspectiveDivisor=]
+      </blockquote>
+
+      In more detail:
+      *  |fp|.x and |fp|.y are the interpolated x and y coordinates of the
+          position the current fragment in
+          the [=framebuffer=].
+
+          The framebuffer is a two-dimensional grid of pixels with the top-left at (0.0,0.0)
+          and the bottom right at (|vp|.width, |vp|.height).
+          Each pixel has an extent of 1.0 unit in each of the x and y dimensions,
+          and pixel centers are at (0.5,0.5) offset from integer coordinates.
+
+      * |fp|.z is the interpolated depth of the current fragment.
+          For example:
+          * depth 0 in [=normalized device coordinates=] maps to |fp|.z = |vp|.minDepth,
+          * depth 1 in normalized device coordinates maps to |fp|.z = |vp|.maxDepth.
+
+      * |fp|.w is the perspective divisor for the fragment,
+          which is the interpolation of 1.0 &divide; |vertex_w|,
+          where |vertex_w| is the w component
+          of the [=built-in values/position=] output of the vertex shader.
+
+      See [[WebGPU#coordinate-systems]] and [[WebGPU#rasterization]].
+      </div>
+
+  <tr><td><dfn noexport dfn-for="built-in values">front_facing</dfn>
+      <td>fragment
+      <td>input
+      <td>bool
+      <td style="width:50%">True when the current fragment is on a [=front-facing=] primitive.
+         False otherwise.
+
+  <tr><td><dfn noexport dfn-for="built-in values">frag_depth</dfn>
+      <td>fragment
+      <td>output
+      <td>f32
+      <td style="width:50%">Updated depth of the fragment, in the viewport depth range.
+      See [[WebGPU#coordinate-systems]].
+
+  <tr><td><dfn noexport dfn-for="built-in values">local_invocation_id</dfn>
+      <td>compute
+      <td>input
+      <td>vec3&lt;u32&gt;
+      <td style="width:50%">The current invocation's [=local invocation ID=],
+            i.e. its position in the [=workgroup grid=].
+
+  <tr><td><dfn noexport dfn-for="built-in values">local_invocation_index</dfn>
+      <td>compute
+      <td>input
+      <td>u32
+      <td style="width:50%">The current invocation's [=local invocation index=], a linearized index of
+          the invocation's position within the [=workgroup grid=].
+
+  <tr><td><dfn noexport dfn-for="built-in values">global_invocation_id</dfn>
+      <td>compute
+      <td>input
+      <td>vec3&lt;u32&gt;
+      <td style="width:50%">The current invocation's [=global invocation ID=],
+          i.e. its position in the [=compute shader grid=].
+
+  <tr><td><dfn noexport dfn-for="built-in values">workgroup_id</dfn>
+      <td>compute
+      <td>input
+      <td>vec3&lt;u32&gt;
+      <td style="width:50%">The current invocation's [=workgroup ID=],
+          i.e. the position of the workgroup in overall [=compute shader grid=].
+
+          All invocations in the same workgroup have the same workgroup ID.
+
+          Workgroup IDs span from (0,0,0) to ([=group_count_x=] - 1, [=group_count_y=] - 1, [=group_count_z=] - 1).
+
+  <tr><td><dfn noexport dfn-for="built-in values">num_workgroups</dfn>
+      <td>compute
+      <td>input
+      <td>vec3&lt;u32&gt;
+      <td style="width:50%">The [=dispatch size=], `vec3<u32>(group_count_x,
+      group_count_y, group_count_z)`, of the compute shader
+      [[WebGPU#compute-pass-encoder-dispatch|dispatched]] by the API.
+
+  <tr><td><dfn noexport dfn-for="built-in values">sample_index</dfn>
+      <td>fragment
+      <td>input
+      <td>u32
+      <td style="width:50%">Sample index for the current fragment.
+         The value is least 0 and at most `sampleCount`-1, where
+         `sampleCount` is the MSAA sample {{GPUMultisampleState/count}}
+         specified for the GPU render pipeline.
+         <br>See [[WebGPU#gpurenderpipeline]].
+
+  <tr><td rowspan=2><dfn noexport dfn-for="built-in values">sample_mask</dfn>
+      <td>fragment
+      <td>input
+      <td>u32
+      <td style="width:50%">Sample coverage mask for the current fragment.
+         It contains a bitmask indicating which samples in this fragment are covered
+         by the primitive being rendered.
+         <br>See [[WebGPU#sample-masking]].
+
+  <tr>
+      <td>fragment
+      <td>output
+      <td>u32
+      <td style="width:50%">Sample coverage mask control for the current fragment.
+         The last value written to this variable becomes the
+         [=shader-output mask=].
+         Zero bits in the written value will cause corresponding samples in
+         the color attachments to be discarded.
+         <br>See [[WebGPU#sample-masking]].
+</table>
+
+<div class='example wgsl global-scope' heading="Declaring built-in values">
+  <xmp highlight=wgsl>
+    struct VertexOutput {
+      @builtin(position) my_pos: vec4<f32>
+    }
+
+    @vertex
+    fn vs_main(
+      @builtin(vertex_index) my_index: u32,
+      @builtin(instance_index) my_inst_index: u32,
+    ) -> VertexOutput {}
+
+    struct FragmentOutput {
+      @builtin(frag_depth) depth: f32,
+      @builtin(sample_mask) mask_out: u32
+    }
+
+    @fragment
+    fn fs_main(
+      @builtin(front_facing) is_front: bool,
+      @builtin(position) coord: vec4<f32>,
+      @builtin(sample_index) my_sample_index: u32,
+      @builtin(sample_mask) mask_in: u32,
+    ) -> FragmentOutput {}
+
+    @compute @workgroup_size(64)
+    fn cs_main(
+      @builtin(local_invocation_id) local_id: vec3<u32>,
+      @builtin(local_invocation_index) local_index: u32,
+      @builtin(global_invocation_id) global_id: vec3<u32>,
+   ) {}
+  </xmp>
+</div>
 
 #### User-defined Inputs and Outputs #### {#user-defined-inputs-outputs}
 
@@ -8638,186 +9049,6 @@ The following table shows examples of [=NRuntime=] for the `point` member of the
   </thead>
 </table>
 </div>
-
-# Extensions # {#extensions}
-
-WGSL is expected to evolve over time.
-
-An <dfn noexport>extension</dfn> is a named grouping of a coherent
-set of modifications to the WGSL specification, consisting of any combination of:
-* Addition of new concepts and behaviors via new syntax, including:
-    * declarations, statements, attributes, and built-in functions.
-* Removal of restrictions in the current specification or in previously published extensions.
-* Syntax for reducing the set of permissible behaviors.
-* Syntax for limiting the features available to a part of the program.
-* A description of how the extension interacts with the existing specification, and optionally with other extensions.
-
-Hypothetically, extensions could:
-* Add numeric scalar types, such as different bit width integers.
-* Add syntax to constrain floating point rounding mode.
-* Add syntax to signal that a shader does not use atomic types.
-* Add new kinds of statements.
-* Add new built-in functions.
-* Add syntax to constrain how shader invocations execute.
-* Add new shader stages.
-
-There are two kinds of extensions: [=enable-extensions=] and [=language extensions=].
-
-## Enable Extensions ## {#enable-extensions-sec}
-
-An <dfn noexport>enable-extension</dfn> is an [=extension=] whose functionality is available only if:
-* The implementation supports it, and
-* The shader explicitly requests it via an [=enable directive=], and
-* The corresponding WebGPU {{GPUFeatureName}} was one of the required features requested when creating the {{GPUDevice}}.
-
-[=Enable-extensions=] are intended to expose hardware functionality that is not universally available.
-
-An <dfn noexport>enable directive</dfn> is a [=directive=] that turns on support for one or more enable-extensions.
-A [=shader-creation error=] results if the implementation does not support all the listed enable-extensions.
-
-<pre class=include>
-path: syntax/enable_directive.syntax.bs.include
-</pre>
-<pre class=include>
-path: syntax/enable_extension_list.syntax.bs.include
-</pre>
-
-Like other directives, if an [=enable directive=] is present, it must appear before all [=declarations=] and [[#const-assert-statement|const assertions]].
-Extension names are not [=identifiers=]: they do not [=resolve=] to [=declarations=].
-
-The valid [=enable-extensions=] are listed in the following table.
-<table class='data'>
-  <caption>Enable-extensions</caption>
-  <thead>
-    <tr><th>WGSL enable-extension
-        <th>WebGPU {{GPUFeatureName}}
-        <th>Description
-  </thead>
-  <tr><td><dfn noexport dfn-for="extension">`f16`</dfn>
-      <td>`"shader-f16"`
-      <td>The [=f16=] type is valid to use in the WGSL program. Otherwise, using [=f16=] (directly or indirectly) will result in a [=shader-creation error=].
-</table>
-
-<div class='example wgsl using extensions expect-error' heading="Using hypothetical enable-extensions">
-  <xmp highlight=wgsl>
-    // Enable a hypothetical extension for arbitrary precision floating point types.
-    enable arbitrary_precision_float;
-    enable arbitrary_precision_float; // A redundant enable directive is ok.
-
-    // Enable a hypothetical extension to control the rounding mode.
-    enable rounding_mode;
-
-    // Assuming arbitrary_precision_float enables use of:
-    //    - a type f<E,M>
-    //    - as a type in function return, formal parameters and let-declarations
-    //    - as a value constructor from AbstractFloat
-    //    - operands to division operator: /
-    // Assuming @rounding_mode attribute is enabled by the rounding_mode enable directive.
-    @rounding_mode(round_to_even)
-    fn halve_it(x : f<8, 7>) -> f<8, 7> {
-      let two = f<8, 7>(2);
-      return x / 2; // uses round to even rounding mode.
-    }
-  </xmp>
-</div>
-
-## Language Extensions ## {#language-extensions-sec}
-
-A <dfn noexport>language extension</dfn> is an [=extension=] which is automatically available if the implementation supports it.
-The program does not have to explicitly request it.
-
-[=Language extensions=] embody functionality which could reasonably be supported on any WebGPU implementation.
-If the feature is not universally available, that it is because some WebGPU implementation has not yet implemented it.
-
-Note: For example, do-while loops could be a language extension.
-
-The {{GPU/wgslLanguageFeatures}} member of the WebGPU {{GPU}} object lists the set of
-[=language extensions=] supported by the implementation.
-
-A <dfn noexport>requires-directive</dfn> is a [=directive=] that *documents* the program's use of one or more [=language extensions=].
-It does not change the functionality exposed by the implementation.
-A [=shader-creation error=] results if the implementation does not support one of the required extensions.
-
-A WGSL program *can* use a [=requires-directive=] to signal the potential for non-portability,
-and to signal the *intended* minimum bar for portability.
-
-Note: Tooling outside of a WebGPU implementation could check whether all the [=language extensions=] used by a
-program are covered by [=requires-directives=] in the program.
-
-<pre class=include>
-path: syntax/requires_directive.syntax.bs.include
-</pre>
-<pre class=include>
-path: syntax/software_extension_list.syntax.bs.include
-</pre>
-
-Like other directives, if a [=requires-directive=] is present, it must appear before all [=declarations=] and [[#const-assert-statement|const assertions]].
-Extension names are not [=identifiers=]: they do not [=resolves|resolve=] to [=declarations=].
-
-<table class='data'>
-  <caption>Language extensions</caption>
-  <thead>
-    <tr><th style="width:30%">WGSL language extension
-        <th>Description
-    <tr><td colspan=2 class=note><span class="marker">Note:</span> No [=language extensions=] are currently defined.
-  </thead>
-</table>
-
-Note: The intent is that, over time, WGSL will define language extensions embodying all functionality in language extensions commonly supported at that time.
-In a [=requires-directive=], these serve as a shorthand for listing all those common features.
-They represent progressively increasing sets of functionality, and can be thought of as language versions, of a sort.
-
-# WGSL Program # {#wgsl-program}
-
-A WGSL program is a sequence of optional [=directives=] followed by [=module scope=] [=declarations=].
-
-<pre class=include>
-path: syntax/translation_unit.syntax.bs.include
-</pre>
-
-<pre class=include>
-path: syntax/global_decl.syntax.bs.include
-</pre>
-
-## Limits ## {#limits}
-
-A WGSL implementation [=behavioral requirement|will=] support shaders that
-satisfy the following limits.
-A WGSL implementation may support shaders that go beyond the specified limits.
-
-Note: A WGSL implementation should issue an error if it does not support a
-shader that goes beyond the specified limits.
-
-<table class='data'>
-  <caption>Quantifiable shader complexity limits</caption>
-  <thead>
-    <tr><th>Limit<th>Minimum supported value
-  </thead>
-    <tr><td>Maximum number of members in a [=structure=] type<td>16383
-    <tr><td>Maximum [=nesting depth=] of a [=composite=] type<td>255
-    <tr><td>Maximum nesting depth of brace-enclosed statements in a function<td>127
-    <tr><td>Maximum number of [=formal parameter|parameters=] for a function<td>255
-    <tr><td>Maximum number of case selector values in a [=statement/switch=] statement<td>16383
-    <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
-            [=address spaces/function=] or [=address spaces/private=] address spaces
-
-            For the purposes of this limit, [=bool=] has a size of 1 byte.
-        <td>65535
-    <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
-            [=address spaces/workgroup=] address space.
-
-            For the purposes of this limit, [=bool=] has a size of 1 byte and a
-            [=fixed footprint|fixed-footprint=] array is treated as a [=creation-fixed
-            footprint=] array when substituting the override value.
-
-            This maps the WebGPU [=supported limits/maxComputeWorkgroupStorageSize=] limit
-            into a standalone WGSL limit.
-
-            Note: Several workgroup variables that individually
-            satisfy this limit can still combine to exceed the API limit.
-        <td>[=supported limits/maxComputeWorkgroupStorageSize|16384=]
-    <tr><td>Maximum number of elements in [=const-expression=] of [=array=] type<td>65535
-</table>
 
 # Memory # {#memory}
 
@@ -9592,13 +9823,13 @@ with `NonPrivatePointer | MakePointerAvailable` memory operands with the
 
 # Execution # {#execution}
 
-[[#technical-overview]] describes how a shader is invoked and partitioned into [=invocations=].
+[[#overview]] describes how a shader is invoked and partitioned into [=invocations=].
 This section describes further constraints on how invocations execute,
 individually and collectively.
 
 ## Program Order Within an Invocation ## {#program-order}
 
-Each statement in a WGSL program may be executed zero or more times during
+Each statement in a WGSL module may be executed zero or more times during
 execution.
 For a given invocation, each execution of a given statement represents a unique
 <dfn noexport>dynamic statement instance</dfn>.
@@ -9616,7 +9847,7 @@ WGSL.
 For example, `foo() + bar()` must evaluate `foo()` before `bar()`.
 See [[#expressions]].
 
-Statements in a WGSL program are executed in control flow order.
+Statements in a WGSL module are executed in control flow order.
 See [[#statements]] and [[#function-calls]].
 
 ## Uniformity ## {#uniformity}
@@ -11295,7 +11526,7 @@ the source type is a floating point type with fewer exponent and mantissa bits t
 ## Reserved Words ## {#reserved-words}
 
 A <dfn>reserved word</dfn> is a [=token=] which is reserved for future use.
-A WGSL program [=shader-creation error|must not=] contain a reserved word.
+A WGSL module [=shader-creation error|must not=] contain a reserved word.
 
 The following are reserved words:
 
@@ -11414,221 +11645,10 @@ The [=swizzle=] names are used in [[#vector-access-expr|vector access expression
 path: syntax/swizzle_name.syntax.bs.include
 </pre>
 
-# Built-in Values # {#builtin-values}
-
-The following table lists the available [=built-in values=].
-Each is a [=predeclared=] [=enumerant=].
-
-See [[#builtin-inputs-outputs]] for how to specify that a pipeline input or output is a built-in value.
-
-<table class='data'>
-  <caption>Built-in input and output values</caption>
-  <thead>
-    <tr><th>Predeclared Name<th>Stage<th>Input or Output<th>Type<th>Description
-  </thead>
-
-  <tr><td><dfn noexport dfn-for="built-in values">vertex_index</dfn>
-      <td>vertex
-      <td>input
-      <td>u32
-      <td style="width:50%">Index of the current vertex within the current API-level draw command,
-         independent of draw instancing.
-
-         For a non-indexed draw, the first vertex has an index equal to the `firstVertex` argument
-         of the draw, whether provided directly or indirectly.
-         The index is incremented by one for each additional vertex in the draw instance.
-
-         For an indexed draw, the index is equal to the index buffer entry for the
-         vertex, plus the `baseVertex` argument of the draw, whether provided directly or indirectly.
-
-  <tr><td><dfn noexport dfn-for="built-in values">instance_index</dfn>
-      <td>vertex
-      <td>input
-      <td>u32
-      <td style="width:50%">Instance index of the current vertex within the current API-level draw command.
-
-         The first instance has an index equal to the `firstInstance` argument of the draw,
-         whether provided directly or indirectly.
-         The index is incremented by one for each additional instance in the draw.
-
-  <tr><td rowspan=2><dfn noexport dfn-for="built-in values">position</dfn>
-      <td>vertex
-      <td>output
-      <td>vec4&lt;f32&gt;
-      <td style="width:50%">The [=clip position=] of the current vertex,
-      in [=clip space coordinates=].
-
-      An output value (*x*,*y*,*z*,*w*)
-      [=behavioral requirement|will=] map to (*x*/*w*, *y*/*w*, *z*/*w*) in
-      WebGPU [=normalized device coordinates=].
-
-      See [[WebGPU#coordinate-systems]] and [[WebGPU#primitive-clipping]].
-
-  <tr>
-      <td>fragment
-      <td>input
-      <td>vec4&lt;f32&gt;
-      <td style="width:50%">
-      <div algorithm="fragment position calculation">
-      Input position of the current fragment.
-
-      Let |fp| be the input position of the fragment.<br>
-      Let |rp| be the [=RasterizationPoint=] for the fragment.<br>
-      Let |vp| be the {{RenderState/[[viewport]]}} in effect for the draw command.
-
-      Then schematically:
-      <blockquote>
-      |fp|.xy = |rp|.[=rasterizationpoint-destination|destination=].[=fragmentdestination-position|position=]<br>
-      |fp|.z = |rp|.[=rasterizationpoint-depth|depth=]<br>
-      |fp|.w = |rp|.[=rasterizationpoint-perspectivedivisor|perspectiveDivisor=]
-      </blockquote>
-
-      In more detail:
-      *  |fp|.x and |fp|.y are the interpolated x and y coordinates of the
-          position the current fragment in
-          the [=framebuffer=].
-
-          The framebuffer is a two-dimensional grid of pixels with the top-left at (0.0,0.0)
-          and the bottom right at (|vp|.width, |vp|.height).
-          Each pixel has an extent of 1.0 unit in each of the x and y dimensions,
-          and pixel centers are at (0.5,0.5) offset from integer coordinates.
-
-      * |fp|.z is the interpolated depth of the current fragment.
-          For example:
-          * depth 0 in [=normalized device coordinates=] maps to |fp|.z = |vp|.minDepth,
-          * depth 1 in normalized device coordinates maps to |fp|.z = |vp|.maxDepth.
-
-      * |fp|.w is the perspective divisor for the fragment,
-          which is the interpolation of 1.0 &divide; |vertex_w|,
-          where |vertex_w| is the w component
-          of the [=built-in values/position=] output of the vertex shader.
-
-      See [[WebGPU#coordinate-systems]] and [[WebGPU#rasterization]].
-      </div>
-
-  <tr><td><dfn noexport dfn-for="built-in values">front_facing</dfn>
-      <td>fragment
-      <td>input
-      <td>bool
-      <td style="width:50%">True when the current fragment is on a [=front-facing=] primitive.
-         False otherwise.
-
-  <tr><td><dfn noexport dfn-for="built-in values">frag_depth</dfn>
-      <td>fragment
-      <td>output
-      <td>f32
-      <td style="width:50%">Updated depth of the fragment, in the viewport depth range.
-      See [[WebGPU#coordinate-systems]].
-
-  <tr><td><dfn noexport dfn-for="built-in values">local_invocation_id</dfn>
-      <td>compute
-      <td>input
-      <td>vec3&lt;u32&gt;
-      <td style="width:50%">The current invocation's [=local invocation ID=],
-            i.e. its position in the [=workgroup grid=].
-
-  <tr><td><dfn noexport dfn-for="built-in values">local_invocation_index</dfn>
-      <td>compute
-      <td>input
-      <td>u32
-      <td style="width:50%">The current invocation's [=local invocation index=], a linearized index of
-          the invocation's position within the [=workgroup grid=].
-
-  <tr><td><dfn noexport dfn-for="built-in values">global_invocation_id</dfn>
-      <td>compute
-      <td>input
-      <td>vec3&lt;u32&gt;
-      <td style="width:50%">The current invocation's [=global invocation ID=],
-          i.e. its position in the [=compute shader grid=].
-
-  <tr><td><dfn noexport dfn-for="built-in values">workgroup_id</dfn>
-      <td>compute
-      <td>input
-      <td>vec3&lt;u32&gt;
-      <td style="width:50%">The current invocation's [=workgroup ID=],
-          i.e. the position of the workgroup in overall [=compute shader grid=].
-
-          All invocations in the same workgroup have the same workgroup ID.
-
-          Workgroup IDs span from (0,0,0) to ([=group_count_x=] - 1, [=group_count_y=] - 1, [=group_count_z=] - 1).
-
-  <tr><td><dfn noexport dfn-for="built-in values">num_workgroups</dfn>
-      <td>compute
-      <td>input
-      <td>vec3&lt;u32&gt;
-      <td style="width:50%">The [=dispatch size=], `vec3<u32>(group_count_x,
-      group_count_y, group_count_z)`, of the compute shader
-      [[WebGPU#compute-pass-encoder-dispatch|dispatched]] by the API.
-
-  <tr><td><dfn noexport dfn-for="built-in values">sample_index</dfn>
-      <td>fragment
-      <td>input
-      <td>u32
-      <td style="width:50%">Sample index for the current fragment.
-         The value is least 0 and at most `sampleCount`-1, where
-         `sampleCount` is the MSAA sample {{GPUMultisampleState/count}}
-         specified for the GPU render pipeline.
-         <br>See [[WebGPU#gpurenderpipeline]].
-
-  <tr><td rowspan=2><dfn noexport dfn-for="built-in values">sample_mask</dfn>
-      <td>fragment
-      <td>input
-      <td>u32
-      <td style="width:50%">Sample coverage mask for the current fragment.
-         It contains a bitmask indicating which samples in this fragment are covered
-         by the primitive being rendered.
-         <br>See [[WebGPU#sample-masking]].
-
-  <tr>
-      <td>fragment
-      <td>output
-      <td>u32
-      <td style="width:50%">Sample coverage mask control for the current fragment.
-         The last value written to this variable becomes the
-         [=shader-output mask=].
-         Zero bits in the written value will cause corresponding samples in
-         the color attachments to be discarded.
-         <br>See [[WebGPU#sample-masking]].
-</table>
-
-<div class='example wgsl global-scope' heading="Declaring built-in values">
-  <xmp highlight=wgsl>
-    struct VertexOutput {
-      @builtin(position) my_pos: vec4<f32>
-    }
-
-    @vertex
-    fn vs_main(
-      @builtin(vertex_index) my_index: u32,
-      @builtin(instance_index) my_inst_index: u32,
-    ) -> VertexOutput {}
-
-    struct FragmentOutput {
-      @builtin(frag_depth) depth: f32,
-      @builtin(sample_mask) mask_out: u32
-    }
-
-    @fragment
-    fn fs_main(
-      @builtin(front_facing) is_front: bool,
-      @builtin(position) coord: vec4<f32>,
-      @builtin(sample_index) my_sample_index: u32,
-      @builtin(sample_mask) mask_in: u32,
-    ) -> FragmentOutput {}
-
-    @compute @workgroup_size(64)
-    fn cs_main(
-      @builtin(local_invocation_id) local_id: vec3<u32>,
-      @builtin(local_invocation_index) local_index: u32,
-      @builtin(global_invocation_id) global_id: vec3<u32>,
-   ) {}
-  </xmp>
-</div>
-
 # Built-in Functions # {#builtin-functions}
 
 Certain functions are [=predeclared=], provided by the implementation, and
-therefore always available for use in a WGSL program.
+therefore always available for use in a WGSL module.
 These are called <dfn noexport>built-in functions</dfn>.
 
 A built-in function is a family of functions, all with the same name,
@@ -11660,7 +11680,7 @@ Wherever such a built-in function is used, the [=identifier=]
 
 Note: The structure types returned by [[#frexp-builtin|frexp]],
 [[#modf-builtin|modf]], and [[#atomic-rmw|atomicCompareExchangeWeak]] cannot be
-written in WGSL programs.
+written in WGSL modules.
 
 Note: A value declaration of the type needs to be valid at that statement of
 the WGSL text.
@@ -16773,7 +16793,7 @@ path: wgsl.recursive.bs.include
 
 The Internet Assigned Numbers Authority (IANA) maintains a registry of media types, at [[IANA-MEDIA-TYPES]].
 
-The following is the definition of the `text/wgsl` media type for WGSL programs.
+The following is the definition of the `text/wgsl` media type for WGSL modules.
 It has been registered at IANA,
 appearing at [https://www.iana.org/assignments/media-types/text/wgsl](https://www.iana.org/assignments/media-types/text/wgsl).
 


### PR DESCRIPTION
Fixes #4145

* Rename technical overview to overview
* Rename WGSL Program to WGSL Module
  * move earlier in the spec
  * inerit shader lifecycle and its subsections
* Move attributes to a new chapter
* Move directives to a new chapter
* Move built-in values into a subsection of built-in inputs and outputs

Left larger edits of the overview for #4153 and reworking the built-in values table for #4151.