### PR TITLE
fix(wgsl): fix doc of reference ray

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -481,7 +481,7 @@ Following syntax notation describes the conventions of the syntactic grammar of 
 
 <dfn noexport>Angles</dfn>:
 * By convention, angles are measured in radians.
-* The reference ray for measuring angles is the ray from the origin (0,0) toward (0,&infin;).
+* The reference ray for measuring angles is the ray from the origin (0,0) toward (+&infin;,0).
 * Let &theta; be the angle subtended by a comparison ray and the reference ray.
     Then &theta; increases as the comparison ray moves counterclockwise.
 * There are 2 &pi; radians in a complete circle.


### PR DESCRIPTION
If I understand correctly, the definition of reference ray should follow the common math convention where the initial side of the angle is on the positive x-axis.

after the fix, it's consistent with examples.