### PR TITLE
Specify copy rules for different canvas contexts

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -72,9 +72,13 @@ spec: WebCodecs; urlPrefix: https://www.w3.org/TR/webcodecs/#
         text: Close VideoFrame; url: close-videoframe
 spec: WEBGL-1; urlPrefix: https://www.khronos.org/registry/webgl/specs/latest/1.0/#
     type: interface
-        text: WebGLRenderingContext; url: WEBGLRENDERINGCONTEXT
-    type: attribute; for: WebGLRenderingContext
+        text: WebGLRenderingContextBase; url: WEBGLRENDERINGCONTEXTBASE
+    type: attribute; for: WebGLRenderingContextBase
         text: drawingBufferColorSpace; url: DOM-WebGLRenderingContext-drawingBufferColorSpace
+    type: attribute; for: WebGLRenderingContextBase
+        text: drawingBufferWidth; url: DOM-WebGLRenderingContext-drawingBufferWidth
+    type: attribute; for: WebGLRenderingContextBase
+        text: drawingBufferHeight; url: DOM-WebGLRenderingContext-drawingBufferHeight
     type: dictionary
         text: WebGLContextAttributes; url: WEBGLCONTEXTATTRIBUTES
 spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
@@ -2174,7 +2178,7 @@ For various image sources of {{GPUImageCopyExternalImage}}:
     - Color space is controlled via the {{CanvasRenderingContext2DSettings/colorSpace}} context creation attribute.
 - WebGL canvas:
     - Premultiplication is controlled via the `premultipliedAlpha` option in {{WebGLContextAttributes}}.
-    - Color space is controlled via the {{WebGLRenderingContext}}'s {{WebGLRenderingContext/drawingBufferColorSpace}} state.
+    - Color space is controlled via the {{WebGLRenderingContextBase}}'s {{WebGLRenderingContextBase/drawingBufferColorSpace}} state.
 
 Note: Check browser implementation support for these features before relying on them.
 

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -277,6 +277,10 @@ dictionary GPUImageCopyExternalImage {
                     <td>{{ImageBitmap/width|ImageBitmap.width}}
                     <td>{{ImageBitmap/height|ImageBitmap.height}}
                 <tr>
+                    <td>{{HTMLImageElement}}
+                    <td>{{HTMLImageElement/naturalWidth|HTMLImageElement.naturalWidth}}
+                    <td>{{HTMLImageElement/naturalHeight|HTMLImageElement.naturalHeight}}
+                <tr>
                     <td>{{HTMLVideoElement}}
                     <td>[=video/intrinsic width|intrinsic width of the frame=]
                     <td>[=video/intrinsic height|intrinsic height of the frame=]
@@ -285,13 +289,21 @@ dictionary GPUImageCopyExternalImage {
                     <td>{{VideoFrame/codedWidth|VideoFrame.codedWidth}}
                     <td>{{VideoFrame/codedHeight|VideoFrame.codedHeight}}
                 <tr>
-                    <td>{{HTMLCanvasElement}}
+                    <td>{{ImageData}}
+                    <td>{{ImageData/width|ImageData.width}}
+                    <td>{{ImageData/height|ImageData.height}}
+                <tr>
+                    <td>{{HTMLCanvasElement}} or {{OffscreenCanvas}} with {{CanvasRenderingContext2D}} or {{GPUCanvasContext}}
                     <td>{{HTMLCanvasElement/width|HTMLCanvasElement.width}}
                     <td>{{HTMLCanvasElement/height|HTMLCanvasElement.height}}
                 <tr>
-                    <td>{{OffscreenCanvas}}
-                    <td>{{OffscreenCanvas/width|OffscreenCanvas.width}}
-                    <td>{{OffscreenCanvas/height|OffscreenCanvas.height}}
+                    <td>{{HTMLCanvasElement}} or {{OffscreenCanvas}} with {{WebGLRenderingContextBase}}
+                    <td>{{WebGLRenderingContextBase/drawingBufferWidth|WebGLRenderingContextBase.drawingBufferWidth}}
+                    <td>{{WebGLRenderingContextBase/drawingBufferHeight|WebGLRenderingContextBase.drawingBufferHeight}}
+                <tr>
+                    <td>{{HTMLCanvasElement}} or {{OffscreenCanvas}} with {{ImageBitmapRenderingContext}}
+                    <td>{{ImageBitmapRenderingContext}}'s internal output bitmap {{ImageBitmap/width|ImageBitmap.width}}
+                    <td>{{ImageBitmapRenderingContext}}'s internal output bitmap  {{ImageBitmap/height|ImageBitmap.height}}
             </tbody>
         </table>
 

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -268,42 +268,42 @@ dictionary GPUImageCopyExternalImage {
             <thead>
                 <tr>
                     <th>Source type
-                    <th>Width
-                    <th>Height
+                    <th>Dimensions
             </thead>
             <tbody>
                 <tr>
                     <td>{{ImageBitmap}}
-                    <td>{{ImageBitmap/width|ImageBitmap.width}}
-                    <td>{{ImageBitmap/height|ImageBitmap.height}}
+                    <td>{{ImageBitmap/width|ImageBitmap.width}},
+                        {{ImageBitmap/height|ImageBitmap.height}}
                 <tr>
                     <td>{{HTMLImageElement}}
-                    <td>{{HTMLImageElement/naturalWidth|HTMLImageElement.naturalWidth}}
-                    <td>{{HTMLImageElement/naturalHeight|HTMLImageElement.naturalHeight}}
+                    <td>{{HTMLImageElement/naturalWidth|HTMLImageElement.naturalWidth}},
+                        {{HTMLImageElement/naturalHeight|HTMLImageElement.naturalHeight}}
                 <tr>
                     <td>{{HTMLVideoElement}}
-                    <td>[=video/intrinsic width|intrinsic width of the frame=]
-                    <td>[=video/intrinsic height|intrinsic height of the frame=]
+                    <td>[=video/intrinsic width|intrinsic width of the frame=],
+                        [=video/intrinsic height|intrinsic height of the frame=]
                 <tr>
                     <td>{{VideoFrame}}
-                    <td>{{VideoFrame/codedWidth|VideoFrame.codedWidth}}
-                    <td>{{VideoFrame/codedHeight|VideoFrame.codedHeight}}
+                    <td>{{VideoFrame/codedWidth|VideoFrame.codedWidth}},
+                        {{VideoFrame/codedHeight|VideoFrame.codedHeight}}
                 <tr>
                     <td>{{ImageData}}
-                    <td>{{ImageData/width|ImageData.width}}
-                    <td>{{ImageData/height|ImageData.height}}
+                    <td>{{ImageData/width|ImageData.width}},
+                        {{ImageData/height|ImageData.height}}
                 <tr>
                     <td>{{HTMLCanvasElement}} or {{OffscreenCanvas}} with {{CanvasRenderingContext2D}} or {{GPUCanvasContext}}
-                    <td>{{HTMLCanvasElement/width|HTMLCanvasElement.width}}
-                    <td>{{HTMLCanvasElement/height|HTMLCanvasElement.height}}
+                    <td>{{HTMLCanvasElement/width|HTMLCanvasElement.width}},
+                        {{HTMLCanvasElement/height|HTMLCanvasElement.height}}
                 <tr>
                     <td>{{HTMLCanvasElement}} or {{OffscreenCanvas}} with {{WebGLRenderingContextBase}}
-                    <td>{{WebGLRenderingContextBase/drawingBufferWidth|WebGLRenderingContextBase.drawingBufferWidth}}
-                    <td>{{WebGLRenderingContextBase/drawingBufferHeight|WebGLRenderingContextBase.drawingBufferHeight}}
+                    <td>{{WebGLRenderingContextBase/drawingBufferWidth|WebGLRenderingContextBase.drawingBufferWidth}},
+                        {{WebGLRenderingContextBase/drawingBufferHeight|WebGLRenderingContextBase.drawingBufferHeight}}
                 <tr>
                     <td>{{HTMLCanvasElement}} or {{OffscreenCanvas}} with {{ImageBitmapRenderingContext}}
-                    <td>{{ImageBitmapRenderingContext}}'s internal output bitmap {{ImageBitmap/width|ImageBitmap.width}}
-                    <td>{{ImageBitmapRenderingContext}}'s internal output bitmap  {{ImageBitmap/height|ImageBitmap.height}}
+                    <td>{{ImageBitmapRenderingContext}}'s internal output bitmap
+                        {{ImageBitmap/width|ImageBitmap.width}}, 
+                        {{ImageBitmap/height|ImageBitmap.height}}
             </tbody>
         </table>
 


### PR DESCRIPTION
WebGL contexts use context.drawingBufferWidth and
context.drawingBufferHeight.

ImageBitmapRenderingContexts use their internal
"output bitmap"'s width and height (which are
opaque to the app) but the app itself
added the ImageBitmap to the context
and so had it's chance to know the size.

HTMLImageElement uses naturalWidth and naturalHeight

ImageData uses width, heigh

See #4255 and #4256

Note: It wasn't clear to me what to link to. The WebGL IDL lists these properties as part of WebGLRenderingContextxBase which is used by both WebGL and WebGL2. Further, they're only specified in the WebGL spec but not the WebGL2 spec. The links current go the the place these are documented.

Also, it wasn't clear if I should break out the OffscreenCanvas ones into separate issues. I think they are the same so I combined them rather than adding 3 separate sections, one for each type of context.

Similarly I combined CanvasRenderingContext2D and GPUCanvasContext as they have the same behavior. I can separate those if that's better.

I'm guessing there's probably more specs needed for the color space issues from these sources.