### PR TITLE
Do not always require GPUProgrammableStage.entryPoint

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7365,8 +7365,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     - If |descriptor|.{{GPUProgrammableStage/entryPoint}} is not `null`:
 
         - |descriptor|.{{GPUProgrammableStage/module}} must contain exactly one
-            entry point for shader stage |stage| with a name equalling
-            |descriptor|.{{GPUProgrammableStage/entryPoint}}.
+            entry point with a name equalling |descriptor|.{{GPUProgrammableStage/entryPoint}},
+            and its shader stage must equal |stage|.
 
         Otherwise:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7335,13 +7335,18 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
 </dl>
 
 <div algorithm>
-    To get the <dfn abstract-op>entry point</dfn>({{GPUShaderStage}} |stage|,
+    To <dfn abstract-op>get the entry point</dfn>({{GPUShaderStage}} |stage|,
     {{GPUProgrammableStage}} |descriptor|)
 
-    - If |descriptor|.{{GPUProgrammableStage/entryPoint}} is not `null`, return
-        |descriptor|.{{GPUProgrammableStage/entryPoint}}.
-    - Return the name of the entry point in |descriptor|.{{GPUProgrammableStage/module}} for shader
-        stage |stage|.
+    - If |descriptor|.{{GPUProgrammableStage/entryPoint}} is not `null`:
+
+        - Return the single entry point in |descriptor|.{{GPUProgrammableStage/module}}
+            with a name equalling |descriptor|.{{GPUProgrammableStage/entryPoint}}.
+
+        Otherwise:
+
+        - Return the single entry point in |descriptor|.{{GPUProgrammableStage/module}}
+            with a shader stage equalling |stage|.
 
 </div>
 
@@ -7357,11 +7362,16 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     Return `true` if all of the following conditions are met, and `false` otherwise:
 
     - |descriptor|.{{GPUProgrammableStage/module}} must be a [=valid=] {{GPUShaderModule}}.
-    - If |descriptor|.{{GPUProgrammableStage/entryPoint}} is not `null`,
-        |descriptor|.{{GPUProgrammableStage/module}} must contain an entry point, for shader stage
-        |stage|, named |descriptor|.{{GPUProgrammableStage/entryPoint}}. Otherwise,
-        |descriptor|.{{GPUProgrammableStage/module}} must contain exactly one entry point for shader
-        stage |stage|.
+    - If |descriptor|.{{GPUProgrammableStage/entryPoint}} is not `null`:
+
+        - |descriptor|.{{GPUProgrammableStage/module}} must contain exactly one
+            entry point for shader stage |stage| with a name equalling
+            |descriptor|.{{GPUProgrammableStage/entryPoint}}.
+
+        Otherwise:
+
+        - |descriptor|.{{GPUProgrammableStage/module}} must contain exactly one
+            entry point for shader stage |stage|.
     - For each |binding| that is [=statically used=] by |descriptor|:
         - [$validating shader binding$](|binding|, |layout|) must return `true`.
     - For each texture and sampler [=statically used=] together in texture sampling call in |descriptor|:
@@ -8327,7 +8337,7 @@ dictionary GPUFragmentState
             - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}
                 must be a [=valid GPUBlendComponent=].
         - |colorState|.{{GPUColorTargetState/writeMask}} must be &lt; 16.
-        - If [$entry point$]({{GPUShaderStage/FRAGMENT}}, |descriptor|) has a
+        - If [$get the entry point$]({{GPUShaderStage/FRAGMENT}}, |descriptor|) has a
             [=shader stage output=] value |output| with [=location=] attribute equal to |index|:
 
             - For each component in |colorState|.{{GPUColorTargetState/format}}, there must be a

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7338,7 +7338,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     To <dfn abstract-op>get the entry point</dfn>({{GPUShaderStage}} |stage|,
     {{GPUProgrammableStage}} |descriptor|)
 
-    - If |descriptor|.{{GPUProgrammableStage/entryPoint}} is not `null`:
+    - If |descriptor|.{{GPUProgrammableStage/entryPoint}} is [=map/exists|provided=]:
 
         - Return the single entry point in |descriptor|.{{GPUProgrammableStage/module}}
             with a name equalling |descriptor|.{{GPUProgrammableStage/entryPoint}}.
@@ -7362,7 +7362,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     Return `true` if all of the following conditions are met, and `false` otherwise:
 
     - |descriptor|.{{GPUProgrammableStage/module}} must be a [=valid=] {{GPUShaderModule}}.
-    - If |descriptor|.{{GPUProgrammableStage/entryPoint}} is not `null`:
+    - If |descriptor|.{{GPUProgrammableStage/entryPoint}} is [=map/exists|provided=]:
 
         - |descriptor|.{{GPUProgrammableStage/module}} must contain exactly one
             entry point with a name equalling |descriptor|.{{GPUProgrammableStage/entryPoint}},

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7249,7 +7249,7 @@ Entry point names follow the rules defined in [=WGSL identifier comparison=].
 <script type=idl>
 dictionary GPUProgrammableStage {
     required GPUShaderModule module;
-    required USVString entryPoint;
+    USVString entryPoint;
     record<USVString, GPUPipelineConstantValue> constants;
 };
 
@@ -7334,6 +7334,17 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         </div>
 </dl>
 
+<div algorithm>
+    To get the <dfn abstract-op>entry point</dfn>({{GPUShaderStage}} |stage|,
+    {{GPUProgrammableStage}} |descriptor|)
+
+    - If |descriptor|.{{GPUProgrammableStage/entryPoint}} is not `null`, return
+        |descriptor|.{{GPUProgrammableStage/entryPoint}}.
+    - Return the name of the entry point in |descriptor|.{{GPUProgrammableStage/module}} for shader
+        stage |stage|.
+
+</div>
+
 <div algorithm data-timeline=device>
     <dfn abstract-op>validating GPUProgrammableStage</dfn>(stage, descriptor, layout)
 
@@ -7346,9 +7357,11 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     Return `true` if all of the following conditions are met, and `false` otherwise:
 
     - |descriptor|.{{GPUProgrammableStage/module}} must be a [=valid=] {{GPUShaderModule}}.
-    - |descriptor|.{{GPUProgrammableStage/module}} must contain
-        an entry point, for shader stage |stage|,
-        named |descriptor|.{{GPUProgrammableStage/entryPoint}}.
+    - If |descriptor|.{{GPUProgrammableStage/entryPoint}} is not `null`,
+        |descriptor|.{{GPUProgrammableStage/module}} must contain an entry point, for shader stage
+        |stage|, named |descriptor|.{{GPUProgrammableStage/entryPoint}}. Otherwise,
+        |descriptor|.{{GPUProgrammableStage/module}} must contain exactly one entry point for shader
+        stage |stage|.
     - For each |binding| that is [=statically used=] by |descriptor|:
         - [$validating shader binding$](|binding|, |layout|) must return `true`.
     - For each texture and sampler [=statically used=] together in texture sampling call in |descriptor|:
@@ -8314,8 +8327,8 @@ dictionary GPUFragmentState
             - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}
                 must be a [=valid GPUBlendComponent=].
         - |colorState|.{{GPUColorTargetState/writeMask}} must be &lt; 16.
-        - If |descriptor|.{{GPUProgrammableStage/entryPoint}} has a [=shader stage output=] value |output|
-            with [=location=] attribute equal to |index|:
+        - If [$entry point$]({{GPUShaderStage/FRAGMENT}}, |descriptor|) has a
+            [=shader stage output=] value |output| with [=location=] attribute equal to |index|:
 
             - For each component in |colorState|.{{GPUColorTargetState/format}}, there must be a
                 corresponding component in |output|.


### PR DESCRIPTION
In an effort to move https://github.com/gpuweb/gpuweb/issues/4342 forward, this PR makes WebGPU spec not always require `GPUProgrammableStage.entryPoint` as discussed in https://github.com/gpuweb/gpuweb/wiki/GPU-Web-2023-11-08#default-entrypoints-to-shader-modules-4342-corentin-is-very-excited-about-this-tiny-addition

@kainino0x Can you have a look at this?