### PR TITLE
[editorial] Clarify that texture copy ranges are 'physical'

### DIFF
--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -401,6 +401,11 @@ dictionary GPUImageCopyExternalImage {
         - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/z=] + |copySize|.[=GPUExtent3D/depthOrArrayLayers=]) &le; |subresourceSize|.[=GPUExtent3D/depthOrArrayLayers=]
         - |copySize|.[=GPUExtent3D/width=] must be a multiple of |blockWidth|.
         - |copySize|.[=GPUExtent3D/height=] must be a multiple of |blockHeight|.
+
+        Note:
+        The texture copy range is validated against the *physical* (rounded-up)
+        size for [=compressed formats=], allowing copies to access texture
+        blocks which are not fully inside the texture.
 </div>
 
 <div algorithm>

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -179,7 +179,7 @@ dictionary GPUImageCopyTexture {
             |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/mipLevelCount}}.
         - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/x=] must be a multiple of |blockWidth|.
         - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/y=] must be a multiple of |blockHeight|.
-        - The [=imageCopyTexture subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
+        - The [=imageCopyTexture physical subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
             the following conditions is true:
             - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}} is a depth-stencil format.
             - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/sampleCount}} &gt; 1.
@@ -312,8 +312,8 @@ dictionary GPUImageCopyExternalImage {
 
 ### Subroutines ### {#image-copies-subroutines}
 
-<div algorithm="imageCopyTexture subresource size">
-    <dfn dfn>imageCopyTexture subresource size</dfn>
+<div algorithm="imageCopyTexture physical subresource size">
+    <dfn dfn>imageCopyTexture physical subresource size</dfn>
 
     **Arguments:**
 
@@ -321,7 +321,7 @@ dictionary GPUImageCopyExternalImage {
 
     **Returns:** {{GPUExtent3D}}
 
-    The [=imageCopyTexture subresource size=] of |imageCopyTexture| is calculated as follows:
+    The [=imageCopyTexture physical subresource size=] of |imageCopyTexture| is calculated as follows:
 
     Its [=GPUExtent3D/width=], [=GPUExtent3D/height=] and [=GPUExtent3D/depthOrArrayLayers=] are the width, height, and depth, respectively,
     of the [=physical miplevel-specific texture extent=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} [=subresource=] at [=mipmap level=]
@@ -393,7 +393,7 @@ dictionary GPUImageCopyExternalImage {
 
     1. Let |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
     1. Let |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
-    1. Let |subresourceSize| be the [=imageCopyTexture subresource size=] of |imageCopyTexture|.
+    1. Let |subresourceSize| be the [=imageCopyTexture physical subresource size=] of |imageCopyTexture|.
     1. Return whether all the conditions below are satisfied:
 
         - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/x=] + |copySize|.[=GPUExtent3D/width=]) &le; |subresourceSize|.[=GPUExtent3D/width=]


### PR DESCRIPTION
This makes it a little less buried how to do image copies with mip-mapped compressed textures.