### PR TITLE
Include GPUProgrammableStage validation in derived type validation.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7356,7 +7356,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
 </div>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>validating GPUProgrammableStage</dfn>(stage, descriptor, layout)
+    <dfn abstract-op>validating GPUProgrammableStage</dfn>(|stage|, |descriptor|, |layout|)
 
     **Arguments:**
 
@@ -8001,14 +8001,9 @@ dictionary GPURenderPipelineDescriptor
 
     Return `true` if all of the following conditions are satisfied:
 
-    - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}},
-        |descriptor|.{{GPURenderPipelineDescriptor/vertex}}, |layout|) succeeds.
-    - [$validating GPUVertexState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/vertex}},
-        |descriptor|.{{GPURenderPipelineDescriptor/vertex}}) succeeds.
+    - [$validating GPUVertexState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/vertex}}, |layout|) succeeds.
     - If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is [=map/exist|provided=]:
-        - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
-            |descriptor|.{{GPURenderPipelineDescriptor/fragment}}, |layout|) succeeds.
-        - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
+        - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}}, |layout|) succeeds.
         - If the [=builtin/sample_mask=] builtin is a [=shader stage output=] of
             |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
             - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
@@ -8325,10 +8320,17 @@ dictionary GPUFragmentState
 </dl>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUFragmentState</dfn>({{GPUDevice}} |device|, {{GPUFragmentState}} |descriptor|)
+    <dfn abstract-op>validating GPUFragmentState</dfn>(|device|, |descriptor|, |layout|)
+
+    **Arguments:**
+
+    - {{GPUDevice}} |device|
+    - {{GPUFragmentState}} |descriptor|
+    - {{GPUPipelineLayout}} |layout|
 
     Return `true` if all of the following requirements are met:
 
+    - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}}, |descriptor|, |layout|) succeeds.
     - |descriptor|.{{GPUFragmentState/targets}}.length must be &le;
         |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
     - [=list/For each=] |index| of the [=list/indices=] of |descriptor|.{{GPUFragmentState/targets}}
@@ -9319,15 +9321,17 @@ dictionary GPUVertexAttribute {
 </div>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUVertexState</dfn>(device, descriptor)
+    <dfn abstract-op>validating GPUVertexState</dfn>(device, descriptor, layout)
 
     **Arguments:**
 
     - {{GPUDevice}} |device|
     - {{GPUVertexState}} |descriptor|
+    - {{GPUPipelineLayout}} |layout|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
+    - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}}, |descriptor|, |layout|) succeeds.
     - |descriptor|.{{GPUVertexState/buffers}}.length is &le;
         |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
     - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}


### PR DESCRIPTION
Clean up validation of vertex and fragment shader descriptors by having the "validate GPUVertexState" and "validate GPUFragmentState" algorithms invoke "validate GPUProgrammableStage" themselves, rather than making their callers responsible for validating their base dictionary separately.

No intended change in requirements or behavior.