### PR TITLE
Remove the greater-or-equal constraint on maxBindingsPerBindGroup

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2450,17 +2450,6 @@ Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the followi
         {{GPUFeatureName/"texture-compression-astc"}} are supported.
 - All supported limits must be either the [=limit/default=] value or [=limit/better=].
 - All [=limit class/alignment|alignment-class=] limits must be powers of 2.
-- {{supported limits/maxBindingsPerBindGroup}} must be must be &ge;
-    ([=max bindings per shader stage=] &times; [=max shader stages per pipeline=]), where:
-
-    - <dfn dfn for="">max bindings per shader stage</dfn> is
-        ({{supported limits/maxSampledTexturesPerShaderStage}} +
-        {{supported limits/maxSamplersPerShaderStage}} +
-        {{supported limits/maxStorageBuffersPerShaderStage}} +
-        {{supported limits/maxStorageTexturesPerShaderStage}} +
-        {{supported limits/maxUniformBuffersPerShaderStage}}).
-    - <dfn dfn for="">max shader stages per pipeline</dfn> is `2`, because a
-        {{GPURenderPipeline}} supports both a vertex and fragment shader.
 
     Note: {{supported limits/maxBindingsPerBindGroup}} does not reflect a fundamental limit;
     implementations should raise it to conform to this requirement, rather than lowering the


### PR DESCRIPTION
This constraint is problematic for configurations where the theoretical maximum number of bindings is very large. For example on this linux desktop I get the following limits:

```
Max Sampled Textures Per Shader Stage: 1000000
Max Samplers Per Shader Stage: 1000000
Max Storage Buffers Per Shader Stage: 1000000
Max Storage Textures Per Shader Stage: 1000000
Max Uniform Buffers Per Shader Stage: 1000000
```

Which would mean `maxBindingsPerBindGroup` has to be very high.

However, the intent behind `maxBindingsPerBindGroup` is to restrict the maximum binding index to "allows implementations to treat binding space as an array, within reasonable memory space, rather than a sparse map structure." Which is the case of the vulkan backend in Firefox.

So high theoretical maximum binding limits should not force the maximum binding index to be raised to very large number and this formula in the spec should be removed.

There is also a CTS test `webgpu:api,validation,capability_checks,limits,maxBindingsPerBindGroup:validate:` that should be removed for the same reasons.