### PR TITLE
Clarify behavior of out-of-gamut canvas

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13720,7 +13720,8 @@ is being composited into (e.g. an HTML page rendering, or a 2D canvas).
         Read RGBA as premultiplied: color values are premultiplied by their alpha value.
         100% red at 50% alpha is `[0.5, 0, 0, 0.5]`.
 
-        If [=out-of-gamut premultiplied RGBA values=] are output to the canvas, and the canvas is:
+        If the canvas texture contains [=out-of-gamut premultiplied RGBA values=] at the time the
+        canvas contents are read, the behavior depends on whether the canvas is:
 
         <dl class=switch>
             : [$get a copy of the image contents of a context|used as an image source$]

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13739,8 +13739,9 @@ is being composited into (e.g. an HTML page rendering, or a 2D canvas).
                 <code><a funcdef>color</a>(srgb 1.02 0 0 / 0.5)</code>,
                 however upon presentation it could be internally unpremultiplied before color
                 conversion to the display's native color space, resulting in `[1.02, 0, 0, 0.5]`
-                being clamped to `[1, 0, 0, 0.5]`
-                (<code><a funcdef>color</a>(srgb 1 0 0 / 0.5)</code>).
+                which might be then clamped to `[1, 0, 0, 0.5]`
+                (<code><a funcdef>color</a>(srgb 1 0 0 / 0.5)</code>)
+                or result in unpredictable end results in other ways.
         </dl>
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13729,8 +13729,18 @@ is being composited into (e.g. an HTML page rendering, or a 2D canvas).
 
             : displayed to the screen
             :: Compositing results are undefined.
+
+                Note:
                 This is true even if color space conversion would produce in-gamut values before
-                compositing, because the intermediate format for compositing is not specified.
+                compositing, because during compositing implementations may use intermediate
+                representations that can't represent out-of-gamut values. For example, on a
+                {{GPUCanvasAlphaMode/"premultiplied"}}, {{PredefinedColorSpace/"srgb"}},
+                {{GPUTextureFormat/"rgba8unorm"}} canvas, the color `[0.51, 0, 0, 0.5]` represents
+                <code><a funcdef>color</a>(srgb 1.02 0 0 / 0.5)</code>,
+                however upon presentation it could be internally unpremultiplied before color
+                conversion to the display's native color space, resulting in `[1.02, 0, 0, 0.5]`
+                being clamped to `[1, 0, 0, 0.5]`
+                (<code><a funcdef>color</a>(srgb 1 0 0 / 0.5)</code>).
         </dl>
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13732,16 +13732,7 @@ is being composited into (e.g. an HTML page rendering, or a 2D canvas).
 
                 Note:
                 This is true even if color space conversion would produce in-gamut values before
-                compositing, because during compositing implementations may use intermediate
-                representations that can't represent out-of-gamut values. For example, on a
-                {{GPUCanvasAlphaMode/"premultiplied"}}, {{PredefinedColorSpace/"srgb"}},
-                {{GPUTextureFormat/"rgba8unorm"}} canvas, the color `[0.51, 0, 0, 0.5]` represents
-                <code><a funcdef>color</a>(srgb 1.02 0 0 / 0.5)</code>,
-                however upon presentation it could be internally unpremultiplied before color
-                conversion to the display's native color space, resulting in `[1.02, 0, 0, 0.5]`
-                which might be then clamped to `[1, 0, 0, 0.5]`
-                (<code><a funcdef>color</a>(srgb 1 0 0 / 0.5)</code>)
-                or result in unpredictable end results in other ways.
+                compositing, because the intermediate format for compositing is not specified.
         </dl>
 </dl>
 


### PR DESCRIPTION
It's OK if out-of-gamut intermediate values are written to the canvas, it only matters what's there when it gets presented.

Also move the existing explanation of the undefined behavior to a note, ~and expand it with an example.~