### PR TITLE
[editorial] Clarify that override declarations must be at module scope

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4696,6 +4696,8 @@ be used via type inference.
 
 An <dfn noexport>override-declaration</dfn> specifies a name for a
 [=pipeline-overridable=] constant value.
+An override-declaration [=shader-creation error|must=] only be declared at
+[=module scope=].
 The value of a <dfn noexport>pipeline-overridable</dfn> constant is fixed at
 [=pipeline creation|pipeline-creation time=].
 The value is one provided by the WebGPU pipeline-creation method, if


### PR DESCRIPTION
* The grammar restricts override declarations to module scope, but that limitation was missing from the prose description of the declaration