### PR TITLE
depthCompare is not required for depth attachments if not used

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8639,7 +8639,12 @@ will affect a render pass's {{GPURenderPassDescriptor/depthStencilAttachment}}:
             - |descriptor|.{{GPUDepthStencilState/format}} must have a stencil component.
     - If |descriptor|.{{GPUDepthStencilState/format}} has a depth component:
         - |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} must be [=map/exist|provided=].
-        - |descriptor|.{{GPUDepthStencilState/depthCompare}} must be [=map/exist|provided=].
+        - |descriptor|.{{GPUDepthStencilState/depthCompare}} must be [=map/exist|provided=] if:
+            - |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true` or,
+            - |descriptor|.{{GPUDepthStencilState/stencilFront}}.{{GPUStencilFaceState/depthFailOp}}
+                is not {{GPUStencilOperation/"keep"}} or,
+            - |descriptor|.{{GPUDepthStencilState/stencilBack}}.{{GPUStencilFaceState/depthFailOp}}
+                is not {{GPUStencilOperation/"keep"}}.
 
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8640,9 +8640,9 @@ will affect a render pass's {{GPURenderPassDescriptor/depthStencilAttachment}}:
     - If |descriptor|.{{GPUDepthStencilState/format}} has a depth component:
         - |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} must be [=map/exist|provided=].
         - |descriptor|.{{GPUDepthStencilState/depthCompare}} must be [=map/exist|provided=] if:
-            - |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true` or,
+            - |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true`, or
             - |descriptor|.{{GPUDepthStencilState/stencilFront}}.{{GPUStencilFaceState/depthFailOp}}
-                is not {{GPUStencilOperation/"keep"}} or,
+                is not {{GPUStencilOperation/"keep"}}, or
             - |descriptor|.{{GPUDepthStencilState/stencilBack}}.{{GPUStencilFaceState/depthFailOp}}
                 is not {{GPUStencilOperation/"keep"}}.
 


### PR DESCRIPTION
Following https://github.com/gpuweb/gpuweb/issues/3905#issuecomment-1762325586, this PR updates the WebGPU specification to make `depthCompare` not required for depth attachments, if it's not used for anything: i.e. if depthWriteEnabled is false AND depthFailOp is "keep".

@kainino0x Please review
