### PR TITLE
[editorial] Fix typo in WGSLLanguageFeatures definition

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1922,9 +1922,8 @@ interface GPUSupportedFeatures {
 <h5 id=gpuwgsllanguagefeatures data-dfn-type=interface>`WGSLLanguageFeatures`
 </h5>
 
-{{WGSLLanguageFeatures}} is a [=setlike=] interface.
-Its [=set entries=] are
-the string names of the WGSL [=language extensions=] supported all adapters.
+{{WGSLLanguageFeatures}} is a [=setlike=] interface. Its [=set entries=] are
+the string names of the WGSL [=language extensions=] supported by all adapters.
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1922,8 +1922,10 @@ interface GPUSupportedFeatures {
 <h5 id=gpuwgsllanguagefeatures data-dfn-type=interface>`WGSLLanguageFeatures`
 </h5>
 
-{{WGSLLanguageFeatures}} is a [=setlike=] interface. Its [=set entries=] are
-the string names of the WGSL [=language extensions=] supported by all adapters.
+{{WGSLLanguageFeatures}} is the [=setlike=] interface of
+<code>navigator.gpu.{{GPU/wgslLanguageFeatures}}</code>.
+Its [=set entries=] are the string names of the WGSL [=language extensions=]
+supported by the implementation (regardless of the adapter or device).
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]


### PR DESCRIPTION
Add a missing 'by' in the definition of WGSLLanguageFeatures.

Issue: #3875