### PR TITLE
[wgsl] Assume `bool` is 4 bytes for array limits

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -888,12 +888,12 @@ shader that goes beyond the specified limits.
     <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
             [=address spaces/function=] or [=address spaces/private=] address spaces
 
-            For the purposes of this limit, [=bool=] has a size of 1 byte.
+            For the purposes of this limit, [=bool=] has a size of 4 bytes.
         <td>65535
     <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
             [=address spaces/workgroup=] address space.
 
-            For the purposes of this limit, [=bool=] has a size of 1 byte and a
+            For the purposes of this limit, [=bool=] has a size of 4 bytes and a
             [=fixed footprint|fixed-footprint=] array is treated as a [=creation-fixed
             footprint=] array when substituting the override value.
 


### PR DESCRIPTION
The size of a bool is opaque on many platforms, so this more conservative assumption helps implementations meet the minmax array limits.

This was [originally suggested in the PR that added these limits](https://github.com/gpuweb/gpuweb/pull/3078#discussion_r906311025), and we think the use of 1 byte was likely a typo.