### PR TITLE
Remove wgsl_unit_tests

### DIFF
--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -51,8 +51,6 @@ unit_tests: $(TREESITTER_PARSER) wgsl_unit_tests.py
 WGSL_GRAMMAR=grammar/src/grammar.json
 $(WGSL_GRAMMAR) : $(TREESITTER_GRAMMAR_INPUT)
 
-wgsl_unit_tests: 
-
 .PHONY: nfkc
 nfkc:
 	python3 ../tools/check-nfkc.py


### PR DESCRIPTION
Trying to triangulate source of error for dylib issue, but this recipe seems empty. In case it is not meaningful for the Makefile (I don't see any reference to it), pruning could be beneficial.