### PR TITLE
editorial: Improve "Note" headings

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -146,8 +146,11 @@ p, ul, ol, dl {
 
 /* Styling for "editorial" issues */
 .note.editorial {
-    border-color: var(--note-editorial-border);
+    border-color: var(--note-editorial-color);
     background: var(--note-editorial-bg);
+}
+.note.editorial > .marker {
+    color: var(--note-editorial-color);
 }
 
 /* Our SVGs aren't responsive to light/dark mode, so they're opaque with a
@@ -414,7 +417,7 @@ thead.stickyheader th, th.stickyheader {
     --tint-green: rgba(0, 255, 0, 10%);
     --tint-blue: rgba(0, 0, 255, 5%);
     --tint-purple: rgba(255, 0, 255, 5%);
-    --note-editorial-border: #ffa500;
+    --note-editorial-color: #c06e00;
     --note-editorial-bg: #ffeedd;
 }
 @media (prefers-color-scheme:dark) {
@@ -425,7 +428,7 @@ thead.stickyheader th, th.stickyheader {
         --tint-green: rgba(0, 255, 0, 18%);
         --tint-blue: rgba(0, 130, 255, 24%);
         --tint-purple: rgba(255, 0, 255, 22%);
-        --note-editorial-border: #ffa500;
+        --note-editorial-color: #ff9100;
         --note-editorial-bg: var(--borderedblock-bg);
     }
 }
@@ -506,8 +509,7 @@ The precise mechanism of clearing the workgroup memory can differ between platfo
 If the native API does not provide facilities to clear it, the WebGPU implementation transforms the compute
 shader to first do a clear across all invocations, synchronize them, and continue executing developer's code.
 
-<div class=note>
-    Note:
+<div class=note heading>
     The initialization status of a resource used in a queue operation can only be known when the
     operation is enqueued (not when it is encoded into a command buffer, for example). Therefore,
     some implementations will require an unoptimized late-clear at enqueue time (e.g. clearing a
@@ -784,7 +786,7 @@ In this specification, the following syntactic shorthands are used:
     The phrasing "`Foo.Bar`" means "the `Bar` member of the value (or interface) `Foo`."
     If `Foo` is an [=ordered map=], [=asserts=] that the key `Bar` exists.
 
-    <p class="note editorial">Editorial:
+    <p class="note editorial"><span class=marker>Editorial note:</span>
     Some phrasing in this spec may currently assume this resolves to `undefined` if `Bar` doesn't exist.
 
     The phrasing "`Foo.Bar` is [=map/exist|provided=]" means
@@ -893,7 +895,7 @@ interface mixin GPUObjectBase {
         Examples include displaying the label in {{GPUError}} messages, console warnings,
         browser developer tools, and platform debugging utilities.
 
-        <div class=note>
+        <div class=note heading>
             Implementations **should** use labels to enhance error messages by using them to
             identify WebGPU objects.
 
@@ -908,8 +910,7 @@ interface mixin GPUObjectBase {
             - The label of the source {{GPURenderBundleEncoder}} when printing a {{GPURenderBundle}}.
         </div>
 
-        <div class=note>
-            Note:
+        <div class=note heading>
             The {{GPUObjectBase/label}} is a property of the {{GPUObjectBase}}.
             Two {{GPUObjectBase}} "wrapper" objects have completely separate label states,
             even if they refer to the same underlying object
@@ -926,8 +927,7 @@ interface mixin GPUObjectBase {
         </div>
 </dl>
 
-<div class=note>
-    Note:
+<div class=note heading>
     Ideally [=WebGPU interfaces=] should not prevent their parent objects, such as the
     {{GPUObjectBase/[[device]]}} that owns them, from being garbage collected. This cannot be
     guaranteed, however, as holding a strong reference to a parent object may be required in some
@@ -1341,8 +1341,7 @@ This specification defines the following [=usage scopes=]:
 Issue: The above should probably talk about [=GPU commands=]. But we don't have a way to
 reference specific GPU commands (like dispatch) yet.
 
-<div class=note>
-    Note:
+<div class=note heading>
     The above rules mean the following example resource usages **are**
     included in [=usage scope validation=]:
 
@@ -1893,8 +1892,7 @@ interface GPUSupportedFeatures {
 };
 </script>
 
-<div class=note>
-    Note:
+<div class=note heading>
     The type of the {{GPUSupportedFeatures}} [=set entries=] is {{DOMString}} to allow user
     agents to gracefully handle valid {{GPUFeatureName}}s which are added in later revisions of the spec
     but which the user agent has not been updated to recognize yet. If the [=set entries=] type was
@@ -2103,8 +2101,7 @@ It is used for the automatic, timed expiry (destruction) of certain objects:
 Tasks from the [=automatic expiry task source=] **should** be processed with high priority; in
 particular, once queued, they **should** run before user-defined (JavaScript) tasks.
 
-<div class=note>
-    Note:
+<div class=note heading>
     This behavior is more predictable, and the strictness helps developers write more portable
     applications by eagerly detecting incorrect assumptions about implicit lifetimes that may be
     hard to detect. Developers are still strongly encouraged to test in multiple implementations.
@@ -3191,8 +3188,7 @@ enum GPUBufferMapState {
             1. Let |size| be |range|[1] - |range|[0].
             1. Let |data| be [=?=] [$CreateByteDataBlock$](|size|).
 
-                <div class=note>
-                    Note:
+                <div class=note heading>
                     This may result in a {{RangeError}} being thrown.
                     For consistency and predictability:
 
@@ -4087,8 +4083,7 @@ dictionary GPUTextureDescriptor
         {{GPUTexture/createView()}} on this texture (in addition to the texture's actual
         {{GPUTextureDescriptor/format}}).
 
-        <div class=note>
-            Note:
+        <div class=note heading>
             Adding a format to this list may have a significant performance impact, so it is best
             to avoid adding formats unnecessarily.
 
@@ -4586,8 +4581,7 @@ enum GPUTextureAspect {
     ::
         Creates a {{GPUTextureView}}.
 
-        <div class=note>
-            Note:
+        <div class=note heading>
             By default {{GPUTexture/createView()}} will create a view with a dimension that can
             represent the entire texture. For example, calling {{GPUTexture/createView()}} without
             specifying a {{GPUTextureViewDescriptor/dimension}} on a {{GPUTextureDimension/"2d"}}
@@ -4939,8 +4933,7 @@ The {{GPUTextureFormat/stencil8}} format may be implemented as
 either a real "stencil8", or "depth24stencil8", where the depth aspect is
 hidden and inaccessible.
 
-<div class=note>
-    Note:
+<div class=note heading>
     While the precision of depth32float channels is strictly higher than the precision of
     [=24-bit depth=] channels for all values in the representable range (0.0 to 1.0),
     note that the set of representable values is not an exact superset.
@@ -5018,8 +5011,7 @@ They are bound into bind group layouts using the {{GPUBindGroupLayoutEntry/exter
 bind group layout entry member.
 External textures use several binding slots: see [=Exceeds the binding slot limits=].
 
-<div class=note>
-    Note:
+<div class=note heading>
     External textures *can* be implemented without creating a copy of the imported source,
     but this depends implementation-defined factors.
     Ownership of the underlying representation may either be exclusive or shared with other
@@ -6580,8 +6572,7 @@ dictionary GPUShaderModuleDescriptor
                 Issue: Describe remaining {{GPUDevice/createShaderModule()}} validation and
                 algorithm steps.
 
-                <div class=note>
-                    Note:
+                <div class=note heading>
                     User agents **should not** include detailed compiler error messages or shader text in
                     the {{GPUError/message}} text of validation errors arising here:
                     these details are accessible via {{GPUShaderModule/getCompilationInfo()}}.
@@ -6648,8 +6639,7 @@ dictionary GPUShaderModuleCompilationHint {
         for the entry point associated with this hint will be used.
 </dl>
 
-<div class=note>
-    Note:
+<div class=note heading>
     If possible, authors should be supplying the same information to
     {{GPUDevice/createShaderModule()}} and {{GPUDevice/createComputePipeline()}} /
     {{GPUDevice/createRenderPipeline()}}.
@@ -6710,7 +6700,7 @@ any specific point in the code at all.
         and direction information=]. This includes making use of any future standards which may
         emerge regarding the reporting of string language and direction metadata.
 
-        <p class="note editorial">Editorial:
+        <p class="note editorial"><span class=marker>Editorial note:</span>
         At the time of this writing, no language/direction recommendation is available that provides
         compatibility and consistency with legacy APIs, but when there is, adopt it formally.
 
@@ -10636,8 +10626,7 @@ dictionary GPUComputePassDescriptor
                     |workgroupCountZ|: Z dimension of the grid of workgroups to dispatch.
                 </pre>
 
-                <div class=note>
-                    Note:
+                <div class=note heading>
                     The `x`, `y`, and `z` values passed to {{GPUComputePassEncoder/dispatchWorkgroups()}}
                     and {{GPUComputePassEncoder/dispatchWorkgroupsIndirect()}} are the number of
                     *workgroups* to dispatch for each dimension, *not* the number of shader invocations
@@ -13316,8 +13305,7 @@ interface GPUCanvasContext {
         Get the {{GPUTexture}} that will be composited to the document by the {{GPUCanvasContext}}
         next.
 
-        <div class=note>
-            Note:
+        <div class=note heading>
             An application **should** call {{GPUCanvasContext/getCurrentTexture()}}
             in the same task that renders to the canvas texture.
             Otherwise, the texture could get destroyed by these steps before the
@@ -13451,8 +13439,7 @@ specified points.
     1. Return [$get a copy of the image contents of a context|a copy of the image contents$]
         of |context|.
 
-    <div class=note>
-        Note:
+    <div class=note heading>
         This occurs in many places, including:
 
         - When an {{HTMLCanvasElement}} has its rendering updated.
@@ -13776,7 +13763,7 @@ JSON, for a debug report).
         direction information=]. This includes making use of any future standards which may emerge
         regarding the reporting of string language and direction metadata.
 
-        <p class="note editorial">Editorial:
+        <p class="note editorial"><span class=marker>Editorial note:</span>
         At the time of this writing, no language/direction recommendation is available that provides
         compatibility and consistency with legacy APIs, but when there is, adopt it formally.
 </dl>
@@ -14111,8 +14098,8 @@ partial interface GPUDevice {
     </pre>
 </div>
 
-<div class=note>
-Note: Error scopes can encompass as many commands as needed. The number of commands an error scope covers
+<div class=note heading>
+Error scopes can encompass as many commands as needed. The number of commands an error scope covers
 will generally be correlated to what sort of action the application intends to take in response to
 an error occuring.
 
@@ -14201,7 +14188,7 @@ Issue: This section is incomplete.
 
 ## Transfer ## {#transfer-operations}
 
-<p class="note editorial">Editorial: describe the transfers at the high level
+<p class="note editorial"><span class=marker>Editorial note:</span> describe the transfers at the high level
 
 ## Computing ## {#computing-operations}
 
@@ -14214,7 +14201,7 @@ These operations are encoded within {{GPUComputePassEncoder}} as:
 - {{GPUComputePassEncoder/dispatchWorkgroups()}}
 - {{GPUComputePassEncoder/dispatchWorkgroupsIndirect()}}
 
-<p class="note editorial">Editorial: describe the computing algorithm
+<p class="note editorial"><span class=marker>Editorial note:</span> describe the computing algorithm
 
 The [=device=] may become [=lose the device|lost=] if
 [=shader execution end|shader execution does not end=]
@@ -14273,11 +14260,11 @@ The main rendering algorithm:
 
         1. **Process depth/stencil**.
 
-            <p class="note editorial">Editorial: fill out the section, using |fragments|
+            <p class="note editorial"><span class=marker>Editorial note:</span> fill out the section, using |fragments|
 
         1. **Write pixels**.
 
-            <p class="note editorial">Editorial: fill out the section
+            <p class="note editorial"><span class=marker>Editorial note:</span> fill out the section
 </div>
 
 ### Index Resolution ### {#index-resolution}
@@ -14316,7 +14303,7 @@ a list of vertices to process for each instance.
     and other properties of |drawCall| are read from the indirect buffer
     instead of the draw command itself.
 
-    <p class="note editorial">Editorial: specify indirect commands better.
+    <p class="note editorial"><span class=marker>Editorial note:</span> specify indirect commands better.
 </div>
 
 <div algorithm>
@@ -14498,7 +14485,7 @@ Primitives are assembled by a fixed-function stage of GPUs.
                 Each subsequent primitive takes 1 vertices.
         </dl>
 
-        <p class="note editorial">Editorial: should this be defined more formally?
+        <p class="note editorial"><span class=marker>Editorial note:</span> should this be defined more formally?
 
         Any incomplete primitives are dropped.
 </div>
@@ -14555,7 +14542,7 @@ The clipped shader output |c|.v is produced based on the interpolation qualifier
         The interpolation ratio gets adjusted against the perspective coordinates of the
         [=clip position=]s, so that the result of interpolation is linear in screen space.
 
-        <p class="note editorial">Editorial: provide more specifics here, if possible
+        <p class="note editorial"><span class=marker>Editorial note:</span> provide more specifics here, if possible
 
     : "perspective"
     ::
@@ -14564,7 +14551,7 @@ The clipped shader output |c|.v is produced based on the interpolation qualifier
         |c|.v = |t| &times; |a|.v &plus; (1 &minus; |t|) &times; |b|.v
 </dl>
 
-<p class="note editorial">Editorial: link to interpolation qualifiers in WGSL
+<p class="note editorial"><span class=marker>Editorial note:</span> link to interpolation qualifiers in WGSL
 
 The result of primitive clipping is a new set of primitives, which are contained
 within the [=clip volume=].
@@ -14630,7 +14617,7 @@ Rasterization produces a list of <dfn dfn>RasterizationPoint</dfn>s, each contai
     :: refers to [[#barycentric-coordinates]]
 </dl>
 
-<p class="note editorial">Editorial: define the depth computation algorithm
+<p class="note editorial"><span class=marker>Editorial note:</span> define the depth computation algorithm
 
 <div algorithm>
     <dfn abstract-op>rasterize</dfn>(primitiveList, state)
@@ -14664,7 +14651,7 @@ Rasterization produces a list of <dfn dfn>RasterizationPoint</dfn>s, each contai
 
     1. Let |rasterizationPoints| be an empty list.
 
-        <p class="note editorial">Editorial: specify that each rasterization point gets assigned an interpolated `divisor(p)`,
+        <p class="note editorial"><span class=marker>Editorial note:</span> specify that each rasterization point gets assigned an interpolated `divisor(p)`,
         `framebufferCoords(n)`, `depth(n)`, as well as the other attributes.
 
     1. Proceed with a specific rasterization algorithm,
@@ -14703,7 +14690,7 @@ The coverage mask depends on multi-sampling mode:
 
 #### Line Rasterization #### {#line-rasterization}
 
-<p class="note editorial">Editorial: fill out this section
+<p class="note editorial"><span class=marker>Editorial note:</span> fill out this section
 
 #### Barycentric coordinates #### {#barycentric-coordinates}
 
@@ -14809,7 +14796,7 @@ Otherwise, the polygon is <dfn dfn>back-facing</dfn>.
 
         1. Let |d|<sub>|i|</sub> be the depth value of |v|<sub>|i|</sub>.
 
-            <p class="note editorial">Editorial: define how this value is constructed.
+            <p class="note editorial"><span class=marker>Editorial note:</span> define how this value is constructed.
         1. Set |rp|.[=RasterizationPoint/depth=] to &sum; (|b|<sub>|i|</sub> &times; |d|<sub>|i|</sub>)
         1. Append |rp| to |rasterizationPoints|.
 
@@ -14868,7 +14855,7 @@ This stage produces a <dfn dfn>Fragment</dfn> for each [=RasterizationPoint=]:
                 based on |rp|.[=RasterizationPoint/barycentricCoordinates=], |rp|.[=RasterizationPoint/primitiveVertices=],
                 and the [=interpolation=] qualifier on the input.
 
-                <p class="note editorial">Editorial: describe the exact equations.
+                <p class="note editorial"><span class=marker>Editorial note:</span> describe the exact equations.
             1. Set the corresponding fragment shader [=location=] input to |value|.
         1. Invoke the fragment shader entry point described by |desc|.
 
@@ -14895,7 +14882,7 @@ may happen in any order.
 
 ### Output Merging ### {#output-merging}
 
-<p class="note editorial">Editorial: fill out this section
+<p class="note editorial"><span class=marker>Editorial note:</span> fill out this section
 
 The depth input to this stage, if any, is clamped to the current
 {{RenderState/[[viewport]]}} depth range
@@ -14924,7 +14911,7 @@ It guarantees that:
 
 ### Sample frequency shading ### {#sample-frequency-shading}
 
-<p class="note editorial">Editorial: fill out the section
+<p class="note editorial"><span class=marker>Editorial note:</span> fill out the section
 
 ### Sample Masking ### {#sample-masking}
 
@@ -15708,7 +15695,7 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
     <thead>
         <tr>
             <th>Format
-            <th class=note>[=Texel block memory cost=] (Bytes)
+            <th class=note heading>[=Texel block memory cost=] (Bytes)
             <th>Aspect
             <th>{{GPUTextureSampleType}}
             <th>Valid [=image copy=] source
@@ -15827,8 +15814,7 @@ The depth aspects of depth24plus formats
 have opaque representations (implemented as either [=24-bit depth=] or {{GPUTextureFormat/"depth32float"}}).
 As a result, depth-aspect [=image copies=] are not allowed with these formats.
 
-<div class=note>
-    Note:
+<div class=note heading>
     It is possible to imitate these disallowed copies:
 
     - All of these formats can be written in a render pass using a fragment shader that outputs


### PR DESCRIPTION
- Use `<div class=note heading>` (equivalent to `heading=""`) to get a properly formatted "NOTE:" on multi-paragraph notes, without the verbosity of `<span class=marker>Note:</span>` \*
- Use `<span class=marker>` to get a nicer "EDITORIAL NOTE:" header

[Relevant Bikeshed documentation](https://speced.github.io/bikeshed/#notes-etc)

\* Not applied to the WGSL spec because the style changes a little (puts "NOTE:" on its own line), but FYI @dneto0 if you want to use it