### PR TITLE
Require depthWriteEnabled and depthCompare only for formats with depth

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8511,8 +8511,8 @@ enum GPUBlendOperation {
 dictionary GPUDepthStencilState {
     required GPUTextureFormat format;
 
-    required boolean depthWriteEnabled;
-    required GPUCompareFunction depthCompare;
+    boolean depthWriteEnabled;
+    GPUCompareFunction depthCompare;
 
     GPUStencilFaceState stencilFront = {};
     GPUStencilFaceState stencilBack = {};
@@ -8612,6 +8612,10 @@ will affect a render pass's {{GPURenderPassDescriptor/depthStencilAttachment}}:
     - If |descriptor|.{{GPUDepthStencilState/stencilFront}} or
             |descriptor|.{{GPUDepthStencilState/stencilBack}} are not the default values:
             - |descriptor|.{{GPUDepthStencilState/format}} must have a stencil component.
+    - If |descriptor|.{{GPUDepthStencilState/format}} has a depth component:
+        - |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} must be [=map/exist|provided=].
+        - |descriptor|.{{GPUDepthStencilState/depthCompare}} must be [=map/exist|provided=].
+
 </div>
 
 <script type=idl>


### PR DESCRIPTION
This PR addresses https://github.com/gpuweb/gpuweb/issues/3905 and makes `depthWriteEnabled` and `depthCompare` required only for formats with depth.

@toji Please review