### PR TITLE
[editorial] Fix typo in uniformity table

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10332,6 +10332,7 @@ notations:
       <td>*Vin*(*next*)
       <td>*Vout*(*s1*)
   <tr><td>
+          if *e* *s1* else *s2*<br>
           where *Next* is in the behavior of *s2*, but not *s1*
       <td>*Vin*(*next*)
       <td>*Vout*(*s2*)


### PR DESCRIPTION
* Table entry was missing the statement description in function variable value analysis