### PR TITLE
Increase `maxInterStageShaderComponents` to 64

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1791,7 +1791,7 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxInterStageShaderComponents</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>60
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>64
     <tr class=row-continuation><td colspan=4>
         The maximum allowed number of components of input or output variables
         for inter-stage communication (like vertex outputs or fragment inputs).


### PR DESCRIPTION
Follow-up to https://github.com/gpuweb/gpuweb/pull/4503, https://github.com/gpuweb/gpuweb/pull/4509 & https://github.com/gpuweb/gpuweb/issues/1962#issuecomment-1966619852.

We need to increase this limit to 64 since `maxInterStageShaderVariables` is 16 and the new algorithm counts each variable as 4 components.