### PR TITLE
Use y component in vec4 constructor

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -13062,7 +13062,7 @@ specify the component type; the component type is inferred from the constructor 
   <tr><td>Parameterization
       <td>`T` is [=scalar=]
   <tr><td>Description
-      <td>[=Component-wise=] construction of a four-component [=vector=] with `e1`, `e2`, `v1.x`, and `v1.x` as components.
+      <td>[=Component-wise=] construction of a four-component [=vector=] with `e1`, `e2`, `v1.x`, and `v1.y` as components.
 </table>
 <table class='data builtin'>
   <tr><td style="width:10%">Overload


### PR DESCRIPTION
In one of the overloaded constructor functions for `vec4`, the component `v1.x` was accidentally listed twice instead of `v1.x` and `v1.y`.