### PR TITLE
Really fix link for localizable text

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -118,7 +118,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: SizeOf; url: sizeof
 spec: Internationalization Glossary; urlPrefix: https://www.w3.org/TR/i18n-glossary/#
     type: dfn
-        text: localizable text; url: def-localizable-text
+        text: localizable text; url: dfn-localizable-text
 spec: Strings on the Web; urlPrefix: https://w3c.github.io/string-meta/#
     type: dfn
         text: best practices for language and direction information; url: bp_and-reco


### PR DESCRIPTION
Fix introduced in #4095 to address #4079 had a typo, so link was still broken.