### PR TITLE
Clarify that *concrete* fixed-footprint types are storable

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3002,7 +3002,7 @@ module creation|shader creation=] time.
 A type has a <dfn>fixed footprint</dfn> if its size is fully determined
 at [=pipeline creation=] time.
 
-All creation-fixed footprint and fixed footprint types are [=storable=].
+Note: All [=concrete=] creation-fixed footprint and fixed footprint types are [=storable=].
 
 Note: Pipeline creation depends on shader creation, so a type with [=creation-fixed footprint=] also has [=fixed footprint=].
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3002,7 +3002,7 @@ module creation|shader creation=] time.
 A type has a <dfn>fixed footprint</dfn> if its size is fully determined
 at [=pipeline creation=] time.
 
-Note: All [=concrete=] creation-fixed footprint and fixed footprint types are [=storable=].
+Note: All [=type/concrete=] creation-fixed footprint and fixed footprint types are [=storable=].
 
 Note: Pipeline creation depends on shader creation, so a type with [=creation-fixed footprint=] also has [=fixed footprint=].
 


### PR DESCRIPTION
Fixes: #4212