### PR TITLE
Add LHS expr rules for * and &

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11175,10 +11175,12 @@ of a [=composite=] type separately.
       [=MayBeNonUniform=]
       <td>
   <tr><td class="nowrap">*e*.field
-      <td>
-      <td class="nowrap">[=LHSValue=]: (*CF*, *e*) => (*CF1*, *L1*)
-      <td class="nowrap">*CF1*, *L1*
-      <td>
+      <td rowspan=3>
+      <td class="nowrap" rowspan=3>[=LHSValue=]: (*CF*, *e*) => (*CF1*, *L1*)
+      <td class="nowrap" rowspan=3>*CF1*, *L1*
+      <td rowspan=3>
+  <tr><td class="nowrap">**e*
+  <tr><td class="nowrap">&*e*
   <tr><td class="nowrap">*e1*[*e2*]
       <td>
       <td class="nowrap">[=LHSValue=]: (*CF*, *e1*) => (*CF1*, *L1*)<br>


### PR DESCRIPTION
* Add uniformity rules for LHSValue expressions of `*` and `&`

See also https://github.com/gpuweb/cts/issues/3266