### PR TITLE
Add scalar value constructors from abstracts

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11972,9 +11972,6 @@ Note: In other words, floating point to integer conversion rounds toward zero, t
 
 </div>
 
-Note: There are no direct conversions from [=AbstractFloat=] to an integer scalar type.
-All conversions first convert to another floating point type ([=f32=] usually).
-
 The <dfn noexport>numeric scalar conversion to floating point</dfn> algorithm is:
 <blockquote>
 When converting a [=numeric scalar=] value to a floating point type:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12214,18 +12214,21 @@ WGSL provides two kinds of value constructors:
 
 Each [=type/concrete=], [=constructible=] *T* has a unique <dfn noexport>zero value</dfn>,
 and a corresponding built-in function written in WGSL as the type followed by an empty pair of parentheses: *T* `()`.
+[=Abstract numeric types=] also have zero values, but there are no built-in function to access them.
 
 The zero values are as follows:
 
 * `bool()` is `false`
-* `i32()` is 0
-* `u32()` is 0
-* `f32()` is 0.0
-* `f16()` is 0.0
+* `i32()` is 0i
+* `u32()` is 0u
+* `f32()` is 0.0f
+* `f16()` is 0.0h
 * The zero value for an *N*-component vector of type *T* is the *N*-component vector of the zero value for *T*.
 * The zero value for an *C*-column *R*-row matrix of type *T* is the matrix of those dimensions filled with the zero value for *T*.
 * The zero value for a [=constructible=] *N*-element array with element type *E* is an array of *N* elements of the zero value for *E*.
 * The zero value for a [=constructible=] structure type *S* is the structure value *S* with zero-valued members.
+* The zero value of an [=AbstractInt=] is 0.
+* The zero value of an [=AbstractFloat=] is 0.0.
 
 Note: WGSL does not have zero built-in functions for [=atomic types=],
 [=runtime-sized=] arrays, or other types that are not [=constructible=].
@@ -12334,7 +12337,7 @@ specify the component type; the component type is inferred from the constructor 
       <td>
         <xmp highlight=wgsl>@const @must_use fn bool(e : T) -> bool</xmp>
   <tr><td>Parameterization
-      <td>`T` is a [=type/concrete=] [=scalar=] type.
+      <td>`T` is a [=scalar=] type.
   <tr><td>Description
       <td>Construct a [=bool=] value.
 
@@ -12350,12 +12353,12 @@ specify the component type; the component type is inferred from the constructor 
       <td>
         <xmp highlight=wgsl>@const @must_use fn f16(e : T) -> f16</xmp>
   <tr><td>Parameterization
-      <td>`T` is a [=type/concrete=] [=scalar=] type
+      <td>`T` is a [=scalar=] type
   <tr><td>Description
       <td>Construct an [=f16=] value.
 
       If `T` is [=f16=], this is an identity operation.<br>
-      If `T` is a [[#integer-types|integer type]] or [=f32=], `e` is converted to [=f16=] (including invalid conversions).<br>
+      If `T` is a [=numeric scalar=] (other than [=f16=]), `e` is converted to [=f16=] (including invalid conversions).<br>
       If `T` is [=bool=], the result is `1.0h` if `e` is `true` and `0.0h` otherwise.
 </table>
 
@@ -12371,7 +12374,7 @@ specify the component type; the component type is inferred from the constructor 
       <td>Construct an [=f32=] value.
 
       If `T` is [=f32=], this is an identity operation.<br>
-      If `T` is a [[#integer-types|integer type]] or [=f16=], `e` is converted to [=f32=] (including invalid conversions).<br>
+      If `T` is a [=numeric scalar=] (other than [=f32=]), `e` is converted to [=f32=] (including invalid conversions).<br>
       If `T` is [=bool=], the result is `1.0f` if `e` is `true` and `0.0f` otherwise.
 </table>
 
@@ -12382,7 +12385,7 @@ specify the component type; the component type is inferred from the constructor 
       <td>
         <xmp highlight=wgsl>@const @must_use fn i32(e : T) -> i32</xmp>
   <tr><td>Parameterization
-      <td>`T` is a [=type/concrete=] [=scalar=] type
+      <td>`T` is a [=scalar=] type
   <tr><td>Description
       <td>Construct an [=i32=] value.
 
@@ -12390,6 +12393,7 @@ specify the component type; the component type is inferred from the constructor 
       If `T` is [=u32=], this is a reinterpretation of bits (i.e. the result is the unique value in [=i32=] that has the same bit pattern as `e`).<br>
       If `T` is a [[#floating-point-types|floating point type]], `e` is [=scalar floating point to integral conversion|converted=] to [=i32=], rounding towards zero.<br>
       If `T` is [=bool=], the result is `1i` if `e` is `true` and `0i` otherwise.
+      If `T` is an [=AbstractInt=], this is an identity operation if `e` can be represented in [=i32=], otherwise it produces a [=shader-creation error=].
 </table>
 
 #### `mat2x2` #### {#mat2x2-builtin}
@@ -12837,7 +12841,7 @@ specify the component type; the component type is inferred from the constructor 
       <td>
         <xmp highlight=wgsl>@const @must_use fn u32(e : T) -> u32</xmp>
   <tr><td>Parameterization
-      <td>`T` is a [=type/concrete=] [=scalar=] type or [=AbstractInt=]
+      <td>`T` is a [=scalar=] type
   <tr><td>Description
       <td>Construct a [=u32=] value.
 


### PR DESCRIPTION
Fixes #4415

* Add zero values for abstract numerics
* Add overloads for scalar value constructors from abstract types for:
  * `bool` - NFC
  * `i32` - avoids conversion to f32 first
  * `f32` - allows `0xffffffff` to f32
  * `f16` - allows `0xffffffff` to f16
  * `u32` - avoids conversion to f32 first