### PR TITLE
Clarify typography of abstract int 0 and abstract float 0

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12233,8 +12233,8 @@ The zero values are as follows:
 * The zero value for an *C*-column *R*-row matrix of type *T* is the matrix of those dimensions filled with the zero value for *T*.
 * The zero value for a [=constructible=] *N*-element array with element type *E* is an array of *N* elements of the zero value for *E*.
 * The zero value for a [=constructible=] structure type *S* is the structure value *S* with zero-valued members.
-* The zero value of an [=AbstractInt=] is 0.
-* The zero value of an [=AbstractFloat=] is 0.0.
+* The zero value of an [=AbstractInt=] is `0`
+* The zero value of an [=AbstractFloat=] is `0.0`
 
 Note: WGSL does not have zero built-in functions for [=atomic types=],
 [=runtime-sized=] arrays, or other types that are not [=constructible=].


### PR DESCRIPTION
Addresses @ben-clayton feedback on a previous PR: https://github.com/gpuweb/gpuweb/pull/4449/files#r1447358137