### PR TITLE
Always connect the uniformity graph after a function call.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10785,8 +10785,6 @@ The most complex rule is for function calls:
 
 Note: Refer to [[#func-var-value-analysis]] for the definition of *Vout*(*call*).
 
-A [=value constructor=] expression is analyzed as if it were a function call with the same arguments.
-
 Most built-in functions have tags of:
 - A [=call site tag=] of [=CallSiteNoRestriction=].
 - A [=function tag=] of [=NoRestriction=].

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10771,7 +10771,7 @@ The most complex rule is for function calls:
 - If the [=call site tag=] of the function is [=CallSiteRequiredToBeUniform.S=], then:
     - Add an edge from [=RequiredToBeUniform.S=] to the last [=CF_i=].
     - Add the members of the [=potential-trigger-set=] of the [=call site tag=] to the potential-trigger-set associated with [=RequiredToBeUniform.S=].
-- Otherwise add an edge from [=CF_after=] to the last [=CF_i=]
+- Add an edge from [=CF_after=] to the last [=CF_i=]
 - If the [=function tag=] is [=ReturnValueMayBeNonUniform=], then add an edge from [=Result=] to [=MayBeNonUniform=]
 - Add an edge from [=Result=] to [=CF_after=]
 - For each argument *i*:


### PR DESCRIPTION
For function calls, if the call was tagged as CallSiteRequiredToBeUniform.S (any severity) then no edge was added to link the before (last CF_i) and after (CF_after) the call. This was ok when the severity was always an error, but if the severity is warning or info, the rules will miss a collective operation requirement after the function call at a higher severity. It should always be safe to connect the control flow before and after. The disconnection was simply an optimization when diagnostics were always errors.