### PR TITLE
[wgsl] Fixup bitcast return types.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4148,7 +4148,7 @@ WebGPU [$validating shader binding|validates$] compatibility between the
 texture, the {{GPUTextureBindingLayout/sampleType}} of the bind group layout,
 and the [=sampled type=] of the texture variable.
 
-The texture is parameterized by a [=sampled type=] and 
+The texture is parameterized by a [=sampled type=] and
 [=shader-creation error|must=] be `f32`, `i32`, or `u32`.
 
 <table class='data'>
@@ -4603,7 +4603,7 @@ effective-value-type.
     creation|pipeline-creation time=].
 4. [=Override-declarations=] are part of the shader interface, but are not
     bound resources.
-5. [=Storage buffers=] with an access mode other than [=access/read=] and 
+5. [=Storage buffers=] with an access mode other than [=access/read=] and
     [=type/storage textures=] cannot be [=statically accessed=]
     in a [=vertex shader stage=].
     See WebGPU {{GPUDevice/createBindGroupLayout()}}.
@@ -9550,7 +9550,7 @@ WGSL [=predeclared|predeclares=] an [=enumerant=] for each address space, except
 shader stage=].
 
 [=Variables=] in the [=address spaces/storage=] address space ([=storage
-buffers=]) can only be [=statically accessed=] by a [=vertex shader stage=] if the access mode is [=access/read=]. 
+buffers=]) can only be [=statically accessed=] by a [=vertex shader stage=] if the access mode is [=access/read=].
 Variables whose [=store type=] is a [=type/storage texture=] with a
 [=access/write=] or [=access/read_write=] [=access mode=] cannot be
 [=statically accessed=] by a [=vertex shader stage=].
@@ -13154,7 +13154,7 @@ The internal layout rules are described in [[#internal-value-layout]].
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
-        <xmp highlight=wgsl>@const @must_use fn bitcast<vecN<T>>(e : vecN<S>) -> T</xmp>
+        <xmp highlight=wgsl>@const @must_use fn bitcast<vecN<T>>(e : vecN<S>) -> vecN<T></xmp>
   <tr><td>Parameterization
       <td>`S` is i32, u32, or f32<br>
       `T` is not `S` and is i32, u32, or f32
@@ -13165,9 +13165,9 @@ The internal layout rules are described in [[#internal-value-layout]].
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
-        <xmp highlight=wgsl>@const @must_use fn bitcast<u32>(e : AbstractInt) -> T
+        <xmp highlight=wgsl>@const @must_use fn bitcast<u32>(e : AbstractInt) -> u32
 
-                            @const @must_use fn bitcast<vecN<u32>>(e : vecN<AbstractInt>) -> T</xmp>
+                            @const @must_use fn bitcast<vecN<u32>>(e : vecN<AbstractInt>) -> vecN<u32></xmp>
   <tr><td>Parameterization
       <td>
   <tr><td>Description


### PR DESCRIPTION
The bitcast overloads which accept a `vecN` should also be returning a `vecN`. The `u32` overrides should return a `u32` as that is what is being bitcast too.

This CL fixes the definitions in the spec to return the correct types.