### PR TITLE
Add synchronous GPUAdapter.info

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1955,10 +1955,16 @@ interface WGSLLanguageFeatures {
 
 {{GPUAdapterInfo}} exposes various identifying information about an adapter.
 
-None of the members in {{GPUAdapterInfo}} are guaranteed to be populated. It is at the user
+None of the members in {{GPUAdapterInfo}} are guaranteed to be populated (non-empty). It is at the user
 agent's discretion which values to reveal, and it is likely that on some devices none of the values
 will be populated. As such, applications **must** be able to handle any possible {{GPUAdapterInfo}} values,
 including the absence of those values.
+
+All {{GPUAdapterInfo}} objects from a given adapter **should** produce the same contents
+at any given time, regardless of which way they're accessed.
+The contents could change over time; for example, if some call to
+{{GPUAdapter/requestAdapterInfo()}} reveals more information (though it generally **shouldn't**),
+it should be visible via {{GPUAdapter/info|GPUAdapter.info}} as well.
 
 <p tracking-vector>
 For privacy considerations, see [[#privacy-adapter-identifiers]].
@@ -2595,6 +2601,7 @@ To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 interface GPUAdapter {
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
+    [SameObject] readonly attribute GPUAdapterInfo info;
     readonly attribute boolean isFallbackAdapter;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
@@ -2612,6 +2619,14 @@ interface GPUAdapter {
     : <dfn>limits</dfn>
     ::
         The limits in `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[limits]]}}.
+
+    : <dfn>info</dfn>
+    ::
+        The {{GPUAdapterInfo}} for this adapter. Returns the same object each time, whereas
+        {{GPUAdapter/requestAdapterInfo()}} returns a new object each time.
+
+        All {{GPUAdapterInfo}} objects from a given adapter **should** produce the same contents
+        at any given time, regardless of which way they're accessed, but may change over time.
 
     : <dfn>isFallbackAdapter</dfn>
     ::
@@ -2737,10 +2752,19 @@ interface GPUAdapter {
 
     : <dfn>requestAdapterInfo()</dfn>
     ::
-        Requests the {{GPUAdapterInfo}} for this {{GPUAdapter}}.
+        Requests {{GPUAdapterInfo}} for this {{GPUAdapter}}.
 
-        Note: Adapter info values are returned with a Promise to give user agents an
-        opportunity to perform potentially long-running checks in the future.
+        Returns a new object each time, whereas <code>adapter.{{GPUAdapter/info}}</code>
+        returns the same object each time.
+
+        <div class=note heading>
+            The synchronous {{GPUAdapter/info|GPUAdapter.info}} reports the same info.
+            Generally there is no need to use the asynchronous {{GPUAdapter/requestAdapterInfo()}},
+            which **should** not reveal more information than {{GPUAdapter/info}}.
+
+            This async entry point (as defined currently) will not perform long-running checks
+            and always returns an already-resolved promise.
+        </div>
 
         <div algorithm=GPUAdapter.requestAdapterInfo>
             <div data-timeline=content>
@@ -2752,9 +2776,7 @@ interface GPUAdapter {
 
                 1. Let |promise| be [=a new promise=].
                 1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
-                1. Run the following steps [=in parallel=]:
-                    1. [=Resolve=] |promise| with a [$new adapter info$] for |adapter|.
-
+                1. [=Resolve=] |promise| with a [$new adapter info$] for |adapter|.
                 1. Return |promise|.
             </div>
         </div>


### PR DESCRIPTION
- Add a `[SameObject] readonly attribute GPUAdapterInfo info;` to `GPUAdapter`. - It returns the same JS object every time you access it.
- `requestAdapterInfo` still returns a new one each time for minor backward-compatibility reasons. - **HOWEVER** it has been changed to always return an already-resolved promise instead of resolving later.
- If the info available to the page changes for some reason (generally shouldn't), the attributes on the `GPUAdapterInfo` object start returning different values (like an empty string gets changed to a non-empty string).

Fixes #4536