### PR TITLE
Relate fp edge cases to IEEE 754 exceptions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2298,7 +2298,7 @@ WGSL defines two <dfn>abstract numeric types</dfn> for these evaluations:
     in the [[!IEEE-754|IEEE-754]] binary64 (double precision) format.
 
 An evaluation of an expression in one of these types [=shader-creation
-error|must not=] overflow or produce infinite, NaN, undefined, or [=indeterminate value|indeterminate=] results.
+error|must not=] overflow or produce an infinite or NaN value.
 
 A type is <dfn dfn-for="type" noexport>abstract</dfn> if it is an abstract
 numeric type or contains an abstract numeric type.
@@ -11404,28 +11404,40 @@ If one of these functions is called in non-uniform control flow, then the result
 ## Floating Point Evaluation ## {#floating-point-evaluation}
 
 WGSL follows the [[!IEEE-754|IEEE-754]] standard for floating point computation with
-the following exceptions:
+the following differences:
+* No rounding mode is specified. An implementation may round a value up or down.
 * No floating point exceptions are generated.
+    * A floating point operation in WGSL [=behavioral requirement|will=] produce an intermediate result
+        according to IEEE-754 rules, but exceptions mandated by IEEE-754 will map to different
+        behaviors depending on whether the expression is
+        a [=const-expression=], an [=override-expression=], or a [=runtime expression=].
+    * IEEE-754 defines five kinds of exceptions:
+        * Invalid operation. These operations yield a NaN.  An example of an invalid operation is 0 &times; &infin;.
+        * Division by zero. This occurs when an operation on finite operands is defined as having an exact infinite result.
+            Examples are 1 &divide; 0, and log(0).
+        * Overflow. See [[#floating-point-overflow]].
+        * Underflow. This occurs when the rounded or unrounded result is subnormal.
+        * Inexact. This occurs when the rounded result is different from the intermediate result,
+            or when overflow occurs.
+    * Consider an operation on finite operands.
+        The operation produces overflow, infinity, or a NaN if and only if IEEE-754 would require the
+        operation to signal an invalid operation, division-by-zero, or overflow exception.
 * Signaling NaNs may not be generated.
     Any signaling NaN may be converted to a quiet NaN.
-* No rounding mode is specified. An implementation may round a value up or down.
-* Infinities and NaNs generated before runtime are errors.
+* Overflow, infinities, and NaNs generated before runtime are errors.
     * [=Const-expressions=] and [=override-expressions=] over finite values
-        [=behavioral requirement|will=] generate infinities and NaNs
-        as intermediate values, following IEEE-754 rules. See [[#floating-point-overflow]].
-        * For example, IEEE-754 prescribes when
-            adding two finite values will overflow and produce an infinite value result.
-            A const-expression or override-expression of a floating point addition
-            must produce an infinite intermediate value result under the same conditions.
-        * Note: This rule requires implementations to reliably detect infinities and NaNs,
-            to within accuracy limits, so that errors can be generated consistently.
+        [=behavioral requirement|will=] generate overflow, infinities, and NaNs
+        as intermediate values, following IEEE-754 rules.
+        * Note: This rule requires implementations to reliably detect overflow, infinities, and NaNs
+            to within accuracy limits for these kinds of expressions, so that errors can be generated consistently.
     * A [=shader-creation error=] results if any [=const-expression=] of
-        floating-point type evaluates to NaN or infinity.
+        floating-point type overflows or evaluates to NaN or infinity.
     * A [=pipeline-creation error=] results if any [=override-expression=] of
-        floating-point type evaluates to NaN or infinity.
-* Implementations may assume that NaNs and infinities are not present at runtime.
-    * In such an implementation, when a [=runtime expression=] evaluation would produce an
-        infinity or a NaN, an [=indeterminate value=] of the target type is produced instead.
+        floating-point type overflows or evaluates to NaN or infinity.
+* Implementations may assume that overflow, infinities, and NaNs are not present at runtime.
+    * In such an implementation, if the intermediate result of evaluating a [=runtime expression=] overflows,
+        or yields infinity or a NaN, the final result [=behavioral requirement|will=] be
+        an [=indeterminate value=] of the target type.
     * Note: This means some functions (e.g. `min` and `max`)
         may not return the expected result due to optimizations about the presence
         of NaNs and infinities.
@@ -13878,7 +13890,8 @@ but a value may infer the type.
     * When `e` is zero, the fraction is zero.
     * When `e` is non-zero and normal, `e` &equals; `fraction * 2`<sup>`exponent`</sup>, where
         the fraction is in the range [0.5, 1.0) or (-1.0, -0.5].
-    * When `e` is denormalized, the fraction and exponent are [=indeterminate values=].
+    * When `e` is denormalized, the fraction and exponent are have unbounded error.
+        The fraction may be any AbstractFloat value, and the exponent may be any AbstractInt value.
 
     Note: AbstractFloat expressions resulting in infinity or NaN cause a [=shader-creation error=].
 
@@ -14002,6 +14015,8 @@ but a value may infer the type.
     * When `ei` is zero, the fraction is zero.
     * When `ei` is non-zero and normal, `ei` &equals; `fraction * 2`<sup>`exponent`</sup>, where
         the fraction is in the range [0.5, 1.0) or (-1.0, -0.5].
+    * When `ei` is denormalized, the fraction and exponent are have unbounded error.
+        The fraction may be any AbstractFloat value, and the exponent may be any AbstractInt value.
 
     Note: AbstractFloat expressions resulting in infinity or NaN cause a [=shader-creation error=].
 


### PR DESCRIPTION
Also, "indeterminate value" is not allowed for abstract numeric expressions. Update frexp(AbstractFloat) variants to say the result has unbounded error when the argument is denormalized.