### PR TITLE
Fix result type in occlusion query

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13126,7 +13126,8 @@ that no samples passed the tests.
 When beginning a render pass, {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/occlusionQuerySet}}
 must be set to be able to use occlusion queries during the pass. An occlusion query is begun
 and ended by calling {{GPURenderPassEncoder/beginOcclusionQuery()}} and
-{{GPURenderPassEncoder/endOcclusionQuery()}} in pairs that cannot be nested.
+{{GPURenderPassEncoder/endOcclusionQuery()}} in pairs that cannot be nested, and resolved into a
+{{GPUBuffer}} as 64-bit unsigned integer by {{GPUCommandEncoder}}.{{GPUCommandEncoder/resolveQuerySet()}}.
 
 ## Timestamp Query ## {#timestamp}
 


### PR DESCRIPTION
Add missing resolve method and result type in occlusion query section.

Issue: #4427