### PR TITLE
WGSL: Fix explanation of hyperbolic angles.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -497,6 +497,21 @@ Following syntax notation describes the conventions of the syntactic grammar of 
     * The angle &pi; points from the origin to the point (-1,0)
     * The angle (3/2)&pi; points from the origin to the point (0,-1)
 
+A <dfn noexport>hyperbolic angle</dfn> is a unitless area, not an angle in the traditional
+sense. Specifically:
+
+*   Consider the hyperbola |x|<sup>2</sup> - |y|<sup>2</sup> = 1 for |x| &gt; 0.
+
+*   Let |R| be a ray from the origin to some point (|x|, |y|) on the hyperbola.
+
+*   Let |a| be twice the area enclosed by |R|, the |x| axis, and the curve of the hyperbola
+    itself.
+
+*   Consider |a| to be positive when |R| is above the |x| axis, and negative when below.
+
+Then the area |a| is a hyperbolic angle such that |x| is the hyperbolic cosine of |a|, and
+|y| is the hyperbolic sine of |a|.
+
 An <dfn noexport>interval</dfn> is a contiguous set of numbers with a lower and upper bound.
 Depending on context, they are sets of integers, floating point numbers, or real numbers.
 * The closed interval [*a*,*b*] is the set of numbers *x* such that *a* &le; *x* &le; *b*.
@@ -13207,23 +13222,22 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
     <td style="width:10%">Overload
     <td class="nowrap">
       <xmp highlight=wgsl>
-        @const @must_use fn acosh(e: T) -> T
+        @const @must_use fn acosh(x: T) -> T
       </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the inverse hyperbolic cosine (cosh<sup>-1</sup>) of `e`, as a
-    hyperbolic [=angle=] in radians.<br>
-    That is, approximates `x` with 0 &le; x &le; &infin;, such that `cosh`(`x`) = `e`.
+    <td>Returns the inverse hyperbolic cosine (cosh<sup>-1</sup>) of `x`, as a [=hyperbolic angle=].<br>
+    That is, approximates `a` with 0 &le; a &le; &infin;, such that `cosh`(`a`) = `x`.
 
     [=Component-wise=] when `T` is a vector.
   <tr>
     <td>
     <td>
 
-Note: The result is not mathematically meaningful when `e` &lt; 1.
+Note: The result is not mathematically meaningful when `x` &lt; 1.
 
 </table>
 
@@ -13257,15 +13271,15 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
     <td style="width:10%">Overload
     <td class="nowrap">
       <xmp highlight=wgsl>
-        @const @must_use fn asinh(e: T) -> T
+        @const @must_use fn asinh(y: T) -> T
       </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the inverse hyperbolic sine (sinh<sup>-1</sup>) of `e`, as a hyperbolic [=angle=] in radians.<br>
-    That is, approximates `x` such that `sinh`(`x`) = `e`.
+    <td>Returns the inverse hyperbolic sine (sinh<sup>-1</sup>) of `y`, as a [=hyperbolic angle=].<br>
+    That is, approximates `a` such that `sinh`(`y`) = `a`.
 
     [=Component-wise=] when `T` is a vector.
 </table>
@@ -13295,22 +13309,22 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
     <td style="width:10%">Overload
     <td class="nowrap">
       <xmp highlight=wgsl>
-        @const @must_use fn atanh(e: T) -> T
+        @const @must_use fn atanh(t: T) -> T
       </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the inverse hyperbolic tangent (tanh<sup>-1</sup>) of `e`, as a hyperbolic [=angle=] in radians.<br>
-    That is, approximates `x` such that `tanh`(`x`) = `e`.
+    <td>Returns the inverse hyperbolic tangent (tanh<sup>-1</sup>) of `t`, as a [=hyperbolic angle=].<br>
+    That is, approximates `a` such that `tanh`(`a`) = `t`.
 
     [=Component-wise=] when `T` is a vector.
   <tr>
     <td>
     <td>
 
-Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
+Note: The result is not mathematically meaningful when `abs(t)` &ge; 1.
 
 </table>
 
@@ -13415,15 +13429,15 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td style="width:10%">Overload
     <td class="nowrap">
       <xmp highlight=wgsl>
-        @const @must_use fn cosh(arg: T) -> T
+        @const @must_use fn cosh(a: T) -> T
       </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the hyperbolic cosine of `arg`, where `arg` is a hyperbolic [=angle=] in radians.
-    Approximates the pure mathematical function (*e*<sup>arg</sup> + *e*<sup>&minus;arg</sup>)&divide;2,
+    <td>Returns the hyperbolic cosine of `a`, where `a` is a [=hyperbolic angle=].
+    Approximates the pure mathematical function (*e*<sup>a</sup> + *e*<sup>&minus;a</sup>)&divide;2,
     but not necessarily computed that way.
 
     [=Component-wise=] when `T` is a vector
@@ -14782,16 +14796,16 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td style="width:10%">Overload
     <td class="nowrap">
       <xmp highlight=wgsl>
-        @const @must_use fn sinh(e: T) -> T
+        @const @must_use fn sinh(a: T) -> T
       </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the hyperbolic sine of `e`, where `e` is a hyperbolic [=angle=] in radians.
+    <td>Returns the hyperbolic sine of `a`, where `a` is a [=hyperbolic angle=].
     Approximates the pure mathematical function
-    (*e*<sup>arg</sup> &minus; *e*<sup>&minus;arg</sup>)&divide;2,
+    (*e*<sup>a</sup> &minus; *e*<sup>&minus;a</sup>)&divide;2,
     but not necessarily computed that way.
 
     [=Component-wise=] when `T` is a vector.
@@ -14878,16 +14892,16 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td style="width:10%">Overload
     <td class="nowrap">
       <xmp highlight=wgsl>
-        @const @must_use fn tanh(e: T) -> T
+        @const @must_use fn tanh(a: T) -> T
       </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the hyperbolic tangent of `e`, where `e` is a hyperbolic [=angle=] in radians.
+    <td>Returns the hyperbolic tangent of `a`, where `a` is a [=hyperbolic angle=].
     Approximates the pure mathematical function
-    (*e*<sup>arg</sup> &minus; *e*<sup>&minus;arg</sup>) &divide (*e*<sup>arg</sup> + *e*<sup>&minus;arg</sup>)
+    (*e*<sup>a</sup> &minus; *e*<sup>&minus;a</sup>) &divide (*e*<sup>a</sup> + *e*<sup>&minus;a</sup>)
     but not necessarily computed that way.
 
     [=Component-wise=] when `T` is a vector.


### PR DESCRIPTION
Define "hyperbolic angle", and cite that in the specification of hyperbolic functions. Do not claim they are measured in radians.

Use appropriate metavariable names in definitions of hyperbolic functions; `e` is awkward, given the hyperbolic functions' close association with the natural exponential function.