### PR TITLE
Make GPUPipelineError constructor options optional

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6922,7 +6922,7 @@ There are two ways to create pipelines:
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext, Serializable]
 interface GPUPipelineError : DOMException {
-    constructor(optional DOMString message = "", GPUPipelineErrorInit options);
+    constructor(optional DOMString message = "", optional GPUPipelineErrorInit options);
     readonly attribute GPUPipelineErrorReason reason;
 };
 


### PR DESCRIPTION
The first argument is optional, so the second one also needs to be.