### PR TITLE
Allow SharedArrayBuffer in writeBuffer/writeTexture with AllowSharedBufferSource

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12549,13 +12549,13 @@ interface GPUQueue {
     undefined writeBuffer(
         GPUBuffer buffer,
         GPUSize64 bufferOffset,
-        [AllowShared] BufferSource data,
+        AllowSharedBufferSource data,
         optional GPUSize64 dataOffset = 0,
         optional GPUSize64 size);
 
     undefined writeTexture(
         GPUImageCopyTexture destination,
-        [AllowShared] BufferSource data,
+        AllowSharedBufferSource data,
         GPUImageDataLayout dataLayout,
         GPUExtent3D size);
 


### PR DESCRIPTION
See https://github.com/whatwg/webidl/pull/1311 for context.

----

This might not pass CI right away, but it should tomorrow.