### PR TITLE
Remove expired attribute from JS example

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5213,17 +5213,13 @@ dictionary GPUExternalTextureDescriptor
         const videoElement = document.createElement('video');
         // ... set up videoElement, wait for it to be ready...
 
-        let externalTexture;
-
         function frame() {
             requestAnimationFrame(frame);
 
-            // Re-import only if necessary
-            if (!externalTexture || externalTexture.expired) {
-                externalTexture = gpuDevice.importExternalTexture({
-                    source: videoElement
-                });
-            }
+            // Always re-import, because textures are cached internally.
+            const externalTexture = gpuDevice.importExternalTexture({
+                source: videoElement
+            });
 
             // ... render using externalTexture...
         }

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5216,7 +5216,11 @@ dictionary GPUExternalTextureDescriptor
         function frame() {
             requestAnimationFrame(frame);
 
-            // Always re-import, because textures are cached internally.
+            // Always re-import the video on every animation frame, because the
+            // import is likely to have expired.
+            // The browser may cache and reuse a past frame, and if it does it
+            // may return the same GPUExternalTexture object again.
+            // In this case, old bind groups are still valid.
             const externalTexture = gpuDevice.importExternalTexture({
                 source: videoElement
             });


### PR DESCRIPTION
FIX https://github.com/gpuweb/gpuweb/issues/4161

@kainino0x Please review