### PR TITLE
Add note that user-defined functions only have one overload.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7677,11 +7677,11 @@ There are two kinds of functions:
 * A [=built-in function=] is provided by the WGSL implementation,
     and is always available to a WGSL module.
     See [[#builtin-functions]].
-* A <dfn noexport>user-defined function</dfn> is declared in a WGSL module.
+* A [=user-defined function=] is declared in a WGSL module.
 
 ## Declaring a User-defined Function ## {#function-declaration-sec}
 
-A <dfn noexport>function declaration</dfn> creates a user-defined function, by specifying:
+A <dfn noexport>function declaration</dfn> creates a <dfn noexport>user-defined function</dfn>, by specifying:
 * An optional set of [=attributes=].
 * The name of the function.
 * The formal parameter list: an ordered sequence of zero
@@ -7695,6 +7695,8 @@ A <dfn noexport>function declaration</dfn> creates a user-defined function, by s
 
 A function declaration [=shader-creation error|must=] only occur at [=module scope=].
 A function name is [=in scope=] for the entire program.
+
+Note: Each [=user-defined function=] only has one [=overload=].
 
 A <dfn noexport>formal parameter</dfn> [=declaration=] specifies an [=identifier=] name and a type for a value that [=shader-creation error|must=] be
 provided when invoking the function.


### PR DESCRIPTION
Add the note to the section about declaring user-defined functions.

Also, the definition of a user-defined function is in that section, rather than the forward reference in the previous section.