### PR TITLE
Refactor `hints` record into `compilationHints` sequence

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6492,7 +6492,7 @@ dictionary GPUShaderModuleDescriptor
          : GPUObjectDescriptorBase {
     required USVString code;
     object sourceMap;
-    record<USVString, (GPUShaderModuleCompilationHint or sequence<GPUShaderModuleCompilationHint>)> hints;
+    sequence<GPUShaderModuleCompilationHint> compilationHints = [];
 };
 </script>
 
@@ -6511,21 +6511,20 @@ dictionary GPUShaderModuleDescriptor
         WGSL names (identifiers) in source maps follow the rules defined in [=WGSL identifier
         comparison=].
 
-    : <dfn>hints</dfn>
+    : <dfn>compilationHints</dfn>
     ::
-        If defined, maps an entry point name from the shader to one or a list of
-        {{GPUShaderModuleCompilationHint}}s.
+        A list of {{GPUShaderModuleCompilationHint}}s.
 
-        Each hint should provide information about one pipeline that will eventually be created from
-        the entry point.
-        Implementations should use any information present in the {{GPUShaderModuleCompilationHint}}
+        Any hint provided by an application **should** contain information about one entry point of
+        a pipeline that will eventually be created from the entry point.
+
+        Implementations **should** use any information present in the {{GPUShaderModuleCompilationHint}}
         to perform as much compilation as is possible within {{GPUDevice/createShaderModule()}}.
-        Entry point names follow the rules defined in [=WGSL identifier comparison=].
 
         Aside from type-checking, these hints are not validated in any way.
 
         <div class=note heading>
-            Supplying information in {{GPUShaderModuleDescriptor/hints}} does not have any
+            Supplying information in {{GPUShaderModuleDescriptor/compilationHints}} does not have any
             observable effect, other than performance. It may be detrimental to performance to
             provide hints for pipelines that never end up being created.
 
@@ -6641,6 +6640,7 @@ information may aid in compiling the shader module earlier, potentially increasi
 
 <script type=idl>
 dictionary GPUShaderModuleCompilationHint {
+    required USVString entryPoint;
     (GPUPipelineLayout or GPUAutoLayoutMode) layout;
 };
 </script>
@@ -6659,10 +6659,11 @@ dictionary GPUShaderModuleCompilationHint {
     {{GPUDevice/createShaderModule()}} and {{GPUDevice/createComputePipeline()}} /
     {{GPUDevice/createRenderPipeline()}}.
 
-    If an author is unable to provide hint information at the time of calling
-    {{GPUDevice/createShaderModule()}}, they should usually not delay calling
-    {{GPUDevice/createShaderModule()}}; but should instead just omit the unknown information from
-    {{GPUShaderModuleDescriptor/hints}} or {{GPUShaderModuleCompilationHint}}. Omitting this information
+    If an application is unable to provide hint information at the time of calling
+    {{GPUDevice/createShaderModule()}}, it should usually not delay calling
+    {{GPUDevice/createShaderModule()}}, but instead just omit the unknown information from
+    the {{GPUShaderModuleDescriptor/compilationHints}} sequence or the individual members of
+    {{GPUShaderModuleCompilationHint}}. Omitting this information
     may cause compilation to be deferred to {{GPUDevice/createComputePipeline()}} /
     {{GPUDevice/createRenderPipeline()}}.
 


### PR DESCRIPTION
This is a non-breaking change:
- `hints` was optional and had no normative behavior (and was not implemented in any shipping implementation except for the IDL in Chromium). If it is used, IDL rules will ignore it.
- `compilationHints` is still optional

Fixes #4338