### PR TITLE
Remove unnecessary anchrors for access mode

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -286,10 +286,6 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
             text: wgslLanguageFeatures; url: gpuwgsllanguagefeatures
     type: abstract-op
         text: validating GPUProgrammableStage; url: abstract-opdef-validating-gpuprogrammablestage
-    type: enum-value
-        for: GPUStorageTextureAccess
-            text: read-only; url: dom-gpustoragetextureaccess-read-only
-            text: read-write; url: dom-gpustoragetextureaccess-read-write
 </pre>
 
 # Introduction # {#intro}


### PR DESCRIPTION
Pull #4326 introduced temporary anchors for "read-only" and "read-write" storage texture access.
This commit removes them since the real anchors are landed in the API spec.