### PR TITLE
Fix the computation of inter-stage shader components

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8055,7 +8055,8 @@ dictionary GPURenderPipelineDescriptor
         - There must be no more than |maxVertexShaderOutputComponents| scalar
             components across all user-defined outputs for
             |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
-            (For example, a `f32` output uses 1 component, and a `vec3<f32>` output uses 3 components.)
+            Each user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}}
+            consumes 4 scalar components.
         - The [=location=] of each user-defined output of
             |descriptor|.{{GPURenderPipelineDescriptor/vertex}} must be
             &lt; |device|.limits.{{supported limits/maxInterStageShaderVariables}}.
@@ -8075,6 +8076,8 @@ dictionary GPURenderPipelineDescriptor
             - There must be no more than |maxFragmentShaderInputComponents| scalar
                 components across all user-defined inputs for
                 |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
+              Each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}
+              consumes 4 scalar components.
             - For each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}} there
                 must be a user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}} that
                 [=location=], type, and [=interpolation=] of the input.


### PR DESCRIPTION
In the validation of inter-stage interfaces, each user-defined inter-stage shader variable should always consume 4 inter-stage shader components because in latest Vulkan SPEC the Location value specifies an interface slot comprised of a 32-bit four-component vector conveyed between stages.

Fixes: #1962