### PR TITLE
editorial: clip position definition links to clip space coords

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14538,7 +14538,7 @@ Primitives are assembled by a fixed-function stage of GPUs.
 ### Primitive Clipping ### {#primitive-clipping}
 
 Vertex shaders have to produce a built-in [=position builtin|position=] (of type `vec4<f32>`),
-which denotes the <dfn dfn>clip position</dfn> of a vertex.
+which denotes the <dfn dfn>clip position</dfn> of a vertex in [=clip space coordinates=].
 
 Primitives are clipped to the <dfn dfn>clip volume</dfn>, which, for any [=clip position=] |p|
 inside a primitive, is defined by the following inequalities:


### PR DESCRIPTION
This addresses a comment from code review: https://github.com/gpuweb/gpuweb/pull/4128/files#r1204975296