### PR TITLE
Remove ResizeObserver example

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13695,26 +13695,6 @@ In WebGPU, it does so by [$Replace the drawing buffer|replacing the drawing buff
     validation will fail inside {{GPUCanvasContext/getCurrentTexture()}}.
 </div>
 
-<div class=example>
-    Reconfigure a {{GPUCanvasContext}} in response to canvas resize, monitored using
-    [ResizeObserver](https://www.w3.org/TR/resize-observer/) to get the exact pixel dimensions of
-    the canvas:
-
-    <pre highlight=js>
-        const canvas = document.createElement('canvas');
-        const context = canvas.getContext('webgpu');
-
-        const resizeObserver = new ResizeObserver(entries => {
-            for (const entry of entries) {
-                if (entry.target != canvas) { continue; }
-                canvas.width = entry.devicePixelContentBoxSize[0].inlineSize;
-                canvas.height = entry.devicePixelContentBoxSize[0].blockSize;
-            }
-        });
-        resizeObserver.observe(canvas);
-    </pre>
-</div>
-
 <h3 id=gpucanvasalphamode data-dfn-type=enum>`GPUCanvasAlphaMode`
 <span id=GPUCanvasAlphaMode></span>
 </h3>


### PR DESCRIPTION
There are a few issues with this section

1. It says "to get the exact pixel dimensions of the canvas"

   This is false and explaining why would take multiple paragraphs

2. It changes the size of element inside the ResizeObserver

   This is considered bad practice. Talking to internal people, doing this is error prone. MDN indirectly mentions it here https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver#observation_errors

3. If used with requestAnimationFrame it flickers

   According to [the HTML spec's event loop processing spec](https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model), ResizeObserver callbacks happen after requestAnimationFrame. This means

   1. You render an image in your requestAnimationFrame callback
   2. You resize the canvas in a ResizeObserver callback which clears the canvas/expires the texture
   3. You composite a blank texture

   Explaining this issue also seems like it's out of scope for the WebGPU spec

So, rather than add all the necessary details to make this example complete and cover all the various issues I think it's better just to remove the example.

#4388
