### PR TITLE
Allow out-of-standard-gamut colors with float canvases

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2153,7 +2153,7 @@ space definition, regardless of whether the point represents a real or imaginary
 (WebGPU makes no distinction between real and imaginary colors).
 That "color" can be represented in other color spaces as well, where it may be in-gamut.
 
-<h4 data-dfn-type=dfn>Out-of-Range Premultiplied RGBA Value
+<h4 data-dfn-type=dfn>Out-of-Range Premultiplied RGBA Values
 <span id=out-of-gamut-premultiplied-rgba-value><!-- historical permalink --></span>
 </h4>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2149,20 +2149,77 @@ WebGPU allows all of the color spaces in the {{PredefinedColorSpace}} enum.
 Note, each color space is defined over an extended range, as defined by the referenced CSS definitions,
 to represent color values outside of its space (in both chrominance and luminance).
 
-An <dfn dfn>out-of-gamut premultiplied RGBA value</dfn> is one where any of the R/G/B channel values
-exceeds the alpha channel value. For example, the premultiplied sRGB RGBA value [1.0, 0, 0, 0.5]
-represents the (unpremultiplied) color [2, 0, 0] with 50% alpha, written `rgb(srgb 2 0 0 / 50%)` in CSS.
-Just like any color value outside the sRGB color gamut, this is a well defined point in the extended color space
-(except when alpha is 0, in which case there is no color).
-However, when such values are output to a visible canvas, the result is undefined
-(see {{GPUCanvasAlphaMode}} {{GPUCanvasAlphaMode/"premultiplied"}}).
+<h4 id=out-of-gamut-premultiplied-rgba-value data-dfn-type=dfn>Out-of-Gamut Premultiplied RGBA Values
+</h4>
+
+An [=out-of-gamut premultiplied RGBA value=] is one where any of the R/G/B channel values
+exceeds the alpha channel value.
+
+<div class=example>
+    For example, the premultiplied sRGB RGBA value `[0.51, 0, 0, 0.5]`
+    represents the (unpremultiplied) color <code><a funcdef>color</a>(srgb 1.02 0 0 / 0.5)</code>.
+</div>
+
+Just like any color value outside the sRGB color gamut, any value is a well-defined point in the
+extended color space (regardless of whether the point represents a real color).
+When a canvas containing such a value is
+[$get a copy of the image contents of a context|used as an image source$],
+the color value must not be clamped in the image value given to the calling algorithm
+regardless of the canvas's {{GPUCanvasConfiguration/format}}.
+
+However, when a canvas containing such a value is displayed *on screen*, **if and only if** the
+canvas has a range-limited format (like `unorm` formats, which have a range of 0&ndash;1),
+the visible result for the entire canvas is undefined.
+
+<div class=example>
+    For example, on a display with a color space of exactly Display P3,
+    an on-screen, solid-color {{PredefinedColorSpace/"srgb"}} canvas displays as follows:
+
+    <table class=data>
+        <thead>
+            <tr><th>{{GPUCanvasConfiguration/alphaMode}},<br>{{GPUCanvasConfiguration/format}}<th>Pixel Value<th>Result
+        <tbody>
+            <tr><td>{{GPUCanvasAlphaMode/"opaque"}},<br>{{GPUTextureFormat/"rgba16float"}}
+                <td rowspan=2>`[1.04, 0, 0, 1.0]`
+                <td rowspan=2><code><a funcdef>color</a>(display-p3 0.95 0.21 0.15 / 1.0)</code>,
+                    <br>because the format is not range-limited.
+            <tr><td>{{GPUCanvasAlphaMode/"premultiplied"}},<br>{{GPUTextureFormat/"rgba16float"}}
+            <tr><td>{{GPUCanvasAlphaMode/"premultiplied"}},<br>{{GPUTextureFormat/"rgba16float"}}
+                <td>`[0.52, 0, 0, 0.5]`
+                <td><code><a funcdef>color</a>(display-p3 0.95 0.21 0.15 / 0.5)</code>,
+                    <br>because the format is not range-limited.
+            <tr><td>{{GPUCanvasAlphaMode/"premultiplied"}},<br>{{GPUTextureFormat/"rgba8unorm"}}
+                <td>`[0.50, 0, 0, 0.5]`
+                <td><code><a funcdef>color</a>(display-p3 0.92 0.20 0.14 / 0.5)</code>,
+                    <br>because the color is in-gamut for {{PredefinedColorSpace/"srgb"}}.
+            <tr><td>{{GPUCanvasAlphaMode/"premultiplied"}},<br>{{GPUTextureFormat/"rgba8unorm"}}
+                <td>`[0.52, 0, 0, 0.5]`
+                <td>(undefined result),
+                    <br>because the format is range-limited
+                    <br>and the color is out-of-gamut for {{PredefinedColorSpace/"srgb"}}.
+    </table>
+
+    The last result is undefined because the color could be:
+
+    - blended directly to the display buffer as
+        <code><a funcdef>color</a>(display-p3 0.95 0.21 0.15 / 0.5)</code>.
+    - blended through an intermediate sRGB buffer as `[0.5, 0, 0, 0.5]`,
+        then sent to the display buffer resulting in the appearance of
+        <code><a funcdef>color</a>(display-p3 0.92 0.2 0.14 / 0.5)</code>.
+    - displayed by some other process.
+</div>
+
+Note:
+Implementations may defer compositing steps to operating system compositors,
+which often have undefined behavior in these cases. Implementations may not be able to avoid
+these undefined behaviors without significant power usage penalties.
 
 ### Color Space Conversions ### {#color-space-conversions}
 
 A color is converted between spaces by translating its representation in one space to a
 representation in another according to the definitions above.
 
-If the source value has fewer than 4 RGBA channels, the missing green/blue/alpha channels are set to
+If the source value has fewer than 4 RGBA channels, any missing green/blue/alpha channels are set to
 `0, 0, 1`, respectively, before converting for color space/encoding and alpha premultiplication.
 After conversion, if the destination needs fewer than 4 channels, the additional channels
 are ignored.
@@ -2174,7 +2231,7 @@ Colors are not lossily clamped during conversion: converting from one color spac
 will result in values outside the range [0, 1] if the source color values were outside the range
 of the destination color space's gamut. For an sRGB destination, for example, this can occur if the
 source is rgba16float, in a wider color space like Display-P3, or is premultiplied and contains
-[=out-of-gamut premultiplied RGBA value|out-of-gamut values=].
+[=out-of-gamut premultiplied RGBA value|out-of-gamut values=]. <!-- FIXME? -->
 
 Similarly, if the source value has a high bit depth (e.g. PNG with 16 bits per component) or
 extended range (e.g. canvas with `float16` storage), these colors are preserved through color space
@@ -13748,19 +13805,14 @@ is being composited into (e.g. an HTML page rendering, or a 2D canvas).
     : <dfn>"premultiplied"</dfn>
     ::
         Read RGBA as premultiplied: color values are premultiplied by their alpha value.
-        100% red at 50% alpha is `[0.5, 0, 0, 0.5]`.
+        For example, 100% red at 50% alpha is `[0.5, 0, 0, 0.5]`.
 
-        If [=out-of-gamut premultiplied RGBA values=] are output to the canvas, and the canvas is:
+        When alpha is 0, no color is represented, regardless of the RGB values.
+        (Attempting to compute the color results in division by zero.)
 
-        <dl class=switch>
-            : [$get a copy of the image contents of a context|used as an image source$]
-            :: Values are preserved, as described in [[#color-space-conversions|color space conversion]].
-
-            : displayed to the screen
-            :: Compositing results are undefined.
-                This is true even if color space conversion would produce in-gamut values before
-                compositing, because the intermediate format for compositing is not specified.
-        </dl>
+        In this mode, the canvas texture may represent [=out-of-gamut premultiplied RGBA values=].
+        If the canvas has a range-limited format and is displayed on screen, out-of-gamut values
+        have undefined display results. Refer to that section for details.
 </dl>
 
 # Errors &amp; Debugging # {#errors-and-debugging}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2149,22 +2149,28 @@ WebGPU allows all of the color spaces in the {{PredefinedColorSpace}} enum.
 Note, each color space is defined over an extended range, as defined by the referenced CSS definitions,
 to represent color values outside of its space (in both chrominance and luminance).
 
-<h4 id=out-of-gamut-premultiplied-rgba-value data-dfn-type=dfn>Out-of-Gamut Premultiplied RGBA Values
+<h4 data-dfn-type=dfn>Out-of-Standard-Gamut Color Representation
+<span id=out-of-gamut-premultiplied-rgba-value><!-- historical permalink --></span>
 </h4>
 
-An [=out-of-gamut premultiplied RGBA value=] is one where any of the R/G/B channel values
-exceeds the alpha channel value.
+An [=out-of-standard-gamut color representation=] is one where any of the unpremultiplied
+red/green/blue channel numeric values are outside of the 0-to-1 range.
+In a premultiplied representation, the R/G/B value is outside the 0-to-`alpha` range.
+
+Any numeric value in any gamut is a well-defined "color" according to that gamut's extended
+color space (regardless of whether the point represents a real or imaginary color).
+That "color" can be represented in other gamuts as well, where it may be in-gamut.
 
 <div class=example>
-    For example, the premultiplied sRGB RGBA value `[0.52, 0, 0, 0.5]`
-    represents the (unpremultiplied) color <code><a funcdef>color</a>(srgb 1.04 0 0 / 0.5)</code>.
+    For example, the unpremultiplied sRGB RGBA value `[1.04, 0, 0, 0.5]` and the
+    premultiplied sRGB RGBA value `[0.52, 0, 0, 0.5]` both represent the
+    CSS color <code><a funcdef>color</a>(srgb 1.04 0 0 / 0.5)</code>, which is equivalent to the
+    in-gamut Display P3 color <code><a funcdef>color</a>(display-p3 0.95 0.21 0.15 / 0.5)</code>.
 </div>
 
-Just like any color value outside the sRGB color gamut, any value is a well-defined point in the
-extended color space (regardless of whether the point represents a real color).
 When a canvas containing such a value is
 [$get a copy of the image contents of a context|used as an image source$],
-the color value must not be clamped in the image value given to the calling algorithm
+the returned image must represent the original color values without clamping,
 regardless of the canvas's {{GPUCanvasConfiguration/format}}.
 
 However, when a canvas containing such a value is displayed *on screen*, **if and only if** the
@@ -2196,7 +2202,8 @@ the visible result for the entire canvas is undefined.
                 <td>`[0.52, 0, 0, 0.5]`
                 <td>(undefined result),
                     <br>because the format is range-limited
-                    <br>and the color is out-of-gamut for {{PredefinedColorSpace/"srgb"}}.
+                    <br>and the color is out-of-standard-gamut for {{PredefinedColorSpace/"srgb"}}.
+            <!-- POSTV1(#4108): add example for XR format -->
     </table>
 
     The last result is undefined because the color could be:
@@ -2227,15 +2234,14 @@ are ignored.
 Note:
 Grayscale images generally represent RGB values `(V, V, V)`, or RGBA values `(V, V, V, A)` in their color space.
 
-Colors are not lossily clamped during conversion: converting from one color space to another
-will result in values outside the range [0, 1] if the source color values were outside the range
-of the destination color space's gamut. For an sRGB destination, for example, this can occur if the
-source is rgba16float, in a wider color space like Display-P3, or is premultiplied and contains
-[=out-of-gamut premultiplied RGBA value|out-of-gamut values=]. <!-- FIXME? -->
+Colors must not be lossily clamped during conversion: converting from one color space to another
+may result in an [=out-of-standard-gamut color representation=] in the destination gamut,
+which must be preserved. Refer to that section for details.
 
-Similarly, if the source value has a high bit depth (e.g. PNG with 16 bits per component) or
-extended range (e.g. canvas with `float16` storage), these colors are preserved through color space
-conversion, with intermediate computations having at least the precision of the source.
+Similarly, precision must be preserved through color space conversion, with intermediate
+computations being at least as precise as the less-precise of the source and destination
+(for example copying a PNG with 16 bits per component, or a canvas with `float16` storage, into a
+{{GPUTextureFormat/rgba16float}} texture).
 
 ### Color Space Conversion Elision ### {#color-space-conversion-elision}
 
@@ -13810,9 +13816,9 @@ is being composited into (e.g. an HTML page rendering, or a 2D canvas).
         When alpha is 0, no color is represented, regardless of the RGB values.
         (Attempting to compute the color results in division by zero.)
 
-        In this mode, the canvas texture may represent [=out-of-gamut premultiplied RGBA values=].
-        If the canvas has a range-limited format and is displayed on screen, out-of-gamut values
-        have undefined display results. Refer to that section for details.
+        In this mode, the canvas texture may hold [=out-of-standard-gamut color representations=].
+        If the canvas has a range-limited format and is displayed on screen, out-of-standard-gamut
+        values have undefined display results. Refer to that section for details.
 </dl>
 
 # Errors &amp; Debugging # {#errors-and-debugging}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2161,7 +2161,8 @@ An [=out-of-range premultiplied RGBA value=] is one for which the unpremultiplie
 of the same color would be outside of the range of the format.
 
 <div class=example>
-    For example, the unpremultiplied sRGB RGBA value `[1.04, 0, 0, 0.5]` and the
+    For example, on a display with a color space of exactly Display P3,
+    the unpremultiplied sRGB RGBA value `[1.04, 0, 0, 0.5]` and the
     premultiplied sRGB RGBA value `[0.52, 0, 0, 0.5]` both represent the
     CSS color <code><a funcdef>color</a>(srgb 1.04 0 0 / 0.5)</code>, which is equivalent to the
     in-gamut Display P3 color <code><a funcdef>color</a>(display-p3 0.95 0.21 0.15 / 0.5)</code>.
@@ -2169,6 +2170,8 @@ of the same color would be outside of the range of the format.
     When represented in a {{PredefinedColorSpace/"srgb"}} {{GPUTextureFormat/"rgba8unorm"}} canvas,
     both values are out-of-range for the purposes of this definition,
     even though the premultiplied value is representable.
+
+    (The colors in this example are in the gamut of the display to avoid any gamut mapping.)
 </div>
 
 When a canvas containing such a value is
@@ -2212,6 +2215,8 @@ displayed *on screen*, the visible result for the entire canvas is undefined.
         then sent to the display buffer resulting in the appearance of
         <code><a funcdef>color</a>(display-p3 0.92 0.2 0.14 / 0.5)</code>.
     - Value displayed by some other process.
+
+    (The colors in this example are in the gamut of the display to avoid any gamut mapping.)
 </div>
 
 Note:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2148,24 +2148,27 @@ premultiplication) in which the WebGPU numeric values are to be interpreted.
 WebGPU allows all of the color spaces in the {{PredefinedColorSpace}} enum.
 Note, each color space is defined over an extended range, as defined by the referenced CSS definitions,
 to represent color values outside of its space (in both chrominance and luminance).
+Any numeric value in any color space is a well-defined "color" according to its extended color
+space definition, regardless of whether the point represents a real or imaginary color
+(WebGPU makes no distinction between real and imaginary colors).
+That "color" can be represented in other color spaces as well, where it may be in-gamut.
 
-<h4 data-dfn-type=dfn>Out-of-Standard-Gamut Color Representation
+<h4 data-dfn-type=dfn>Out-of-Range Premultiplied RGBA Value
 <span id=out-of-gamut-premultiplied-rgba-value><!-- historical permalink --></span>
 </h4>
 
-An [=out-of-standard-gamut color representation=] is one where any of the unpremultiplied
-red/green/blue channel numeric values are outside of the 0-to-1 range.
-In a premultiplied representation, the R/G/B value is outside the 0-to-`alpha` range.
-
-Any numeric value in any gamut is a well-defined "color" according to that gamut's extended
-color space (regardless of whether the point represents a real or imaginary color).
-That "color" can be represented in other gamuts as well, where it may be in-gamut.
+An [=out-of-range premultiplied RGBA value=] is one for which the unpremultiplied representation
+of the same color would be outside of the range of the format.
 
 <div class=example>
     For example, the unpremultiplied sRGB RGBA value `[1.04, 0, 0, 0.5]` and the
     premultiplied sRGB RGBA value `[0.52, 0, 0, 0.5]` both represent the
     CSS color <code><a funcdef>color</a>(srgb 1.04 0 0 / 0.5)</code>, which is equivalent to the
     in-gamut Display P3 color <code><a funcdef>color</a>(display-p3 0.95 0.21 0.15 / 0.5)</code>.
+
+    When represented in a {{PredefinedColorSpace/"srgb"}} {{GPUTextureFormat/"rgba8unorm"}} canvas,
+    both values are out-of-range for the purposes of this definition,
+    even though the premultiplied value is representable.
 </div>
 
 When a canvas containing such a value is
@@ -2173,9 +2176,8 @@ When a canvas containing such a value is
 the returned image must represent the original color values without clamping,
 regardless of the canvas's {{GPUCanvasConfiguration/format}}.
 
-However, when a canvas containing such a value is displayed *on screen*, **if and only if** the
-canvas has a range-limited format (like `unorm` formats, which have a range of 0&ndash;1),
-the visible result for the entire canvas is undefined.
+However, when a ({{GPUCanvasAlphaMode/"premultiplied"}}) canvas containing such a value is
+displayed *on screen*, the visible result for the entire canvas is undefined.
 
 <div class=example>
     For example, on a display with a color space of exactly Display P3,
@@ -2187,33 +2189,29 @@ the visible result for the entire canvas is undefined.
         <tbody>
             <tr><td>{{GPUCanvasAlphaMode/"opaque"}},<br>{{GPUTextureFormat/"rgba16float"}}
                 <td rowspan=2>`[1.04, 0, 0, 1.0]`
-                <td rowspan=2><code><a funcdef>color</a>(display-p3 0.95 0.21 0.15 / 1.0)</code>,
-                    <br>because the format is not range-limited.
+                <td rowspan=2><code><a funcdef>color</a>(display-p3 0.95 0.21 0.15 / 1.0)</code>.
             <tr><td>{{GPUCanvasAlphaMode/"premultiplied"}},<br>{{GPUTextureFormat/"rgba16float"}}
             <tr><td>{{GPUCanvasAlphaMode/"premultiplied"}},<br>{{GPUTextureFormat/"rgba16float"}}
                 <td>`[0.52, 0, 0, 0.5]`
-                <td><code><a funcdef>color</a>(display-p3 0.95 0.21 0.15 / 0.5)</code>,
-                    <br>because the format is not range-limited.
+                <td><code><a funcdef>color</a>(display-p3 0.95 0.21 0.15 / 0.5)</code>.
             <tr><td>{{GPUCanvasAlphaMode/"premultiplied"}},<br>{{GPUTextureFormat/"rgba8unorm"}}
                 <td>`[0.50, 0, 0, 0.5]`
-                <td><code><a funcdef>color</a>(display-p3 0.92 0.20 0.14 / 0.5)</code>,
-                    <br>because the color is in-gamut for {{PredefinedColorSpace/"srgb"}}.
+                <td><code><a funcdef>color</a>(display-p3 0.92 0.20 0.14 / 0.5)</code>.
             <tr><td>{{GPUCanvasAlphaMode/"premultiplied"}},<br>{{GPUTextureFormat/"rgba8unorm"}}
                 <td>`[0.52, 0, 0, 0.5]`
                 <td>(undefined result),
-                    <br>because the format is range-limited
-                    <br>and the color is out-of-standard-gamut for {{PredefinedColorSpace/"srgb"}}.
-            <!-- POSTV1(#4108): add example for XR format -->
+                    <br>because the unpremultiplied color cannot be represented in this format.
+            <!-- POSTV1(#4108): add example for XR formats, which *probably* handle this -->
     </table>
 
-    The last result is undefined because the color could be:
+    Visible results may be undefined because the value could be lost at different steps of display:
 
-    - blended directly to the display buffer as
+    - Value blended directly to the display buffer as
         <code><a funcdef>color</a>(display-p3 0.95 0.21 0.15 / 0.5)</code>.
-    - blended through an intermediate sRGB buffer as `[0.5, 0, 0, 0.5]`,
+    - Value blended through an intermediate sRGB buffer as `[0.5, 0, 0, 0.5]`,
         then sent to the display buffer resulting in the appearance of
         <code><a funcdef>color</a>(display-p3 0.92 0.2 0.14 / 0.5)</code>.
-    - displayed by some other process.
+    - Value displayed by some other process.
 </div>
 
 Note:
@@ -2234,9 +2232,11 @@ are ignored.
 Note:
 Grayscale images generally represent RGB values `(V, V, V)`, or RGBA values `(V, V, V, A)` in their color space.
 
-Colors must not be lossily clamped during conversion: converting from one color space to another
-may result in an [=out-of-standard-gamut color representation=] in the destination gamut,
-which must be preserved. Refer to that section for details.
+Colors are not lossily clamped during conversion: converting from one color space to another
+will result in values outside the range [0, 1] if the source color values were outside the range
+of the destination color space's gamut. For an sRGB destination, for example, this can occur if the
+source is rgba16float, in a wider color space like Display-P3, or is premultiplied and contains
+[=out-of-range premultiplied RGBA values=].
 
 Similarly, precision must be preserved through color space conversion, with intermediate
 computations being at least as precise as the less-precise of the source and destination
@@ -13816,9 +13816,9 @@ is being composited into (e.g. an HTML page rendering, or a 2D canvas).
         When alpha is 0, no color is represented, regardless of the RGB values.
         (Attempting to compute the color results in division by zero.)
 
-        In this mode, the canvas texture may hold [=out-of-standard-gamut color representations=].
-        If the canvas has a range-limited format and is displayed on screen, out-of-standard-gamut
-        values have undefined display results. Refer to that section for details.
+        In this mode, with some texture formats, the canvas texture can hold
+        [=out-of-range premultiplied RGBA values=], which have undefined display results.
+        Refer to that section for details.
 </dl>
 
 # Errors &amp; Debugging # {#errors-and-debugging}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2156,8 +2156,8 @@ An [=out-of-gamut premultiplied RGBA value=] is one where any of the R/G/B chann
 exceeds the alpha channel value.
 
 <div class=example>
-    For example, the premultiplied sRGB RGBA value `[0.51, 0, 0, 0.5]`
-    represents the (unpremultiplied) color <code><a funcdef>color</a>(srgb 1.02 0 0 / 0.5)</code>.
+    For example, the premultiplied sRGB RGBA value `[0.52, 0, 0, 0.5]`
+    represents the (unpremultiplied) color <code><a funcdef>color</a>(srgb 1.04 0 0 / 0.5)</code>.
 </div>
 
 Just like any color value outside the sRGB color gamut, any value is a well-defined point in the


### PR DESCRIPTION
The spec previously said that it was undefined behavior to display "out-of-gamut premultiplied RGBA values" (R/G/B &gt; A).

But that definition overlooked some cases. We intended to allow using an rgba16float srgb canvas to display wider-than-srgb colors, but such colors would according to the current definition be "out-of-gamut premultiplied RGBA values" (regardless of whether they're opaque like `[1.04, 0, 0, 1]` or transparent like `[0.52, 0, 0, 0.5]`).

This replaces that concept with "out-of-range premultiplied RGBA values", which is when the _unpremultiplied equivalent of the color_ can't be represented in the format used for the color (e.g. premul `[0.52, 0, 0, 0.5]` in `rgba8unorm`). I've written it this way because I _think_ it will be valid for #4108 as well if we ever get that [EDIT: fixed link to point to correct issue]. The idea is that as long as the implementation doesn't use any intermediate format that's _worse_ than the canvas format (in either range or precision), the color will be preserved.