### PR TITLE
Mention that sample_index causes per-sample fragment shader execution

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8975,6 +8975,9 @@ Each is described in detail in subsequent sections.
       Sample index for the current fragment.  The value is least 0 and at most
       `sampleCount`-1, where `sampleCount` is the MSAA sample
       {{GPUMultisampleState/count}} specified for the GPU render pipeline.
+      When this attribute is applied, if the effects of the fragment shader would vary based
+      on the value of [=built-in values/sample_index=], the [=fragment=] shader will be invoked
+      once per sample.
 
       See [[WebGPU#gpurenderpipeline]].
 </table>


### PR DESCRIPTION
I'm not entirely sure how to word this but

* Metal Shading Language Specification, section 5.5

  > If you use any of these attributes with arguments to a fragment
  > function, the fragment function may execute per-sample instead of
  > per-pixel. (The implementation may decide to only execute the code
  > that depends on the per-sample values to execute per-sample and the
  > rest of the fragment function may execute per-fragment.)

* Vulkan 1.3.274 section 28.8

  > If a fragment shader entry point statically uses an input variable
  > decorated with a BuiltIn of SampleId or SamplePosition, sample
  > shading is enabled and a value of 1.0 is used instead of
  > minSampleShading

* DirectX 11.3 section 16.3

  > A per-sample value that can be declared(22.3.11) for hardware to
  > initialize in an input register component is the sampleIndex(23.6),
  > generated by the Rasterizer. Requesting this input is one of the
  > ways to force the Pixel Shader into sample-frequency execution.

* OpenGL ES 3.2 section 14.2.2

  > Using gl_SampleID in a fragment shader causes the entire shader to
  > be executed per sample.