### PR TITLE
Lower maxInterStageShaderVariables to 15

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1797,7 +1797,7 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
         for inter-stage communication (like vertex outputs or fragment inputs).
 
     <tr><td><dfn>maxInterStageShaderVariables</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>15
     <tr class=row-continuation><td colspan=4>
         The maximum allowed number of input or output variables for inter-stage
         communication (like vertex outputs or fragment inputs).


### PR DESCRIPTION
The value of `maxInterStageShaderVariables` should be 15 instead of 16 because in latest WebGPU SPEC any user-defined
inter-stage shader variable always consumes 4 components, then having 16 inter-stage shader variables will exceed the
maximum value of `maxInterStageShaderComponents` (60).

Bugs: https://github.com/gpuweb/gpuweb/issues/1962