### PR TITLE
Split grammar extract build and build in tempdir

### DIFF
--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -30,11 +30,11 @@ TREESITTER_GRAMMAR_INPUT := grammar/grammar.js
 TREESITTER_PARSER := grammar/build/wgsl.so
 # Extract WGSL grammar from the spec
 $(TREESITTER_GRAMMAR_INPUT): index.bs scanner.cc extract-grammar.py
-	source ../tools/custom-action/dependency-versions.sh && python3 ./extract-grammar.py --spec index.bs --scanner scanner.cc --tree-sitter-dir grammar --flow x; \
+	source ../tools/custom-action/dependency-versions.sh && python3 ./extract-grammar.py --spec index.bs --scanner scanner.cc --tree-sitter-dir grammar --flow x
 
 # Build a Treesitter parser to validate grammar extract and later examples in spec
 $(TREESITTER_PARSER): $(TREESITTER_GRAMMAR_INPUT)
-	source ../tools/custom-action/dependency-versions.sh && python3 ./extract-grammar.py --spec index.bs --scanner scanner.cc --tree-sitter-dir grammar --flow b; \
+	source ../tools/custom-action/dependency-versions.sh && python3 ./extract-grammar.py --spec index.bs --scanner scanner.cc --tree-sitter-dir grammar --flow b
 	if ! nm --extern-only --dynamic grammar/build/wgsl.so | grep --quiet tree_sitter_wgsl; then \
 		echo "Error: tree_sitter_wgsl symbol does not exist" >&2; \
 		exit 1; \

--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -28,10 +28,19 @@ img/%.mmd.svg: diagrams/%.mmd ../tools/invoke-mermaid.sh ../tools/mermaid.json
 
 TREESITTER_GRAMMAR_INPUT := grammar/grammar.js
 TREESITTER_PARSER := grammar/build/wgsl.so
+# Extract WGSL grammar from the spec
+$(TREESITTER_GRAMMAR_INPUT): index.bs scanner.cc extract-grammar.py
+	source ../tools/custom-action/dependency-versions.sh && python3 ./extract-grammar.py --spec index.bs --scanner scanner.cc --tree-sitter-dir grammar --flow x; \
 
-# Extract WGSL grammar from the spec, validate it by building a Treesitter parser from it.
-$(TREESITTER_GRAMMAR_INPUT) $(TREESITTER_PARSER): index.bs scanner.cc extract-grammar.py
-	source ../tools/custom-action/dependency-versions.sh && python3 ./extract-grammar.py --spec index.bs --scanner scanner.cc --tree-sitter-dir grammar --flow xb
+# Build a Treesitter parser to validate grammar extract and later examples in spec
+$(TREESITTER_PARSER): $(TREESITTER_GRAMMAR_INPUT)
+	source ../tools/custom-action/dependency-versions.sh && python3 ./extract-grammar.py --spec index.bs --scanner scanner.cc --tree-sitter-dir grammar --flow b; \
+	if ! nm -gD grammar/build/wgsl.so | grep -q tree_sitter_wgsl; then \
+		echo "Error: tree_sitter_wgsl symbol does not exist" >&2; \
+		exit 1; \
+	else \
+		echo "Symbol tree_sitter_wgsl exists"; \
+	fi;
 
 .PHONY: validate-examples
 # Use Treesitter to parse many code examples in the spec.
@@ -49,7 +58,7 @@ unit_tests: $(TREESITTER_PARSER) wgsl_unit_tests.py
 
 # The grammar in JSON form, emitted by Treesitter.
 WGSL_GRAMMAR=grammar/src/grammar.json
-$(WGSL_GRAMMAR) : $(TREESITTER_GRAMMAR_INPUT)
+$(WGSL_GRAMMAR) : $(TREESITTER_PARSER)
 
 .PHONY: nfkc
 nfkc:

--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -35,7 +35,7 @@ $(TREESITTER_GRAMMAR_INPUT): index.bs scanner.cc extract-grammar.py
 # Build a Treesitter parser to validate grammar extract and later examples in spec
 $(TREESITTER_PARSER): $(TREESITTER_GRAMMAR_INPUT)
 	source ../tools/custom-action/dependency-versions.sh && python3 ./extract-grammar.py --spec index.bs --scanner scanner.cc --tree-sitter-dir grammar --flow b; \
-	if ! nm -gD grammar/build/wgsl.so | grep -q tree_sitter_wgsl; then \
+	if ! nm --extern-only --dynamic grammar/build/wgsl.so | grep --quiet tree_sitter_wgsl; then \
 		echo "Error: tree_sitter_wgsl symbol does not exist" >&2; \
 		exit 1; \
 	else \

--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -2,6 +2,7 @@
 
 from datetime import date
 from string import Template
+from tempfile import TemporaryDirectory
 
 import argparse
 import difflib
@@ -11,6 +12,7 @@ import subprocess
 import sys
 import string
 import shutil
+
 import wgsl_unit_tests
 
 from distutils.ccompiler import new_compiler
@@ -1182,43 +1184,49 @@ def flow_build(options):
     # subprocess.run(["npx", "tree-sitter-cli@" + value_from_dotenv("NPM_TREE_SITTER_CLI_VERSION"), "build-wasm", "--docker"],
     #                cwd=options.grammar_dir, check=True)
 
+    def build_library(output_path, input_files):
+        # The py-tree-sitter build_library method with C++17 flags
+        """
+        Build a dynamic library at the given path, based on the parser
+        repositories at the given paths.
 
-    def build_library(output_file, input_files):
-        # The py-tree-sitter build_library method wasn't compiling with C++17 flags,
-        # so invoke the compile ourselves.
+        Returns `True` if the dynamic library was compiled and `False` if
+        the library already existed and was modified more recently than
+        any of the source files.
+        """
+
+        cpp = False
+        source_paths = []
+        for input_file in input_files:
+            source_paths.append(input_file)
+            if input_file.endswith(".cc"):
+                cpp = True
+
         compiler = new_compiler()
-        clang_like = isinstance(compiler, UnixCCompiler)
+        if isinstance(compiler, UnixCCompiler):
+            compiler.set_executables(compiler_cxx="c++")
 
-        # Compile .c and .cc files down to object files.
-        object_files = []
-        includes = [os.path.dirname(input_files[0])]
-        for src in input_files:
-            flags = []
-            if src.endswith(".cc"):
-                if clang_like:
-                    flags.extend(["-fPIC", "-std=c++17"])
+        with TemporaryDirectory(suffix="tree_sitter_language") as out_dir:
+            object_paths = []
+            for source_path in source_paths:
+                flags = ["-fPIC"]
+                if source_path.endswith(".c"):
+                    flags.append("-std=c99")
                 else:
-                    flags.extend(["/std:c++17"])
-            objects = compiler.compile([src],
-                                       extra_preargs=flags,
-                                       include_dirs=includes)
-            object_files.extend(objects)
-
-        # Link object files to a single shared library.
-        if clang_like:
-            link_flags = ["-lstdc++"]
-        compiler.link_shared_object(
-                object_files,
-                output_file,
-                target_lang="c++",
-                extra_postargs=link_flags)
-
-    if newer_than(scanner_cc_staging, options.wgsl_shared_lib) or newer_than(options.grammar_filename,options.wgsl_shared_lib):
-        print("{}: ...Building custom scanner: {}".format(options.script,options.wgsl_shared_lib))
-        build_library(options.wgsl_shared_lib,
-                      [scanner_cc_staging,
-                       os.path.join(options.grammar_dir,"src","parser.c")])
-    return True
+                    flags.append("-std=c++17")
+                object_paths.append(
+                    compiler.compile(
+                        [source_path],
+                        output_dir=out_dir,
+                        include_dirs=[os.path.dirname(source_path)],
+                        extra_preargs=flags,
+                    )[0]
+                )
+            compiler.link_shared_object(
+                object_paths,
+                output_path,
+                target_lang="c++" if cpp else "c",
+            )
 
 def flow_examples(options,scan_result):
     """

--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -1227,6 +1227,13 @@ def flow_build(options):
                 output_path,
                 target_lang="c++" if cpp else "c",
             )
+            
+    if newer_than(scanner_cc_staging, options.wgsl_shared_lib) or newer_than(options.grammar_filename,options.wgsl_shared_lib):
+        print("{}: ...Building custom scanner: {}".format(options.script,options.wgsl_shared_lib))
+        build_library(options.wgsl_shared_lib,
+                      [scanner_cc_staging,
+                       os.path.join(options.grammar_dir,"src","parser.c")])
+    return True
 
 def flow_examples(options,scan_result):
     """


### PR DESCRIPTION
This PR splits grammar extraction and building into two targets to eliminate twin execution that corrupts the `wgsl.so` file in low-resource build systems.

As Codespaces' lowest tier got an update recently, it became (almost?) impossible to reproduce this specific CI issue in isolation there anymore, at least in a productive manner. The main difference between Codespaces and Actions is the runner specification, where Codespaces has more resources. Otherwise, the software is the same Docker image. That meant I had to test by creating PRs and commits in my fork, which took around a minute per attempt.

Firstly, I have put a check `nm --extern-only --dynamic grammar/build/wgsl.so | grep --quiet tree_sitter_wgsl` after extract & build to see if the symbol exists. This check made it clear that there were times when the file had the issue, and there were also times when this check went success, just to fail in the next step.

Secondly, with the clue in the first step, I made the build_library method (which modifies the script with a slight hint to enable C++17) match the newer version of py-tree-sitter. This version uses a TemporaryDirectory for object files before linking. This measure did reduce failures in Actions, but not entirely. I did an oversight with my reading of the first step: the errors kept happening when the build step's statement came twice. This twin execution was making the other step read a malformed version of the file: https://github.com/mehmetoguzderin/gpuweb/actions/runs/6279244638/job/17054572544

Finally, I split the flow xb into first x and then b. With this change, the make execution no longer runs the same flow in twin to influence a file in the linking again. Furthermore, this change made a false dependency better visible; json is an artifact of build, not extract. I also made sure to leave checks in place so that if (hopefully not) the build fails once again, we can have an easier time triangulating. So far, no errors.

Thank you very much.