### PR TITLE
Fix many attributes for `override` summary

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4305,7 +4305,7 @@ Variable and value declarations have a similar overall syntax:
 <xmp highlight=wgsl>
   // Specific value declarations.
                const    name [: type]  = initializer ;
-  [attribute]  override name [: type] [= initializer];
+  [attribute]* override name [: type] [= initializer];
                let      name [: type]  = initializer ;
 
   // General variable form.


### PR DESCRIPTION
According to https://gpuweb.github.io/gpuweb/wgsl/#syntax-global_value_decl , there can be many or no attributes on an `override` declaration.