### PR TITLE
Clarify matching of pipeline constant identifiers.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -86,6 +86,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: location; url: input-output-locations
         text: interpolation; url: interpolation
         text: pipeline-overridable; url: pipeline-overridable
+        text: pipeline constant ID; url: pipeline-constant-id
         text: pipeline-overridable constant identifier string; url: pipeline-overridable-constant-identifier-string
         text: pipeline-overridable constant default value; url: pipeline-overridable-constant-default-value
         text: interface of a shader stage; url: interface-of-a-shader
@@ -7274,11 +7275,14 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         {{GPUProgrammableStage/module}}.
 
         Each such [=pipeline-overridable=] constant is uniquely identified by a single
-        [=pipeline-overridable constant identifier string=] (representing the numeric ID of the
-        constant, if one is specified, and otherwise the constant's identifier name).
-        WGSL names (identifiers) in source maps follow the rules defined in [=WGSL identifier comparison=].
+        [=pipeline-overridable constant identifier string=], representing the [=pipeline
+        constant ID=] of the constant if its declaration specifies one, and otherwise the
+        constant's identifier name.
 
-        The key of each key-value pair must equal the identifier string of one such constant.
+        The key of each key-value pair must equal the
+        [=pipeline-overridable constant identifier string|identifier string=]
+        of one such constant, with the comparison performed
+        according to the rules for [=WGSL identifier comparison=].
         When the pipeline is executed, that constant will have the specified value.
 
         Values are specified as <dfn typedef for="">GPUPipelineConstantValue</dfn>, which is a {{double}}.


### PR DESCRIPTION
In the explanation for `GPUProgrammableStage`'s `constants` member, remove misplaced reference to "source maps", and clarify how the WGSL identifier comparison rules are applied.