### PR TITLE
Add unorm10-10-10-2 vertex format

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8901,6 +8901,7 @@ enum GPUVertexFormat {
     "sint32x2",
     "sint32x3",
     "sint32x4",
+    "rgb10a2",
 };
 </script>
 
@@ -9094,6 +9095,12 @@ enum GPUVertexFormat {
             <td>4
             <td>16
             <td><code>vec4&lt;i32&gt;</code>
+        <tr>
+            <td><dfn>"rgb10a2"</dfn>
+            <td>unsigned normalized
+            <td>4
+            <td>4
+            <td><code>vec4&lt;f32&gt;</code>
     </tbody>
 </table>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8901,7 +8901,7 @@ enum GPUVertexFormat {
     "sint32x2",
     "sint32x3",
     "sint32x4",
-    "rgb10a2",
+    "unorm10-10-10-2",
 };
 </script>
 
@@ -9096,7 +9096,7 @@ enum GPUVertexFormat {
             <td>16
             <td><code>vec4&lt;i32&gt;</code>
         <tr>
-            <td><dfn>"rgb10a2"</dfn>
+            <td><dfn>"unorm10-10-10-2"</dfn>
             <td>unsigned normalized
             <td>4
             <td>4


### PR DESCRIPTION
This PR adds the unorm10-10-10-2 vertex format to WebGPU. 
Let me know what you think.

FIX: https://github.com/gpuweb/gpuweb/issues/4275