### PR TITLE
Make workgroup_count consistent between specs

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8715,8 +8715,8 @@ Each is described in detail in subsequent sections.
       <td>Input
   <tr><td style="width:10%">Description
       <td>
-      The [=dispatch size=], `vec3<u32>(group_count_x, group_count_y,
-      group_count_z)`, of the compute shader
+      The [=dispatch size=], `vec3<u32>(workgroup_count_x, workgroup_count_y,
+      workgroup_count_z)`, of the compute shader
       [[WebGPU#compute-pass-encoder-dispatch|dispatched]] by the API.
 </table>
 
@@ -8893,8 +8893,8 @@ Each is described in detail in subsequent sections.
 
       All invocations in the same workgroup have the same workgroup ID.
 
-      Workgroup IDs span from (0,0,0) to ([=group_count_x=] - 1,
-      [=group_count_y=] - 1, [=group_count_z=] - 1).
+      Workgroup IDs span from (0,0,0) to ([=workgroup_count_x=] - 1,
+      [=workgroup_count_y=] - 1, [=workgroup_count_z=] - 1).
 </table>
 
 #### User-defined Inputs and Outputs #### {#user-defined-inputs-outputs}
@@ -11274,15 +11274,15 @@ and that entire range is covered.</p>
 A compute shader begins execution when a WebGPU implementation
 removes a dispatch command from a queue and begins the specified work on the GPU.
 The dispatch command specifies a <dfn noexport>dispatch size</dfn>,
-which is an integer triple (<dfn>group_count_x</dfn>, <dfn>group_count_y</dfn>, <dfn>group_count_z</dfn>)
+which is an integer triple (<dfn>workgroup_count_x</dfn>, <dfn>workgroup_count_y</dfn>, <dfn>workgroup_count_z</dfn>)
 indicating the number of workgroups to be executed, as described in the following.
 
 The <dfn noexport>compute shader grid</dfn> for a particular dispatch
 is the set of points with integer coordinates *(CSi,CSj,CSk)* with:
 
-*  0 &leq; CSi &lt; workgroup_size_x &times; group_count_x
-*  0 &leq; CSj &lt; workgroup_size_y &times; group_count_y
-*  0 &leq; CSk &lt; workgroup_size_z &times; group_count_z
+*  0 &leq; CSi &lt; workgroup_size_x &times; workgroup_count_x
+*  0 &leq; CSj &lt; workgroup_size_y &times; workgroup_count_y
+*  0 &leq; CSk &lt; workgroup_size_z &times; workgroup_count_z
 
 where *workgroup_size_x*,
 *workgroup_size_y*, and
@@ -11308,7 +11308,7 @@ and a single invocation within that workgroup, identified by [=local invocation 
      *CSj* mod workgroup_size_y ,
      *CSk* mod workgroup_size_z ).
 
-Note: Workgroup IDs span from (0,0,0) to ([=group_count_x=] - 1, [=group_count_y=] - 1, [=group_count_z=] - 1).
+Note: Workgroup IDs span from (0,0,0) to ([=workgroup_count_x=] - 1, [=workgroup_count_y=] - 1, [=workgroup_count_z=] - 1).
 
 WebGPU provides no guarantees about:
 


### PR DESCRIPTION
This PR just editorial. The same thing named as `group_count_x` in wgsl spec and `workgroup_count_x` in webgpu spec https://www.w3.org/TR/webgpu/#dom-gpucomputepassencoder-dispatchworkgroups