### PR TITLE
Update packed_4x8_integer_dot_product description

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1690,8 +1690,12 @@ Extension names are not [=identifiers=]: they do not [=resolves|resolve=] to [=d
   <tr><td>packed_4x8_integer_dot_product
       <td>
       Supports using 32-bit integer scalars packing 4-component vectors of 8-bit integers as inputs
-      to the dot product instructions, packing and unpacking instructions with packed 4-component
-      vectors of 8-bit integers
+      to the dot product instructions with [[#dot4U8Packed-builtin|dot4U8Packed]] and
+      [[#dot4I8Packed-builtin|dot4I8Packed]] built-in functions.
+      Additionally, adds packing and unpacking instructions with packed 4-component vectors of
+      8-bit integers with [[#pack4xI8-builtin|pack4xI8]], [[#pack4xU8-builtin|pack4xU8]],
+      [[#pack4xI8Clamp-builtin|pack4xI8Clamp]], [[#pack4xU8Clamp-builtin|pack4xU8Clamp]],
+      [[#unpack4xI8-builtin|unpack4xI8]], and [[#unpack4xU8-builtin|unpack4xU8]] built-in functions.
   <tr><td>unrestricted_pointer_parameters
       <td>
       Removes the following [[#function-restriction|restrictions]] from [=user-defined functions=]:


### PR DESCRIPTION
This PR links all built-in functions for DP4a in the `packed_4x8_integer_dot_product` description so that it's clear to users what this language extension enables.