### PR TITLE
Disallow sample_index builtin in Compatibility.

### DIFF
--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -89,11 +89,11 @@ A bind group may not reference a subset of array layers. Only views of the entir
 
 **Justification**: OpenGL ES does not support texture views.
 
-### 7. Disallow `sample_mask` builtin in WGSL.
+### 7. Disallow `sample_mask` and `sample_index` builtins in WGSL.
 
-Use of the `sample_mask` builtin would cause a validation error at pipeline creation time.
+Use of the `sample_mask` or `sample_index` builtins would cause a validation error at pipeline creation time.
 
-**Justification**: OpenGL ES 3.1 does not support `gl_SampleMask` or `gl_SampleMaskIn`.
+**Justification**: OpenGL ES 3.1 does not support `gl_SampleMask`, `gl_SampleMaskIn`, or `gl_SampleID`.
 
 ## Issues
 


### PR DESCRIPTION
Disallow sample_index builtin in Compatibility mode.

Disallowed for similar reasons as sample_mask: gl_SampleID is not supported in OpenGL ES 3.1.