### PR TITLE
WGSL: Using a single swizzle letter produces a scalar.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5179,7 +5179,7 @@ A convenience letter [=shader-creation error|must not=] access a component past 
 
 The convenience letterings can be applied in any order, including duplicating letters as needed.
 The provided number of letters [=shader-creation error|must=] be between 1 and 4.
-That is, using convenience letters can only produce a valid vector type.
+That is, using convenience letters can only produce a scalar type or a valid vector type.
 
 The result type depends on the number of letters provided. Assuming a `vec4<f32>`
 <table>


### PR DESCRIPTION
In "Vector Access Expression", admit that supplying 1 through 4 convenience letters in a swizzle name can produce not only vectors, but scalars.