### PR TITLE
Simplify invocation id definition

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8645,7 +8645,10 @@ Each is described in detail in subsequent sections.
   <tr><td style="width:10%">Description
       <td>
       The current invocation's [=global invocation ID=], i.e. its position in
-      the [=compute shader grid=].
+      the [=compute shader grid=]. The value of [=built-in values/global_invocation_id=]
+      is equal to [=built-in values/workgroup_id=] * [=attribute/workgroup_size=] +
+      [=built-in values/local_invocation_id=].
+
 </table>
 
 ##### `instance_index` ##### {#instance-index-builtin-value}
@@ -11257,9 +11260,9 @@ entry point.
 There is exactly one invocation in a workgroup for each point in the workgroup grid.
 
 An invocation's <dfn noexport>local invocation ID</dfn> is the coordinate
-triple for the invocation's corresponding workgroup grid point.
+triple (i,j,k) for the invocation's corresponding workgroup grid point.
 
-When an invocation has [=local invocation ID=] (i,j,k), then its
+When an invocation has [=local invocation ID=], then its
 <dfn noexport>local invocation index</dfn> is
 
   i +


### PR DESCRIPTION
This PR just editorial. This formula is much easier to understand
```
global_invocation_id = workgroup_id * num_workgroups + local_invocation_id
```
than https://www.w3.org/TR/WGSL/#workgroup-id. The same thing exist in [OpenGL](https://registry.khronos.org/OpenGL-Refpages/gl4/html/gl_GlobalInvocationID.xhtml) spec.