### PR TITLE
Make GPUObjectDescriptorBase.label default to the empty string.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -963,7 +963,7 @@ which is typically done via one of the `create*` methods of {{GPUDevice}}.
 
 <script type=idl>
 dictionary GPUObjectDescriptorBase {
-    USVString label;
+    USVString label = "";
 };
 </script>
 


### PR DESCRIPTION
Fixes #4083.