### PR TITLE
Remove restrictions on user-defined pointer parameters

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10879,11 +10879,38 @@ The rules for analyzing expressions take as argument both the expression itself 
       <td class="nowrap">*CF*, *CF*
       <td class>
    <tr><td>identifier [=resolves|resolving=] to [=const-declaration=], [=override-declaration=],
-      [=let-declaration=], or non-built-in [=formal parameter=] "x"
+      [=let-declaration=], or non-built-in [=formal parameter=] of [=pointer type|non-pointer type=] "x"
       <td>*Result*
       <td>*X* is the node corresponding to "x"
       <td class="nowrap">*CF*, *Result*
       <td class="nowrap">*Result* -> {*CF*, *X*}
+   <tr><td>identifier [=resolves|resolving=] to a [=formal parameter=] of
+      [=pointer type=] in the [=address spaces/storage=], [=address spaces/workgroup=],
+      or [=address spaces/private=] [=address spaces=] with a non-read-only
+      [=access mode=] where the identifier appears as the [=root identifier=]
+      of a [=memory view=] expression, *MVE*, and the [=load rule=] is invoked
+      on *MVE* during [=type checking=]
+      <td>
+      <td>
+      <td>*CF*, [=MayBeNonUniform=]
+      <td>
+   <tr><td>identifier [=resolves|resolving=] to a [=formal parameter=] of
+      [=pointer type=] in the [=address spaces/storage=], [=address spaces/workgroup=],
+      or [=address spaces/private=] [=address spaces=] with a non-read-only
+      [=access mode=] where the identifier appears as the [=root identifier=]
+      of a [=memory view=] expression, *MVE*, and the [=load rule=] is not
+      invoked on *MVE* during [=type checking=]
+      <td>
+      <td>
+      <td>*CF*, *CF*
+      <td>
+   <tr><td>identifier [=resolves|resolving=] to a [=formal parameter=] of
+      [=pointer type=] in an [=address space=] other than [=address
+      spaces/function=] with a read-only [=access mode=]
+      <td>
+      <td>
+      <td>*CF*, *CF*
+      <td>
    <tr><td>identifier [=resolves|resolving=] to uniform built-in value "x"
       <td>
       <td>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1667,8 +1667,11 @@ Extension names are not [=identifiers=]: they do not [=resolves|resolve=] to [=d
   <thead>
     <tr><th style="width:30%">WGSL language extension
         <th>Description
-    <tr><td colspan=2 class=note><span class="marker">Note:</span> No [=language extensions=] are currently defined.
   </thead>
+  <tr><td>unrestricted_pointer_parameters
+      <td>
+      Removes address space and memory view restrictions on pointer parameters
+      of user-defined functions
 </table>
 
 Note: The intent is that, over time, WGSL will define language extensions embodying all functionality in language extensions commonly supported at that time.
@@ -7861,24 +7864,6 @@ Note: The [=attribute/const=] attribute cannot be applied to user-declared funct
     function parameter.
     * In particular, an argument that is a pointer [=shader-creation error|must=] agree with the formal parameter
         on [=address space=], [=store type=], and [=access mode=].
-* For [=user-defined functions=], a parameter of pointer type [=shader-creation error|must=] be in one of
-    the following address spaces:
-    * [=address spaces/function=]
-    * [=address spaces/private=]
-* For [=built-in functions=], a parameter of pointer type [=shader-creation error|must=] be in one of
-    the following address spaces:
-    * [=address spaces/function=]
-    * [=address spaces/private=]
-    * [=address spaces/workgroup=]
-    * [=address spaces/storage=]
-* Each argument of pointer type to a [=user-defined function=]
-    [=shader-creation error|must=] have the same [=memory view=] as its [=root
-    identifier=].
-    * Note: This means no [[#vector-access-expr|vector]],
-        [[#matrix-access-expr|matrix]], [[#array-access-expr|array]], or
-        [[#struct-access-expr|struct]] access expressions can be applied to
-        produce a [=memory view=] into the root identifier when traced from the
-        argument back through all the [=let-declarations=].
 
 Note: Recursion is disallowed because cycles are not permitted among any kinds
 of declarations.
@@ -7898,15 +7883,24 @@ of declarations.
       bar(a); // Valid
     }
 
+    fn baz2(p : ptr<storage, f32>) {
+    }
+
     struct S {
       x : i32
     }
+
+    @group(0) @binding(0)
+    var<storage> ro_storage : f32;
+    @group(0) @binding(1)
+    var<storage, read_write> rw_storage : f32;
 
     var usable_priv : i32;
     var unusable_priv : array<i32, 4>;
     fn foo() {
       var usable_func : f32;
       var unusable_func : S;
+      var i32_func : i32;
 
       let a_priv = &usable_priv;
       let b_priv = a_priv;
@@ -7924,13 +7918,17 @@ of declarations.
       baz(a_priv);       // Valid, effectively address-of a variable.
       baz(b_priv);       // Valid, effectively address-of a variable.
       baz(c_priv);       // Valid, effectively address-of a variable.
-      baz(d_priv);       // Invalid, memory view has changed.
-      baz(e_priv);       // Invalid, memory view has changed.
+      baz(d_priv);       // Valid, memory view has changed.
+      baz(e_priv);       // Valid, memory view has changed.
+      baz(&i32_func);    // Invalid, address space mismatch.
 
       bar(&usable_func); // Valid, address-of a variable.
-      bar(c_func);       // Invalid, memory view has changed.
-      bar(d_func);       // Invalid, memory view has changed.
+      bar(c_func);       // Valid, memory view has changed.
+      bar(d_func);       // Valid, memory view has changed.
       bar(e_func);       // Valid, effectively address-of a variable.
+
+      baz2(&ro_storage); // Valid, address-of a variable.
+      baz2(&rw_storage); // Invalid, access mode mismatch.
     }
   </xmp>
 </div>


### PR DESCRIPTION
Fixes #3546

* Removes address space and memory view restrictions on pointer parameters for user-defined functions
* removes built-in function address space listing since it is no longer relevant
* adds language extension unrestricted_pointer_parameters