### PR TITLE
wgsl: Add a carve out for AF `fract` accuracy

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11909,6 +11909,7 @@ the rules in [[#floating-point-overflow]] apply.
 The accuracy of an [=AbstractFloat=] operation is as follows:
 * A correct result is required when the corresponding [=f32=] operation requires a correct result.
 * A [=correctly rounded=] result is required when the corresponding [=f32=] operation requires a correctly rounded result.
+* `fract(x)`'s error is inherited from `x - floor(x)`, where the intermediate calculations are performed as [=AbstractFloat=] operations.
 * Otherwise, the error of the corresponding [=f32=] operation is an absolute error, a relative error, an error inherited
     from a potential implementation, or a combination of these.
     In this case the error of the [=AbstractFloat=] is unbounded.


### PR DESCRIPTION
Fixes #4523