### PR TITLE
Clarify "inherited from" accuracy

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11499,8 +11499,11 @@ possibilities:
 * Correct result (for non-floating point return values).
 * [=Correctly rounded=].
 * A relative error bound expressed as [=ULP=].
-* A function that the accuracy is <dfn noexport>inherited from</dfn>.
-    That is, the accuracy is equal to implementing the operation in terms of the derived function.
+* An expression that the accuracy is <dfn noexport>inherited from</dfn>.
+    That is, the accuracy of the operation is defined as the accuracy of evaluating the given WGSL expression.
+    The given expression is only one valid implementation of the function.
+    A WebGPU implementation may implement the operation differently, with better accuracy
+    or with greater tolerance for extreme inputs.
 * An absolute error bound.
 
 For any accuracy values specified over a range, the accuracy is undefined for


### PR DESCRIPTION
The given expression is only one valid implementation. The implementation may do something better.