### PR TITLE
Infra related with outdated preview prune and preview extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,7 @@
                 "SimonSiefke.svg-preview",
                 "eamodio.gitlens",
                 "streetsidesoftware.code-spell-checker",
+                "ms-vscode.live-server",
                 // New recommendations should also be added to extensions.json
             ]
         }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
         "SimonSiefke.svg-preview",
         "eamodio.gitlens",
         "streetsidesoftware.code-spell-checker",
+        "ms-vscode.live-server",
         // New recommendations should also be added to devcontainer.json
     ]
 }

--- a/wgsl/.pr-preview.json
+++ b/wgsl/.pr-preview.json
@@ -1,7 +1,0 @@
-{
-    "src_file": "index.bs",
-    "type": "bikeshed",
-    "params": {
-        "force": 1
-    }
-}


### PR DESCRIPTION
This PR clears the `.pr-preview.json` left in the wgsl subdirectory, which is something I unfortunately overlooked when I was removing the top directory counterpart.

In addition, I have included the Live Preview extension, which is very convenient for quickly booting up http serving in Codespaces and local Code instances.

Thank you! The review of @kainino0x would be appreciated.