### PR TITLE
Compatibility Mode: further items with tentative consensus.

### DIFF
--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -68,7 +68,7 @@ Each `GPUColorTargetState` in a `GPUFragmentState` must have the same `blend.alp
 
 **Justification**: OpenGL ES 3.1 does not support indexed draw buffer state.
 
-### 3. Disallow CommandEncoder.copyTextureToBuffer() and CommandEncoder.copyTextureToTexture() for compressed texture formats
+### 3. Disallow `CommandEncoder.copyTextureToBuffer()` and `CommandEncoder.copyTextureToTexture()` for compressed texture formats
 `CommandEncoder.copyTextureToBuffer()` and `CommandEncoder.copyTextureToTexture()` of a compressed texture are disallowed, and will result in a validation error.
 
 Justification: Compressed texture formats are non-renderable in OpenGL ES, and `glReadPixels()` requires a framebuffer-complete FBO, preventing `copyTextureToBuffer()`. Additionally, because ES 3.1 does not support `glCopyImageSubData()`, texture-to-texture copies must be worked around with `glBlitFramebuffer()`. Since compressed textures are not renderable, they cannot use the `glBlitFramebuffer()` workaround, preventing implementation of `copyTextureToTexture()`.
@@ -79,6 +79,6 @@ Justification: Compressed texture formats are non-renderable in OpenGL ES, and `
 
 ## Issues
 
-Q: Should WGSL's "fine" derivatives (`dpdXFine()`, `dpdYFine()`, and `fwidthFine()`) be required to deliver high precision results?
+Q: OpenGL ES does not have "coarse" and "fine" variants of the derivative instructions (`dFdx()`, `dFdy()`, `fwidth()`). Should WGSL's "fine" derivatives (`dpdxFine()`, `dpdyFine()`, and `fwidthFine()`) be required to deliver high precision results?
 
 A: Unclear. In SPIR-V, Fine variants must include the value of P for the local fragment, while Coarse variants do not. WGSL is less constraining, and simply says that Coarse "may result in fewer unique positions that dpdxFine(e)."

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -67,3 +67,20 @@ if desc.dimension is "3d":
 Each `GPUColorTargetState` in a `GPUFragmentState` must have the same `blend.alpha`, `blend.color` and `writeMask`, or else a validation error will occur on render pipeline creation.
 
 **Justification**: OpenGL ES 3.1 does not support indexed draw buffer state.
+
+### 3. Disallow CommandEncoder.copyTextureToBuffer() and CommandEncoder.copyTextureToTexture() for compressed texture formats
+CommandEncoder.copyTextureToBuffer() and CommandEncoder.copyTextureToTexture() of a compressed texture is disallowed, and will result in a validation error.
+
+Justification: Compressed texture formats are non-renderable in OpenGL ES, and glReadPixels() on works on a framebuffer-complete FBO, preventing copyTextureToBuffer(). Additionally, because ES 3.1 does not support glCopyImageSubData(), texture-to-texture copies must be worked around with glBlitFramebuffer(). Since compressed textures cannot be bound for rendering, they cannot use the glBlitFramebuffer() workaround, preventing implementation of copyTextureToTexture().
+
+### 4. Disallow `GPUTextureViewDimension` `"CubeArray"` via validation
+
+**Justification**: OpenGL ES does not support Cube Array textures.
+
+**Alternatives Considered**:
+
+## Issues
+
+Q: Should WGSL's "fine" derivatives (dpdXFine(), dpdYFine(), and fwidthFine()) be required to deliver high precision results?
+
+A: Unclear. In SPIR-V, Fine variants must include the value of P for the local fragment, while Coarse variants do not. WGSL is less constraining, and simply says that Coarse "may result in fewer unique positions that dpdxFine(e)."

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -69,18 +69,16 @@ Each `GPUColorTargetState` in a `GPUFragmentState` must have the same `blend.alp
 **Justification**: OpenGL ES 3.1 does not support indexed draw buffer state.
 
 ### 3. Disallow CommandEncoder.copyTextureToBuffer() and CommandEncoder.copyTextureToTexture() for compressed texture formats
-CommandEncoder.copyTextureToBuffer() and CommandEncoder.copyTextureToTexture() of a compressed texture is disallowed, and will result in a validation error.
+`CommandEncoder.copyTextureToBuffer()` and `CommandEncoder.copyTextureToTexture()` of a compressed texture are disallowed, and will result in a validation error.
 
-Justification: Compressed texture formats are non-renderable in OpenGL ES, and glReadPixels() on works on a framebuffer-complete FBO, preventing copyTextureToBuffer(). Additionally, because ES 3.1 does not support glCopyImageSubData(), texture-to-texture copies must be worked around with glBlitFramebuffer(). Since compressed textures cannot be bound for rendering, they cannot use the glBlitFramebuffer() workaround, preventing implementation of copyTextureToTexture().
+Justification: Compressed texture formats are non-renderable in OpenGL ES, and `glReadPixels()` requires a framebuffer-complete FBO, preventing `copyTextureToBuffer()`. Additionally, because ES 3.1 does not support `glCopyImageSubData()`, texture-to-texture copies must be worked around with `glBlitFramebuffer()`. Since compressed textures are not renderable, they cannot use the `glBlitFramebuffer()` workaround, preventing implementation of `copyTextureToTexture()`.
 
 ### 4. Disallow `GPUTextureViewDimension` `"CubeArray"` via validation
 
 **Justification**: OpenGL ES does not support Cube Array textures.
 
-**Alternatives Considered**:
-
 ## Issues
 
-Q: Should WGSL's "fine" derivatives (dpdXFine(), dpdYFine(), and fwidthFine()) be required to deliver high precision results?
+Q: Should WGSL's "fine" derivatives (`dpdXFine()`, `dpdYFine()`, and `fwidthFine()`) be required to deliver high precision results?
 
 A: Unclear. In SPIR-V, Fine variants must include the value of P for the local fragment, while Coarse variants do not. WGSL is less constraining, and simply says that Coarse "may result in fewer unique positions that dpdxFine(e)."

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -79,6 +79,6 @@ Justification: Compressed texture formats are non-renderable in OpenGL ES, and `
 
 ## Issues
 
-Q: OpenGL ES does not have "coarse" and "fine" variants of the derivative instructions (`dFdx()`, `dFdy()`, `fwidth()`). Should WGSL's "fine" derivatives (`dpdxFine()`, `dpdyFine()`, and `fwidthFine()`) be required to deliver high precision results?
+Q: OpenGL ES does not have "coarse" and "fine" variants of the derivative instructions (`dFdx()`, `dFdy()`, `fwidth()`). Should WGSL's "fine" derivatives (`dpdxFine()`, `dpdyFine()`, and `fwidthFine()`) be required to deliver high precision results? See [Issue 4325](https://github.com/gpuweb/gpuweb/issues/4325).
 
 A: Unclear. In SPIR-V, Fine variants must include the value of P for the local fragment, while Coarse variants do not. WGSL is less constraining, and simply says that Coarse "may result in fewer unique positions that dpdxFine(e)."


### PR DESCRIPTION
This PR adds the following tentative consensus items from the Oct. 11 CG meeting:
 - disallowing `copyTextureToBuffer()` and `copyTextureToTexture()` on compressed texture formats
 - disallowing CubeArray textures
 - discussion about Coarse and Fine variants of derivative instructions