### PR TITLE
Remove GPUCommandEncoder.writeTimestamp

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9446,8 +9446,6 @@ interface GPUCommandEncoder {
         optional GPUSize64 offset = 0,
         optional GPUSize64 size);
 
-    undefined writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
-
     undefined resolveQuerySet(
         GPUQuerySet querySet,
         GPUSize32 firstQuery,
@@ -10005,54 +10003,6 @@ dictionary GPUCommandEncoderDescriptor
 ## Queries ## {#command-encoder-queries}
 
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
-    : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
-    ::
-        Writes a timestamp value into a querySet when all previous commands have completed executing.
-
-        Note: Timestamp query values are written in nanoseconds, but how the value is determined is
-        implementation-defined and may not increase monotonically. See [[#timestamp]] for details.
-
-        <div algorithm=GPUCommandEncoder.writeTimestamp>
-            <div data-timeline=content>
-                **Called on:** {{GPUCommandEncoder}} |this|.
-
-                **Arguments:**
-
-                <pre class=argumentdef for="GPUCommandEncoder/writeTimestamp(querySet, queryIndex)">
-                    |querySet|: The query set that will store the timestamp values.
-                    |queryIndex|: The index of the query in the query set.
-                </pre>
-
-                **Returns:** {{undefined}}
-
-                [=Content timeline=] steps:
-
-                1. If {{GPUFeatureName/"timestamp-query"}} is not [=enabled for=] |this|:
-                    1. Throw a {{TypeError}}.
-                1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
-            </div>
-            <div data-timeline=device>
-                [=Device timeline=] steps:
-
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
-
-                    <div class=validusage>
-                        - |querySet| is [$valid to use with$] |this|.
-                        - |querySet|.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
-                        - |queryIndex| &lt; |querySet|.{{GPUQuerySet/count}}.
-                    </div>
-
-                1. [$Enqueue a command$] on |this| which issues the subsequent steps on the
-                    [=Queue timeline=] when executed.
-            </div>
-            <div data-timeline=queue>
-                [=Queue timeline=] steps:
-
-                1. Write the [$current queue timestamp$] into |querySet| at index |queryIndex|.
-            </div>
-        </div>
-
     : <dfn>resolveQuerySet(querySet, firstQuery, queryCount, destination, destinationOffset)</dfn>
     ::
         Resolves query results from a {{GPUQuerySet}} out into a range of a {{GPUBuffer}}.
@@ -13130,7 +13080,6 @@ and ended by calling {{GPURenderPassEncoder/beginOcclusionQuery()}} and
 
 Timestamp queries allow applications to write timestamps to a {{GPUQuerySet}}, using:
 
-- {{GPUCommandEncoder}}.{{GPUCommandEncoder/writeTimestamp()}}
 - {{GPUComputePassDescriptor}}.{{GPUComputePassDescriptor/timestampWrites}}
 - {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/timestampWrites}}
 
@@ -15324,8 +15273,6 @@ This feature adds the following [=optional API surfaces=]:
 
 - New {{GPUQueryType}} values:
     - {{GPUQueryType/"timestamp"}}
-- New {{GPUCommandEncoder}} methods:
-    - {{GPUCommandEncoder/writeTimestamp()}}
 - New {{GPUComputePassDescriptor}} members:
     - {{GPUComputePassDescriptor/timestampWrites}}
 - New {{GPURenderPassDescriptor}} members:


### PR DESCRIPTION
As discussed in GPU Web 2023-11-08 meeting (notes link is coming), this PR removes `GPUCommandEncoder.writeTimestamp` from the spec.

@kainino0x Please review.

cc #3952