### PR TITLE
Disallow requesting alignment limits that are ≥ 2**32

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2668,7 +2668,7 @@ interface GPUAdapter {
                             - |value| must be no [=limit/better=] than the value of that limit in
                                 |adapter|.{{adapter/[[limits]]}}.
                             - If the limit's [=limit class|class=] is [=limit class/alignment=],
-                                |value| must be a power of 2.
+                                |value| must be a power of 2 less than 2<sup>32</sup>.
                     </div>
 
                     Then issue the following steps on <var data-timeline=content>contentTimeline</var>


### PR DESCRIPTION
This text used to allow requesting alignment limits like 2<sup>32</sup> or 2<sup>53</sup>. This didn't do anything useful, but it adds implementation complexity, because, per this spec, alignment limits are 32-bit integers. In order to implement that you would need a special case to handle the casting of the `GPUSize64` (from the `record<DOMString, GPUSize64>`) to a `uint32_t` internally.

Test: https://github.com/gpuweb/cts/pull/3132
Chromium: https://chromium-review.googlesource.com/c/chromium/src/+/5002999