### PR TITLE
fix(wgsl): fix invalid var decl example

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2071,7 +2071,7 @@ a result value, such as the non-result-value effects of its subexpressions.
     }
 
     fn bar() {
-      var a;
+      var a: i32;
       let x = foo(&a); // the call to foo returns a value
                        // and updates the value of a
     }


### PR DESCRIPTION
Hello, I believe this is an invalid example from reading https://gpuweb.github.io/gpuweb/wgsl/#var-and-value:

> Each such declaration must have an explicitly specified type or an initializer.