### PR TITLE
Change all shell scripts to use bash and `set -eo pipefail`

### DIFF
--- a/tools/check-repo-clean.sh
+++ b/tools/check-repo-clean.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -eo pipefail
 
 status=$(git status -s)
 

--- a/tools/copy-if-different.sh
+++ b/tools/copy-if-different.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 usage()
 {

--- a/tools/install-dependencies.sh
+++ b/tools/install-dependencies.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -e
+#!/bin/bash
+set -eo pipefail
 
 code=1
 for opt in "$@"; do

--- a/tools/invoke-bikeshed.sh
+++ b/tools/invoke-bikeshed.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 if [ $# -lt 1 ] ; then
     echo "Usage: $0 output.html SOURCE_FILES..."

--- a/tools/invoke-mermaid.sh
+++ b/tools/invoke-mermaid.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -eo pipefail
 
 cfg_file=$(dirname "$0")/mermaid.json
 

--- a/tools/populate-out.sh
+++ b/tools/populate-out.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is called from the repository root. Populates out/ with everything to
 # publish on GitHub Pages and PR previews.
-set -e
+set -eo pipefail
 
 mkdir -p out/{wgsl,wgsl/grammar,explainer,correspondence}
 


### PR DESCRIPTION
This makes all the scripts exit early on failure so bugs will be caught more easily.

`set -e` exits the shell when any command fails, but only pays attention to the last command in a pipe. `set -o pipefail` is a bit better and catches that case too. It's only guaranteed to exist in bash, so change all the scripts to use bash.