### PR TITLE
editorial: fix typo in writeBuffer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12605,7 +12605,7 @@ GPUQueue includes GPUObjectBase;
                         - |dataOffset| + |contentsSize| &le; |dataSize|.
                         - |contentsSize|, converted to bytes, is a multiple of 4 bytes.
                     </div>
-                1. Let |dataContents| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=].
+                1. Let |dataContents| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
                 1. Let |contents| be the |contentsSize| elements of |dataContents| starting at
                     an offset of |dataOffset| elements.
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.


### PR DESCRIPTION
It didn't say what the buffer source was. Language now matches writeTexture.