### PR TITLE
Add SharedWorker support

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13539,6 +13539,11 @@ specified points.
 
     - "update the rendering or user interface of that `Document`"
     - "update the rendering of that dedicated worker"
+    - "update the rendering of that service worker"
+    - "update the rendering of that shared worker"
+
+    Issue(whatwg/html#10112): HTML doesn't define "update the rendering" for service
+    and shared workers yet. Update this text when it does.
 
     Run the following steps:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1863,7 +1863,7 @@ See {{GPUAdapter/limits|GPUAdapter.limits}} and {{GPUDevice/limits|GPUDevice.lim
 <!-- When adding limits here, add them to the Correspondence Reference as well. -->
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureDimension1D;
     readonly attribute unsigned long maxTextureDimension2D;
@@ -1909,7 +1909,7 @@ the {{GPUFeatureName}} values of the [=features=] supported by an adapter or
 device. It must only contain strings from the {{GPUFeatureName}} enum.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUSupportedFeatures {
     readonly setlike<DOMString>;
 };
@@ -1943,7 +1943,7 @@ Its [=set entries=] are the string names of the WGSL [=language extensions=]
 supported by the implementation (regardless of the adapter or device).
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface WGSLLanguageFeatures {
     readonly setlike<DOMString>;
 };
@@ -1965,7 +1965,7 @@ For privacy considerations, see [[#privacy-adapter-identifiers]].
 </p>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUAdapterInfo {
     readonly attribute DOMString vendor;
     readonly attribute DOMString architecture;
@@ -2296,9 +2296,8 @@ them to WGSL values (`bool`, `i32`, `u32`, `f32`, `f16`).
 
 ## navigator.gpu ## {#navigator-gpu}
 
-A {{GPU}} object is available in the {{Window}}, {{DedicatedWorkerGlobalScope}},
-{{ServiceWorkerGlobalScope}} contexts through the {{Navigator}} and {{WorkerNavigator}} interfaces
-respectively and is exposed via `navigator.gpu`:
+A {{GPU}} object is available in the {{Window}} and {{WorkerGlobalScope}} contexts through the
+{{Navigator}} and {{WorkerNavigator}} interfaces respectively and is exposed via `navigator.gpu`:
 
 <script type=idl>
 interface mixin NavigatorGPU {
@@ -2321,7 +2320,7 @@ WorkerNavigator includes NavigatorGPU;
 <dfn interface>GPU</dfn> is the entry point to WebGPU.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPU {
     Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
     GPUTextureFormat getPreferredCanvasFormat();
@@ -2592,7 +2591,7 @@ and describes its capabilities ([=features=] and [=limits=]).
 To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUAdapter {
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
@@ -2886,7 +2885,7 @@ the functionality of that device.
 To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
@@ -3096,7 +3095,7 @@ its mapping.
 Buffers may be {{GPUBufferDescriptor/mappedAtCreation}}.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUBuffer {
     readonly attribute GPUSize64Out size;
     readonly attribute GPUFlagsConstant usage;
@@ -3308,7 +3307,7 @@ dictionary GPUBufferDescriptor
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 namespace GPUBufferUsage {
     const GPUFlagsConstant MAP_READ      = 0x0001;
     const GPUFlagsConstant MAP_WRITE     = 0x0002;
@@ -3548,7 +3547,7 @@ only be unmapped and destroyed on the worker on which it was mapped. Likewise
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUMapModeFlags;
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 namespace GPUMapMode {
     const GPUFlagsConstant READ  = 0x0001;
     const GPUFlagsConstant WRITE = 0x0002;
@@ -3887,7 +3886,7 @@ two-dimensional image at a particular `z` value in the texture.
 Slices are not separate subresources.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUTexture {
     GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {});
 
@@ -4158,7 +4157,7 @@ enum GPUTextureDimension {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 namespace GPUTextureUsage {
     const GPUFlagsConstant COPY_SRC          = 0x01;
     const GPUFlagsConstant COPY_DST          = 0x02;
@@ -4392,7 +4391,7 @@ A {{GPUTextureView}} is a view onto some subset of the [=texture subresources=] 
 a particular {{GPUTexture}}.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUTextureView {
 };
 GPUTextureView includes GPUObjectBase;
@@ -5060,7 +5059,7 @@ External textures use several binding slots: see [=Exceeds the binding slot limi
 </div>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUExternalTexture {
 };
 GPUExternalTexture includes GPUObjectBase;
@@ -5279,7 +5278,7 @@ be used in a shader to interpret texture resource data.
 {{GPUSampler}}s are created via {{GPUDevice/createSampler()}}.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUSampler {
 };
 GPUSampler includes GPUObjectBase;
@@ -5557,7 +5556,7 @@ enum GPUCompareFunction {
 A {{GPUBindGroupLayout}} defines the interface between a set of resources bound in a {{GPUBindGroup}} and their accessibility in shader stages.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUBindGroupLayout {
 };
 GPUBindGroupLayout includes GPUObjectBase;
@@ -5639,7 +5638,7 @@ dictionary GPUBindGroupLayoutEntry {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 namespace GPUShaderStage {
     const GPUFlagsConstant VERTEX   = 0x1;
     const GPUFlagsConstant FRAGMENT = 0x2;
@@ -6045,7 +6044,7 @@ A {{GPUBindGroup}} defines a set of resources to be bound together in a group
     and how the resources are used in shader stages.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUBindGroup {
 };
 GPUBindGroup includes GPUObjectBase;
@@ -6349,7 +6348,7 @@ The full binding address of a resource can be defined as a trio of:
 The components of this address can also be seen as the binding space of a pipeline. A {{GPUBindGroup}} (with the corresponding {{GPUBindGroupLayout}}) covers that space for a fixed bind group index. The contained bindings need to be a superset of the resources used by the shader at this bind group index.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUPipelineLayout {
 };
 GPUPipelineLayout includes GPUObjectBase;
@@ -6506,7 +6505,7 @@ if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
 </h3>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUShaderModule {
     Promise<GPUCompilationInfo> getCompilationInfo();
 };
@@ -6713,7 +6712,7 @@ enum GPUCompilationMessageType {
     "info",
 };
 
-[Exposed=(Window, DedicatedWorker, ServiceWorker), Serializable, SecureContext]
+[Exposed=(Window, Worker), Serializable, SecureContext]
 interface GPUCompilationMessage {
     readonly attribute DOMString message;
     readonly attribute GPUCompilationMessageType type;
@@ -6723,7 +6722,7 @@ interface GPUCompilationMessage {
     readonly attribute unsigned long long length;
 };
 
-[Exposed=(Window, DedicatedWorker, ServiceWorker), Serializable, SecureContext]
+[Exposed=(Window, Worker), Serializable, SecureContext]
 interface GPUCompilationInfo {
     readonly attribute FrozenArray<GPUCompilationMessage> messages;
 };
@@ -6935,7 +6934,7 @@ There are two ways to create pipelines:
 <!--TODO(gpuweb/gpuweb#3709): Change `message` to optional, defaulting to `""`. -->
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext, Serializable]
+[Exposed=(Window, Worker), SecureContext, Serializable]
 interface GPUPipelineError : DOMException {
     constructor(optional DOMString message = "", GPUPipelineErrorInit options);
     readonly attribute GPUPipelineErrorReason reason;
@@ -7593,7 +7592,7 @@ Stages of a compute [=pipeline=]:
 1. Compute shader
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUComputePipeline {
 };
 GPUComputePipeline includes GPUObjectBase;
@@ -7790,7 +7789,7 @@ A render [=pipeline=] is comprised of the following <dfn dfn>render stages</dfn>
 1. Output merging, controlled by {{GPUFragmentState/targets|GPUFragmentState.targets}}
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPURenderPipeline {
 };
 GPURenderPipeline includes GPUObjectBase;
@@ -8442,7 +8441,7 @@ dictionary GPUBlendState {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUColorWriteFlags;
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 namespace GPUColorWrite {
     const GPUFlagsConstant RED   = 0x1;
     const GPUFlagsConstant GREEN = 0x2;
@@ -9359,7 +9358,7 @@ To reuse rendering commands across multiple submissions, use {{GPURenderBundle}}
 </h3>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUCommandBuffer {
 };
 GPUCommandBuffer includes GPUObjectBase;
@@ -9467,7 +9466,7 @@ The <dfn dfn>encoder state</dfn> may be one of the following:
 </h3>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUCommandEncoder {
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
     GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
@@ -10553,7 +10552,7 @@ It must only be included by interfaces which also include those mixins.
 </h3>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUComputePassEncoder {
     undefined setPipeline(GPUComputePipeline pipeline);
     undefined dispatchWorkgroups(GPUSize32 workgroupCountX, optional GPUSize32 workgroupCountY = 1, optional GPUSize32 workgroupCountZ = 1);
@@ -10861,7 +10860,7 @@ called the compute pass encoder can no longer be used.
 </h3>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPURenderPassEncoder {
     undefined setViewport(float x, float y,
         float width, float height,
@@ -12393,7 +12392,7 @@ changing.
 </h3>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPURenderBundle {
 };
 GPURenderBundle includes GPUObjectBase;
@@ -12431,7 +12430,7 @@ dictionary GPURenderBundleDescriptor
 </script>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPURenderBundleEncoder {
     GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor = {});
 };
@@ -12594,7 +12593,7 @@ dictionary GPUQueueDescriptor
 </h3>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUQueue {
     undefined submit(sequence<GPUCommandBuffer> commandBuffers);
 
@@ -12967,7 +12966,7 @@ GPUQueue includes GPUObjectBase;
 </h3>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUQuerySet {
     undefined destroy();
 
@@ -13222,7 +13221,7 @@ which allows changing the canvas configuration without replacing the canvas.
 ## GPUCanvasContext ## {#canvas-context}
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUCanvasContext {
     readonly attribute (HTMLCanvasElement or OffscreenCanvas) canvas;
 
@@ -13540,7 +13539,6 @@ specified points.
 
     - "update the rendering or user interface of that `Document`"
     - "update the rendering of that dedicated worker"
-    - "update the rendering of that service worker"
 
     Run the following steps:
 
@@ -13753,7 +13751,7 @@ enum GPUDeviceLostReason {
     "destroyed",
 };
 
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUDeviceLostInfo {
     readonly attribute GPUDeviceLostReason reason;
     readonly attribute DOMString message;
@@ -13780,7 +13778,7 @@ partial interface GPUDevice {
 </h3>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUError {
     readonly attribute DOMString message;
 };
@@ -13824,7 +13822,7 @@ JSON, for a debug report).
 </dl>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUValidationError
         : GPUError {
     constructor(DOMString message);
@@ -13849,7 +13847,7 @@ error, and is expected to fail the same way across all devices assuming the same
 </div>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUOutOfMemoryError
         : GPUError {
     constructor(DOMString message);
@@ -13874,7 +13872,7 @@ resources is released first.
 </div>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUInternalError
         : GPUError {
     constructor(DOMString message);
@@ -14181,7 +14179,7 @@ normal operation of an application. Prefer using {{GPUDevice/pushErrorScope()}} 
 {{GPUDevice/popErrorScope()}} in those cases.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker, ServiceWorker), SecureContext]
+[Exposed=(Window, Worker), SecureContext]
 interface GPUUncapturedErrorEvent : Event {
     constructor(
         DOMString type,
@@ -14206,7 +14204,7 @@ dictionary GPUUncapturedErrorEventInit : EventInit {
 
 <script type=idl>
 partial interface GPUDevice {
-    [Exposed=(Window, DedicatedWorker, ServiceWorker)]
+    [Exposed=(Window, Worker)]
     attribute EventHandler onuncapturederror;
 };
 </script>


### PR DESCRIPTION
Following https://github.com/gpuweb/gpuweb/pull/4464#issuecomment-1910914064, this PR adds SharedWorker support to the WebGPU spec.

See issue https://github.com/gpuweb/gpuweb/issues/4197