### PR TITLE
Make setBindGroup non-throwing/non-allocating

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10311,13 +10311,23 @@ It must only be included by interfaces which also include those mixins.
 
                 [=Content timeline=] steps:
 
-                1. If any of the following requirements are unmet, throw a {{RangeError}} and stop.
+                1. If any of the following requirements are unmet:
 
                     <div class=validusage>
                         - |dynamicOffsetsDataStart| must be &ge; 0.
                         - |dynamicOffsetsDataStart| + |dynamicOffsetsDataLength| must be &le;
                             |dynamicOffsetsData|.`length`.
                     </div>
+
+                    Then:
+
+                    1. Issue the following [=device timeline=] steps:
+
+                        <div data-timeline=device>
+                            1. Make |this| invalid.
+                        </div>
+
+                    1. Return.
                 1. Let |dynamicOffsets| be a [=list=] containing the range, starting at index
                     |dynamicOffsetsDataStart|, of |dynamicOffsetsDataLength| elements of
                     [=get a copy of the buffer source|a copy of=] |dynamicOffsetsData|.


### PR DESCRIPTION
Proposal.

If a method can create an exception object, then its JS->C++ calling convention needs to be able to handle JS object allocations. Chromium can optimize bindings for non-allocating API calls (which we use for [many other encoder methods](https://source.chromium.org/search?q=noallocdirectcall%20f:modules%2Fwebgpu%2F.*%5C.idl&ss=chromium)).

This turns an exception into a less-loud validation error, which should be all-but-non-breaking.