### PR TITLE
Remove unmaskHints in GPUAdapter.requestAdapterInfo()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1419,12 +1419,6 @@ An [=adapter=] has the following internal slots:
     : <dfn>\[[fallback]]</dfn>, of type boolean
     ::
         If set to `true` indicates that the adapter is a [=fallback adapter=].
-
-    : <dfn>\[[unmaskedIdentifiers]]</dfn>, of type [=ordered set=]&lt;{{DOMString}}&gt;
-    ::
-        A list of names of {{GPUAdapterInfo}} fields the user agent has chosen to report for this
-        adapter. Initially populated with the names of any {{GPUAdapterInfo}} fields the user agent
-        has chosen to report without user consent.
 </dl>
 
 [=Adapters=] are exposed via {{GPUAdapter}}.
@@ -1994,43 +1988,28 @@ interface GPUAdapterInfo {
     following steps:
 
     1. Let |adapterInfo| be a new {{GPUAdapterInfo}}.
-    1. Let |unmaskedValues| be |adapter|.{{adapter/[[unmaskedIdentifiers]]}}
-    1. If |unmaskedValues| [=set/contains=] `"vendor"` and the vendor is known:
-        1. Set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the name of |adapter|'s vendor as a
-            [=normalized identifier string=].
 
-        Otherwise:
+    1. If the vendor is known, set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the name of
+        |adapter|'s vendor as a [=normalized identifier string=]. To preserve privacy, the user
+        agent may instead set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the empty string or a
+        reasonable approximation of the vendor as a [=normalized identifier string=].
 
-        1. Set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the empty string or a
-            reasonable approximation of the vendor as a [=normalized identifier string=].
+    1. If |the architecture is known, set |adapterInfo|.{{GPUAdapterInfo/architecture}} to a
+        [=normalized identifier string=] representing the family or class of adapters to which
+        |adapter| belongs. To preserve privacy, the user agent may instead set
+        |adapterInfo|.{{GPUAdapterInfo/architecture}} to the empty string or a reasonable
+        approximation of the architecture as a [=normalized identifier string=].
 
-    1. If |unmaskedValues| [=set/contains=] `"architecture"` and the architecture is known:
-        1. Set |adapterInfo|.{{GPUAdapterInfo/architecture}} to a [=normalized identifier string=]
-            representing the family or class of adapters to which |adapter| belongs.
+    1. If the device is known, set |adapterInfo|.{{GPUAdapterInfo/device}} to a
+        [=normalized identifier string=] representing a vendor-specific identifier for |adapter|.
+        To preserve privacy, the user agent may instead set |adapterInfo|.{{GPUAdapterInfo/device}}
+        to to the empty string or a reasonable approximation of a vendor-specific identifier as a
+        [=normalized identifier string=].
 
-        Otherwise:
-
-        1. Set |adapterInfo|.{{GPUAdapterInfo/architecture}} to the empty string or a
-            reasonable approximation of the architecture as a [=normalized identifier string=].
-
-    1. If |unmaskedValues| [=set/contains=] `"device"` and the device is known:
-        1. Set |adapterInfo|.{{GPUAdapterInfo/device}} to a [=normalized identifier string=]
-            representing a vendor-specific identifier for |adapter|.
-
-        Otherwise:
-
-        1. Set |adapterInfo|.{{GPUAdapterInfo/device}} to to the empty string or a
-            reasonable approximation of a vendor-specific identifier as a [=normalized identifier
-            string=].
-
-    1. If |unmaskedValues| [=set/contains=] `"description"` and a description is known:
-        1. Set |adapterInfo|.{{GPUAdapterInfo/description}} to a description of the |adapter| as
-            reported by the driver.
-
-        Otherwise:
-
-        1. Set |adapterInfo|.{{GPUAdapterInfo/description}} to the empty string or a
-            reasonable approximation of a description.
+    1. If a description is known, set |adapterInfo|.{{GPUAdapterInfo/description}} to a description
+        of the |adapter| as reported by the driver. To preserve privacy, the user agent may
+        instead set |adapterInfo|.{{GPUAdapterInfo/description}} to the empty string or a
+        reasonable approximation of a description.
 
     1. Return |adapterInfo|.
 </div>
@@ -2598,7 +2577,7 @@ interface GPUAdapter {
     readonly attribute boolean isFallbackAdapter;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
-    Promise<GPUAdapterInfo> requestAdapterInfo(optional sequence<DOMString> unmaskHints = []);
+    Promise<GPUAdapterInfo> requestAdapterInfo();
 };
 </script>
 
@@ -2740,20 +2719,11 @@ interface GPUAdapter {
         Requests the {{GPUAdapterInfo}} for this {{GPUAdapter}}.
 
         Note: Adapter info values are returned with a Promise to give user agents an
-        opportunity to perform potentially long-running checks when requesting unmasked values,
-        such as asking for user consent before returning. If no `unmaskHints` are specified,
-        however, no dialogs should be displayed to the user.
+        opportunity to perform potentially long-running checks in the future.
 
         <div algorithm=GPUAdapter.requestAdapterInfo>
             <div data-timeline=content>
                 **Called on:** {{GPUAdapter}} |this|.
-
-                **Arguments:**
-
-                <pre class=argumentdef for="GPUAdapter/requestAdapterInfo()">
-                    |unmaskHints|: A list of {{GPUAdapterInfo}} attribute names for which unmasked
-                        values are desired if available.
-                </pre>
 
                 **Returns:** {{Promise}}&lt;{{GPUAdapterInfo}}&gt;
 
@@ -2761,18 +2731,7 @@ interface GPUAdapter {
 
                 1. Let |promise| be [=a new promise=].
                 1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
-                1. Let |hasActivation| be `true` if the [=relevant global object=] for |this| has
-                    [=transient activation=], and `false` otherwise.
                 1. Run the following steps [=in parallel=]:
-                    1. If |unmaskHints|.length &gt; `0`:
-                        1. If |hasActivation| is `false` [=reject=] |promise| with a {{NotAllowedError}}
-                            and abort these steps.
-                        1. Let |unmaskedKeys| be a [=list=] of the fields specified in |unmaskHints|
-                            which the user agent decides to unmask, if any.
-
-                            Note: The user agent is free to use any method it deems appropriate to
-                            decide which fields to unmask.
-                        1. [=set/Append=] |unmaskedKeys| to |adapter|.{{adapter/[[unmaskedIdentifiers]]}}.
                     1. [=Resolve=] |promise| with a [$new adapter info$] for |adapter|.
 
                 1. Return |promise|.


### PR DESCRIPTION
This PR removes unmaskHints in GPUAdapter.requestAdapterInfo() and its potential prompt according to the minutes captured on https://github.com/gpuweb/gpuweb/issues/3962#issuecomment-1523779809.

@toji @kdashg Please review.