### PR TITLE
[wgsl] Clarify the vec and matrix abstract overloads.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8,13 +8,14 @@ ED: https://gpuweb.github.io/gpuweb/wgsl/
 TR: https://www.w3.org/TR/WGSL/
 Repository: gpuweb/gpuweb
 Text Macro: INT i32 or u32
+Text Macro: FLOAT [=f32=] or [=f16=]
 Text Macro: UNSIGNEDINTEGRAL u32 or vecN&lt;u32&gt;
 Text Macro: SIGNEDINTEGRAL i32 or vecN&lt;i32&gt;
 Text Macro: ALLSIGNEDINTEGRAL AbstractInt, i32, vecN&lt;AbstractInt&gt;, or vecN&lt;i32&gt;
 Text Macro: INTEGRAL i32, u32, vecN&lt;i32&gt;, or vecN&lt;u32&gt;
 Text Macro: FLOATING f32, f16, vecN&lt;f32&gt;, or vecN&lt;f16&gt;
 Text Macro: NUMERIC i32, u32, f32, f16, vecN&lt;i32&gt;, vecN&lt;u32&gt;, vecN&lt;f32&gt;, or vecN&lt;f16&gt;
-Text Macro: FLOATSCALAR [=AbstractFloat=], [=f16=], or [=f32=]
+Text Macro: FLOATSCALAR [=AbstractFloat=], [=f32=], or [=f16=]
 Text Macro: ALLINTEGRALDECL S is AbstractInt, i32, or u32<br>T is S or vecN&lt;S&gt;
 Text Macro: ALLFLOATINGDECL S is AbstractFloat, f32, or f16<br>T is S or vecN&lt;S&gt;
 Text Macro: ALLNUMERICDECL S is AbstractInt, AbstractFloat, i32, u32, f32, or f16<br>T is S, or vecN&lt;S&gt;
@@ -12412,38 +12413,50 @@ specify the component type; the component type is inferred from the constructor 
           @const @must_use fn mat2x2(e : mat2x2<S>) -> mat2x2<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
+      <td>`T` is [FLOAT]<br>
       `S` is [FLOATSCALAR]
   <tr><td>Description
       <td>Constructor for a 2x2 column-major [=matrix=].
 
       If `T` does not match `S`, a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn mat2x2<T>(v1 : vec2<T>, v2 : vec2<T>) -> mat2x2<T>
+          @const @must_use fn mat2x2<F>(v1 : vec2<A>, v2 : vec2<A>) -> mat2x2<F>
           @const @must_use fn mat2x2(v1 : vec2<T>, v2 : vec2<T>) -> mat2x2<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 2x2 column-major [=matrix=] from column vectors.
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn mat2x2<T>(e1 : T, e2 : T, e3 : T, e4 : T) -> mat2x2<T>
+          @const @must_use fn mat2x2<F>(e1 : A, e2 : A, e3 : A, e4 : A) -> mat2x2<F>
           @const @must_use fn mat2x2(e1 : T, e2 : T, e3 : T, e4 : T) -> mat2x2<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 2x2 column-major [=matrix=] from elements.
 
           Same as mat2x2(vec2(e1,e2), vec2(e3,e4)).
+
+          When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
 
 #### `mat2x3` #### {#mat2x3-builtin}
@@ -12456,38 +12469,50 @@ specify the component type; the component type is inferred from the constructor 
           @const @must_use fn mat2x3(e : mat2x3<S>) -> mat2x3<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
+      <td>`T` is [FLOAT]<br>
       `S` is [FLOATSCALAR]
   <tr><td>Description
       <td>Constructor for a 2x3 column-major [=matrix=].
 
       If `T` does not match `S`, a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn mat2x3<T>(v1 : vec3<T>, v2 : vec3<T>) -> mat2x3<T>
+          @const @must_use fn mat2x3<F>(v1 : vec3<A>, v2 : vec3<A>) -> mat2x3<F>
           @const @must_use fn mat2x3(v1 : vec3<T>, v2 : vec3<T>) -> mat2x3<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 2x3 column-major [=matrix=] from column vectors.
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn mat2x3<T>(e1 : T, ..., e6 : T) -> mat2x3<T>
+          @const @must_use fn mat2x3<F>(e1 : A, ..., e6 : A) -> mat2x3<F>
           @const @must_use fn mat2x3(e1 : T, ..., e6 : T) -> mat2x3<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 2x3 column-major [=matrix=] from elements.
 
-          Same as mat2x3(vec3(e1,e2,e3), vec3(e4,e5,e6)).
+      Same as mat2x3(vec3(e1,e2,e3), vec3(e4,e5,e6)).
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
 
 #### `mat2x4` #### {#mat2x4-builtin}
@@ -12500,38 +12525,50 @@ specify the component type; the component type is inferred from the constructor 
           @const @must_use fn mat2x4(e : mat2x4<S>) -> mat2x4<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
+      <td>`T` is [FLOAT]<br>
       `S` is [FLOATSCALAR]
   <tr><td>Description
       <td>Constructor for a 2x4 column-major [=matrix=].
 
       If `T` does not match `S`, a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn mat2x4<T>(v1 : vec4<T>, v2 : vec4<T>) -> mat2x4<T>
+          @const @must_use fn mat2x4<F>(v1 : vec4<A>, v2 : vec4<A>) -> mat2x4<F>
           @const @must_use fn mat2x4(v1 : vec4<T>, v2 : vec4<T>) -> mat2x4<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 2x4 column-major [=matrix=] from column vectors.
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn mat2x4<T>(e1 : T, ..., e8 : T) -> mat2x4<T>
+          @const @must_use fn mat2x4<F>(e1 : A, ..., e8 : A) -> mat2x4<F>
           @const @must_use fn mat2x4(e1 : T, ..., e8 : T) -> mat2x4<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 2x4 column-major [=matrix=] from elements.
 
-          Same as mat2x4(vec4(e1,e2,e3,e4), vec4(e5,e6,e7,e8)).
+      Same as mat2x4(vec4(e1,e2,e3,e4), vec4(e5,e6,e7,e8)).
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
 
 #### `mat3x2` #### {#mat3x2-builtin}
@@ -12544,13 +12581,14 @@ specify the component type; the component type is inferred from the constructor 
           @const @must_use fn mat3x2(e : mat3x2<S>) -> mat3x2<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
+      <td>`T` is [FLOAT]]<br>
       `S` is [FLOATSCALAR]
   <tr><td>Description
       <td>Constructor for a 3x2 column-major [=matrix=].
 
       If `T` does not match `S`, a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12558,28 +12596,41 @@ specify the component type; the component type is inferred from the constructor 
           @const @must_use fn mat3x2<T>(v1 : vec2<T>,
                                         v2 : vec2<T>,
                                         v3 : vec2<T>) -> mat3x2<T>
+          @const @must_use fn mat3x2<F>(v1 : vec2<A>,
+                                        v2 : vec2<A>,
+                                        v3 : vec2<A>) -> mat3x2<F>
           @const @must_use fn mat3x2(v1 : vec2<T>,
                                      v2 : vec2<T>,
                                      v3 : vec2<T>) -> mat3x2<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 3x2 column-major [=matrix=] from column vectors.
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn mat3x2<T>(e1 : T, ..., e6 : T) -> mat3x2<T>
+          @const @must_use fn mat3x2<F>(e1 : A, ..., e6 : A) -> mat3x2<F>
           @const @must_use fn mat3x2(e1 : T, ..., e6 : T) -> mat3x2<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 3x2 column-major [=matrix=] from elements.
 
-          Same as mat3x2(vec2(e1,e2), vec2(e3,e4), vec2(e5,e6)).
+        Same as mat3x2(vec2(e1,e2), vec2(e3,e4), vec2(e5,e6)).
+
+        When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
 
 #### `mat3x3` #### {#mat3x3-builtin}
@@ -12592,13 +12643,14 @@ specify the component type; the component type is inferred from the constructor 
           @const @must_use fn mat3x3(e : mat3x3<S>) -> mat3x3<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
+      <td>`T` is [FLOAT]<br>
       `S` is [FLOATSCALAR]
   <tr><td>Description
       <td>Constructor for a 3x3 column-major [=matrix=].
 
       If `T` does not match `S`, a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12606,28 +12658,41 @@ specify the component type; the component type is inferred from the constructor 
           @const @must_use fn mat3x3<T>(v1 : vec3<T>,
                                         v2 : vec3<T>,
                                         v3 : vec3<T>) -> mat3x3<T>
+          @const @must_use fn mat3x3<F>(v1 : vec3<A>,
+                                        v2 : vec3<A>,
+                                        v3 : vec3<A>) -> mat3x3<F>
           @const @must_use fn mat3x3(v1 : vec3<T>,
                                      v2 : vec3<T>,
                                      v3 : vec3<T>) -> mat3x3<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 3x3 column-major [=matrix=] from column vectors.
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn mat3x3<T>(e1 : T, ..., e9 : T) -> mat3x3<T>
+          @const @must_use fn mat3x3<F>(e1 : A, ..., e9 : A) -> mat3x3<F>
           @const @must_use fn mat3x3(e1 : T, ..., e9 : T) -> mat3x3<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 3x3 column-major [=matrix=] from elements.
 
-          Same as mat3x3(vec3(e1,e2,e3), vec3(e4,e4,e6), vec3(e7,e8,e9)).
+      Same as mat3x3(vec3(e1,e2,e3), vec3(e4,e4,e6), vec3(e7,e8,e9)).
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
 
 #### `mat3x4` #### {#mat3x4-builtin}
@@ -12640,13 +12705,14 @@ specify the component type; the component type is inferred from the constructor 
           @const @must_use fn mat3x4(e : mat3x4<S>) -> mat3x4<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
+      <td>`T` is [FLOAT]<br>
       `S` is [FLOATSCALAR]
   <tr><td>Description
       <td>Constructor for a 3x4 column-major [=matrix=].
 
       If `T` does not match `S`, a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12654,28 +12720,41 @@ specify the component type; the component type is inferred from the constructor 
           @const @must_use fn mat3x4<T>(v1 : vec4<T>,
                                         v2 : vec4<T>,
                                         v3 : vec4<T>) -> mat3x4<T>
+          @const @must_use fn mat3x4<F>(v1 : vec4<A>,
+                                        v2 : vec4<A>,
+                                        v3 : vec4<A>) -> mat3x4<F>
           @const @must_use fn mat3x4(v1 : vec4<T>,
                                      v2 : vec4<T>,
                                      v3 : vec4<T>) -> mat3x4<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 3x4 column-major [=matrix=] from column vectors.
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn mat3x4<T>(e1 : T, ..., e12 : T) -> mat3x4<T>
+          @const @must_use fn mat3x4<F>(e1 : A, ..., e12 : A) -> mat3x4<F>
           @const @must_use fn mat3x4(e1 : T, ..., e12 : T) -> mat3x4<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 3x4 column-major [=matrix=] from elements.
 
-          Same as mat3x4(vec4(e1,e2,e3,e4), vec4(e5,e6,e7,e8), vec4(e9,e10,e11,e12)).
+      Same as mat3x4(vec4(e1,e2,e3,e4), vec4(e5,e6,e7,e8), vec4(e9,e10,e11,e12)).
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
 
 #### `mat4x2` #### {#mat4x2-builtin}
@@ -12688,13 +12767,14 @@ specify the component type; the component type is inferred from the constructor 
           @const @must_use fn mat4x2(e : mat4x2<S>) -> mat4x2<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
+      <td>`T` is [FLOAT]<br>
       `S` is [FLOATSCALAR]
   <tr><td>Description
       <td>Constructor for a 4x2 column-major [=matrix=].
 
       If `T` does not match `S`, a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12703,29 +12783,43 @@ specify the component type; the component type is inferred from the constructor 
                                         v2 : vec2<T>,
                                         v3 : vec2<T>,
                                         v4: vec2<T>) -> mat4x2<T>
+          @const @must_use fn mat4x2<F>(v1 : vec2<A>,
+                                        v2 : vec2<A>,
+                                        v3 : vec2<A>,
+                                        v4: vec2<A>) -> mat4x2<F>
           @const @must_use fn mat4x2(v1 : vec2<T>,
                                      v2 : vec2<T>,
                                      v3 : vec2<T>,
                                      v4: vec2<T>) -> mat4x2<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 4x2 column-major [=matrix=] from column vectors.
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn mat4x2<T>(e1 : T, ..., e8 : T) -> mat4x2<T>
+          @const @must_use fn mat4x2<F>(e1 : A, ..., e8 : A) -> mat4x2<F>
           @const @must_use fn mat4x2(e1 : T, ..., e8 : T) -> mat4x2<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 4x2 column-major [=matrix=] from elements.
 
-          Same as mat4x2(vec2(e1,e2), vec2(e3,e4), vec2(e5,e6), vec2(e7,e8)).
+      Same as mat4x2(vec2(e1,e2), vec2(e3,e4), vec2(e5,e6), vec2(e7,e8)).
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
 
 #### `mat4x3` #### {#mat4x3-builtin}
@@ -12738,13 +12832,14 @@ specify the component type; the component type is inferred from the constructor 
           @const @must_use fn mat4x3(e : mat4x3<S>) -> mat4x3<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
+      <td>`T` is [FLOAT]<br>
       `S` is [FLOATSCALAR]
   <tr><td>Description
       <td>Constructor for a 4x3 column-major [=matrix=].
 
       If `T` does not match `S`, a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12753,29 +12848,43 @@ specify the component type; the component type is inferred from the constructor 
                                         v2 : vec3<T>,
                                         v3 : vec3<T>,
                                         v4 : vec3<T>) -> mat4x3<T>
+          @const @must_use fn mat4x3<F>(v1 : vec3<A>,
+                                        v2 : vec3<A>,
+                                        v3 : vec3<A>,
+                                        v4 : vec3<A>) -> mat4x3<F>
           @const @must_use fn mat4x3(v1 : vec3<T>,
                                      v2 : vec3<T>,
                                      v3 : vec3<T>,
                                      v4 : vec3<T>) -> mat4x3<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 4x3 column-major [=matrix=] from column vectors.
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn mat4x3<T>(e1 : T, ..., e12 : T) -> mat4x3<T>
+          @const @must_use fn mat4x3<F>(e1 : A, ..., e12 : A) -> mat4x3<F>
           @const @must_use fn mat4x3(e1 : T, ..., e12 : T) -> mat4x3<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 4x3 column-major [=matrix=] from elements.
 
-          Same as mat4x3(vec3(e1,e2,e3), vec3(e4,e5,e6), vec3(e7,e8,e9), vec3(e10,e11,e12)).
+      Same as mat4x3(vec3(e1,e2,e3), vec3(e4,e5,e6), vec3(e7,e8,e9), vec3(e10,e11,e12)).
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
 
 #### `mat4x4` #### {#mat4x4-builtin}
@@ -12788,13 +12897,14 @@ specify the component type; the component type is inferred from the constructor 
           @const @must_use fn mat4x4(e : mat4x4<S>) -> mat4x4<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=f16=] or [=f32=]<br>
+      <td>`T` is [FLOAT]<br>
       `S` is [FLOATSCALAR]
   <tr><td>Description
       <td>Constructor for a 4x4 column-major [=matrix=].
 
       If `T` does not match `S`, a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
@@ -12803,29 +12913,43 @@ specify the component type; the component type is inferred from the constructor 
                                         v2 : vec4<T>,
                                         v3 : vec4<T>,
                                         v4 : vec4<T>) -> mat4x4<T>
+          @const @must_use fn mat4x4<F>(v1 : vec4<A>,
+                                        v2 : vec4<A>,
+                                        v3 : vec4<A>,
+                                        v4 : vec4<A>) -> mat4x4<F>
           @const @must_use fn mat4x4(v1 : vec4<T>,
                                      v2 : vec4<T>,
                                      v3 : vec4<T>,
                                      v4 : vec4<T>) -> mat4x4<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 4x4 column-major [=matrix=] from column vectors.
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn mat4x4<T>(e1 : T, ..., e16 : T) -> mat4x4<T>
+          @const @must_use fn mat4x4<F>(e1 : A, ..., e16 : A) -> mat4x4<F>
           @const @must_use fn mat4x4(e1 : T, ..., e16 : T) -> mat4x4<T>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [FLOATSCALAR]
+      <td>`T` is [FLOATSCALAR]<br>
+      `F` is [FLOAT]<br>
+      `A` is [=AbstractFloat=]
   <tr><td>Description
       <td>Construct a 4x4 column-major [=matrix=] from elements.
 
-          Same as mat4x4(vec4(e1,e2,e3,e4), vec4(e5,e6,e7,e8), vec4(e9,e10,e11,e12), vec4(e13,e14,e15,e16)).
+      Same as mat4x4(vec4(e1,e2,e3,e4), vec4(e5,e6,e7,e8), vec4(e9,e10,e11,e12), vec4(e13,e14,e15,e16)).
+
+      When providing `A` (an [=AbstractFloat=]) a [[#floating-point-conversion|conversion]] occurs.
 </table>
 
 #### Structures #### {#structures-builtin}
@@ -12859,7 +12983,9 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td>
       <td>
 
-      Note: The overload from [=AbstractInt=] exists so expressions such as `u32(4*1000*1000*1000)` can create a u32 value that would otherwise overflow the i32 type. If this overload did not exist, [=overload resolution=] would select the `u32(i32)` overload, the AbstractInt expression would automatically convert to i32, and this would cause a shader-creation error due to overflow.
+      Note: The overload from [=AbstractInt=] exists so expressions such as `u32(4*1000*1000*1000)` can create a u32 value that would otherwise overflow the i32 type.
+      If this overload did not exist, [=overload resolution=] would select the `u32(i32)` overload, the AbstractInt expression would automatically convert to i32,
+      and this would cause a shader-creation error due to overflow.
 </table>
 
 #### `vec2` #### {#vec2-builtin}
@@ -12869,49 +12995,63 @@ specify the component type; the component type is inferred from the constructor 
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec2<T>(e : T) -> vec2<T>
+          @const @must_use fn vec2<T>(e : A) -> vec2<T>
           @const @must_use fn vec2(e : S) -> vec2<S>
         </xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
       `S` is [=scalar=]
   <tr><td>Description
       <td>Construction of a two-component [=vector=] with `e` as both components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
-          @const @must_use fn vec2<T>(e : vec2<S>) -> vec2<T>
+          @const @must_use fn vec2<T>(e : vec2<T>) -> vec2<T>
+          @const @must_use fn vec2<T>(e : vec2<A>) -> vec2<T>
           @const @must_use fn vec2(e : vec2<S>) -> vec2<S>
         </xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
       `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a two-component [=vector=] with `e.x` and `e.y` as components.
 
-      If `T` does not match `S` a conversion is used and the components are `T(e.x)` and `T(e.y)`.
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e.x)` and `T(e.y)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec2<T>(e1 : T, e2 : T) -> vec2<T>
-          @const @must_use fn vec2(e1 : T, e2 : T) -> vec2<T>
+          @const @must_use fn vec2<T>(e1 : A, e2 : A) -> vec2<T>
+          @const @must_use fn vec2(e1 : S, e2 : S) -> vec2<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=scalar=]
+      <td>`T` is a [=type/concrete=] [=scalar=]<br>
+        `A` is [=type/abstract|abstract=] [=scalar=]<br>
+        `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a two-component [=vector=] with `e1` and `e2` as components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e1)` and `T(e2)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
-          @const @must_use fn vec2() -> vec2<T>
+          @const @must_use fn vec2() -> vec2<I>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is AbstractInt
+      <td>`I` is AbstractInt
   <tr><td>Description
       <td>Returns the value `vec2(0,0)`.
 </table>
@@ -12923,73 +13063,99 @@ specify the component type; the component type is inferred from the constructor 
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec3<T>(e : T) -> vec3<T>
+          @const @must_use fn vec3<T>(e : A) -> vec3<T>
           @const @must_use fn vec3(e : S) -> vec3<S>
         </xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
       `S` is [=scalar=]
   <tr><td>Description
       <td>Construction of a three-component [=vector=] with `e` as all components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
-          @const @must_use fn vec3<T>(e : vec3<S>) -> vec3<T>
+          @const @must_use fn vec3<T>(e : vec3<T>) -> vec3<T>
+          @const @must_use fn vec3<T>(e : vec3<A>) -> vec3<T>
           @const @must_use fn vec3(e : vec3<S>) -> vec3<S>
         </xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
       `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a three-component [=vector=] with `e.x`, `e.y`, and `e.z` as components.
 
-      If `T` does not match `S` a conversion is used and the components are `T(e.x)`, `T(e.y)`, and  `T(e.z)`.
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e.x)`, `T(e.y)`, and `T(e.z)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec3<T>(e1 : T, e2 : T, e3 : T) -> vec3<T>
-          @const @must_use fn vec3(e1 : T, e2 : T, e3 : T) -> vec3<T>
+          @const @must_use fn vec3<T>(e1 : A, e2 : A, e3 : S) -> vec3<T>
+          @const @must_use fn vec3(e1 : S, e2 : S, e3 : S) -> vec3<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=scalar=]
+      <td>`T` is [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
+      `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a three-component [=vector=] with `e1`, `e2`, and `e3` as components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e1)`, `T(e2)`, and `T(e3)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec3<T>(v1 : vec2<T>, e1 : T) -> vec3<T>
-          @const @must_use fn vec3(v1 : vec2<T>, e1 : T) -> vec3<T>
+          @const @must_use fn vec3<T>(v1 : vec2<A>, e1 : S) -> vec3<T>
+          @const @must_use fn vec3(v1 : vec2<S>, e1 : S) -> vec3<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=scalar=]
+      <td>`T` is a [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
+      `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a three-component [=vector=] with `v1.x`, `v1.y`, and `e1` as components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(v1.x)`, `T(v1.y)`, and `T(e1)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec3<T>(e1 : T, v1 : vec2<T>) -> vec3<T>
-          @const @must_use fn vec3(e1 : T, v1 : vec2<T>) -> vec3<T>
+          @const @must_use fn vec3<T>(e1 : A, v1 : vec2<A>) -> vec3<T>
+          @const @must_use fn vec3(e1 : S, v1 : vec2<S>) -> vec3<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=scalar=]
+      <td>`T` is a [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
+      `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a three-component [=vector=] with `e1`, `v1.x`, and `v1.y` as components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e1)`, `T(v1.x)`, and `T(v1.y)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
-          @const @must_use fn vec3() -> vec3<T>
+          @const @must_use fn vec3() -> vec3<I>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is AbstractInt
+      <td>`I` is AbstractInt
   <tr><td>Description
       <td>Returns the value `vec3(0,0,0)`.
 </table>
@@ -13001,121 +13167,171 @@ specify the component type; the component type is inferred from the constructor 
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec4<T>(e : T) -> vec4<T>
+          @const @must_use fn vec<T>(e : A) -> vec4<T>
           @const @must_use fn vec4(e : S) -> vec4<S>
         </xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
       `S` is [=scalar=]
   <tr><td>Description
       <td>Construction of a four-component [=vector=] with `e` as all components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
-          @const @must_use fn vec4<T>(e : vec4<S>) -> vec4<T>
+          @const @must_use fn vec4<T>(e : vec4<T>) -> vec4<T>
+          @const @must_use fn vec4<T>(e : vec4<A>) -> vec4<T>
           @const @must_use fn vec4(e : vec4<S>) -> vec4<S>
         </xmp>
   <tr><td>Parameterization
       <td>`T` is a [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
       `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a four-component [=vector=] with `e.x`, `e.y`, `e.z`, and `e.w` as components.
 
-      If `T` does not match `S` a conversion is used and the components are `T(e.x)`, `T(e.y)`, `T(e.z)` and  `T(e.w)`.
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e.x)`, `T(e.y)`, `T(e.z)`, and `T(e.w)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec4<T>(e1 : T, e2 : T, e3 : T, e4 : T) -> vec4<T>
-          @const @must_use fn vec4(e1 : T, e2 : T, e3 : T, e4 : T) -> vec4<T>
+          @const @must_use fn vec4<T>(e1 : A, e2 : A, e3 : A, e4 : A) -> vec4<T>
+          @const @must_use fn vec4(e1 : S, e2 : S, e3 : S, e4 : S) -> vec4<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=scalar=]
+      <td>`T` is [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
+      `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a four-component [=vector=] with `e1`, `e2`, `e3`, and `e4` as components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e1)`, `T(e2)`, `T(e3)`, and `T(e4)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec4<T>(e1 : T, v1 : vec2<T>, e2 : T) -> vec4<T>
-          @const @must_use fn vec4(e1 : T, v1 : vec2<T>, e2 : T) -> vec4<T>
+          @const @must_use fn vec4<T>(e1 : A, v1 : vec2<A>, e2 : A) -> vec4<T>
+          @const @must_use fn vec4(e1 : S, v1 : vec2<S>, e2 : S) -> vec4<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=scalar=]
+      <td>`T` is [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
+      `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a four-component [=vector=] with `e1`, `v1.x`, `v1.y`, and `e2` as components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e1)`, `T(v1.x)`, `T(v1.y)`, and `T(e2)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec4<T>(e1 : T, e2 : T, v1 : vec2<T>) -> vec4<T>
-          @const @must_use fn vec4(e1 : T, e2 : T, v1 : vec2<T>) -> vec4<T>
+          @const @must_use fn vec4<T>(e1 : A, e2 : A, v1 : vec2<A>) -> vec4<T>
+          @const @must_use fn vec4(e1 : S, e2 : S, v1 : vec2<S>) -> vec4<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=scalar=]
+      <td>`T` is [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
+      `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a four-component [=vector=] with `e1`, `e2`, `v1.x`, and `v1.x` as components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e1)`, `T(e2)`, `T(v1.x)`, and `T(v1.y)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec4<T>(v1 : vec2<T>, v2 : vec2<T>) -> vec4<T>
-          @const @must_use fn vec4(v1 : vec2<T>, v2 : vec2<T>) -> vec4<T>
+          @const @must_use fn vec4<T>(v1 : vec2<A>, v2 : vec2<A>) -> vec4<T>
+          @const @must_use fn vec4(v1 : vec2<S>, v2 : vec2<S>) -> vec4<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=scalar=]
+      <td>`T` is [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
+      `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a four-component [=vector=] with `v1.x`, `v1.y`, `v2.x`, and `v2.y` as components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(v1.x)`, `T(v1.y)`, `T(v2.x)`, and `T(v2.y)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec4<T>(v1 : vec2<T>, e1 : T, e2 : T) -> vec4<T>
-          @const @must_use fn vec4(v1 : vec2<T>, e1 : T, e2 : T) -> vec4<T>
+          @const @must_use fn vec4<T>(v1 : vec2<A>, e1 : A, e2 : A) -> vec4<T>
+          @const @must_use fn vec4(v1 : vec2<S>, e1 : S, e2 : S) -> vec4<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=scalar=]
+      <td>`T` is [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
+      `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a four-component [=vector=] with `v1.x`, `v1.y`, `e1`, and `e2` as components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(v1.x)`, `T(v1.y)`, `T(e1)`, and `T(e2)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec4<T>(v1 : vec3<T>, e1 : T) -> vec4<T>
-          @const @must_use fn vec4(v1 : vec3<T>, e1 : T) -> vec4<T>
+          @const @must_use fn vec4<T>(v1 : vec3<A>, e1 : A) -> vec4<T>
+          @const @must_use fn vec4(v1 : vec3<S>, e1 : S) -> vec4<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=scalar=]
+      <td>`T` is [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
+      `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a four-component [=vector=] with `v1.x`, `v1.y`, `v1.z`, and `e1` as components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(v1.x)`, `T(v1.y)`, `T(v1.z)`, and `T(e1)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec4<T>(e1 : T, v1 : vec3<T>) -> vec4<T>
-          @const @must_use fn vec4(e1 : T, v1 : vec3<T>) -> vec4<T>
+          @const @must_use fn vec4<T>(e1 : A, v1 : vec3<A>) -> vec4<T>
+          @const @must_use fn vec4(e1 : S, v1 : vec3<S>) -> vec4<S>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is [=scalar=]
+      <td>`T` is [=type/concrete=] [=scalar=]<br>
+      `A` is [=type/abstract|abstract=] [=scalar=]<br>
+      `S` is [=scalar=]
   <tr><td>Description
       <td>[=Component-wise=] construction of a four-component [=vector=] with `e1`, `v1.x`, `v1.y`, and `v1.z` as components.
+
+      When providing `A` (an [=type/abstract|abstract=] [=scalar=]) a conversion is used and the components are `T(e1)`, `T(v1.x)`, `T(v1.y)`, and `T(v1.z)`.
 </table>
+
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
         <xmp highlight=wgsl>
-          @const @must_use fn vec4() -> vec4<T>
+          @const @must_use fn vec4() -> vec4<I>
         </xmp>
   <tr><td>Parameterization
-      <td>`T` is AbstractInt
+      <td>`I` is AbstractInt
   <tr><td>Description
       <td>Returns the value `vec4(0,0,0,0)`.
 </table>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -13099,7 +13099,7 @@ specify the component type; the component type is inferred from the constructor 
       <td>
         <xmp highlight=wgsl>
           @const @must_use fn vec3<T>(e1 : T, e2 : T, e3 : T) -> vec3<T>
-          @const @must_use fn vec3<T>(e1 : A, e2 : A, e3 : S) -> vec3<T>
+          @const @must_use fn vec3<T>(e1 : A, e2 : A, e3 : A) -> vec3<T>
           @const @must_use fn vec3(e1 : S, e2 : S, e3 : S) -> vec3<S>
         </xmp>
   <tr><td>Parameterization


### PR DESCRIPTION
In the Builtin functions section it is confusing to determine where abstracts can appear and where they can't. The parameterization is unclear in some cases.

This PR attempts to clarify and be specific about where abstracts can appear and what types are produced.