### PR TITLE
Add VideoFrame to GPUImageCopyExternalImage source

### DIFF
--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -240,8 +240,14 @@ dictionary GPUImageCopyTextureTagged
 </h4>
 
 <script type=idl>
+typedef (ImageBitmap or
+         HTMLVideoElement or
+         VideoFrame or
+         HTMLCanvasElement or
+         OffscreenCanvas) GPUImageCopyExternalImageSource;
+
 dictionary GPUImageCopyExternalImage {
-    required (ImageBitmap or HTMLVideoElement or HTMLCanvasElement or OffscreenCanvas) source;
+    required GPUImageCopyExternalImageSource source;
     GPUOrigin2D origin = {};
     boolean flipY = false;
 };
@@ -272,6 +278,10 @@ dictionary GPUImageCopyExternalImage {
                     <td>{{HTMLVideoElement}}
                     <td>[=video/intrinsic width|intrinsic width of the frame=]
                     <td>[=video/intrinsic height|intrinsic height of the frame=]
+                <tr>
+                    <td>{{VideoFrame}}
+                    <td>{{VideoFrame/codedWidth|VideoFrame.codedWidth}}
+                    <td>{{VideoFrame/codedHeight|VideoFrame.codedHeight}}
                 <tr>
                     <td>{{HTMLCanvasElement}}
                     <td>{{HTMLCanvasElement/width|HTMLCanvasElement.width}}


### PR DESCRIPTION
@kainino0x Please review

FIX https://github.com/gpuweb/gpuweb/issues/4165