### PR TITLE
Remove 'update the rendering' hook for service/shared worker

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13550,11 +13550,12 @@ specified points.
 
     - "update the rendering or user interface of that `Document`"
     - "update the rendering of that dedicated worker"
-    - "update the rendering of that service worker"
-    - "update the rendering of that shared worker"
 
-    Issue(whatwg/html#10112): HTML doesn't define "update the rendering" for service
-    and shared workers yet. Update this text when it does.
+    Note: {{AnimationFrameProvider/requestAnimationFrame()}} is not exposed in
+    {{ServiceWorkerGlobalScope}} and {{SharedWorkerGlobalScope}} and
+    {{HTMLCanvasElement/transferControlToOffscreen()}} is valid only to send to
+    {{DedicatedWorkerGlobalScope}}.
+    See [whatwg/html#10112 issue](https://github.com/whatwg/html/issues/10112).
 
     Run the following steps:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13551,11 +13551,13 @@ specified points.
     - "update the rendering or user interface of that `Document`"
     - "update the rendering of that dedicated worker"
 
-    Note: {{AnimationFrameProvider/requestAnimationFrame()}} is not exposed in
-    {{ServiceWorkerGlobalScope}} and {{SharedWorkerGlobalScope}} and
-    {{HTMLCanvasElement/transferControlToOffscreen()}} is valid only to send to
-    {{DedicatedWorkerGlobalScope}}.
-    See [whatwg/html#10112 issue](https://github.com/whatwg/html/issues/10112).
+    Note:
+    Service and Shared workers do not have "update the rendering" steps
+    because they cannot render to user-visible canvases.
+    {{AnimationFrameProvider/requestAnimationFrame()}} is not exposed in
+    {{ServiceWorkerGlobalScope}} and {{SharedWorkerGlobalScope}}, and
+    {{OffscreenCanvas}}es from {{HTMLCanvasElement/transferControlToOffscreen()}}
+    [cannot be sent to these workers](https://github.com/whatwg/html/issues/10112).
 
     Run the following steps:
 


### PR DESCRIPTION
FIX https://github.com/gpuweb/gpuweb/issues/4478

