### PR TITLE
Adjust Makefile to Handle wgsl Dependency Issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 # This should be invoked with make -j for full parallelism.
 SHELL := /bin/bash
 
-targets := spec wgsl explainer correspondence
+# TODO: Include wgsl as a target once dependencies respect wgsl.so creation
+# and until then, execute make without -j
+targets := spec explainer correspondence
 
-.PHONY: all out $(targets) clean
+.PHONY: all out $(targets) wgsl clean
 
 # Build everything
-all: $(targets)
+all: $(targets) wgsl
 
 # Build everything, and copy it to out/
 out: all
@@ -14,6 +16,9 @@ out: all
 
 $(targets):
 	make -j -C $@
+
+wgsl:
+	make -C wgsl
 
 # Clean up all (or at least most) generated files
 clean:


### PR DESCRIPTION
This PR introduces modifications to the `Makefile` to address CI errors observed with the `wgsl` target.

* `wgsl` has been temporarily removed from the parallel build targets to ensure `wgsl.so` creation dependencies are respected. A TODO note is in place to revisit and potentially revert this once the dependency challenges are addressed.
* A separate directive has been introduced for the `wgsl` target to manage its build process.

Feedback and reviews on this PR are highly appreciated! We had a small discussion at the editors' call for WGSL about going this direction.