### PR TITLE
Update bikeshed to 3.13.1

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -36,6 +36,8 @@ Assume Explicit For: yes
 </pre>
 
 <pre class=link-defaults>
+spec:webidl; type:exception; text:TypeError
+spec:webidl; type:exception; text:RangeError
 </pre>
 <pre class=ignored-specs>
 spec:resource-hints;

--- a/tools/install-dependencies.sh
+++ b/tools/install-dependencies.sh
@@ -5,7 +5,7 @@ code=1
 for opt in "$@"; do
     case "$opt" in
         bikeshed)
-            pip3 install bikeshed==3.12.1
+            pip3 install bikeshed==3.13.1
             bikeshed update
             code=0
             ;;


### PR DESCRIPTION
Bikeshed 3.12.1 is broken with a 400 error on `bikeshed update`. Bikeshed 3.13.0+ fixes this, but makes some of our references newly-ambiguous for some reason, so this fixes those too.

Fixes #4199