### PR TITLE
Make shader-creation errors possible for array sizes

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2805,7 +2805,7 @@ The element count expression |N| of a fixed-size array is subject to the followi
     * Otherwise, it is a [=pipeline-creation error=].
 
 Note:  The element count value is fully determined at [=pipeline creation=]
-time if |N| depends on any [=override-declarations=] and [=shader module creation=]
+time if |N| depends on any [=override-declarations=], and [=shader module creation=]
 otherwise.
 
 Note:  To qualify for type-equivalency, any override expression that is not a const expression must be an **identifier**.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2800,9 +2800,13 @@ An expression [=shader-creation error|must not=] evaluate to a runtime-sized arr
 The element count expression |N| of a fixed-size array is subject to the following constraints:
 * It [=shader-creation error|must=] be an [=override-expression=].
 * It [=shader-creation error|must=] evaluate to a [=type/concrete=] [=integer scalar=].
-* It is a [=pipeline-creation error=] if |N| is not greater than zero.
+* If |N| is not greater than zero:
+    * It is a [=shader-creation error=] if |N| is a [=const-expression=].
+    * Otherwise, it is a [=pipeline-creation error=].
 
-Note:  The element count value is fully determined at [=pipeline creation=] time.
+Note:  The element count value is fully determined at [=pipeline creation=]
+time if |N| depends on any [=override-declarations=] and [=shader module creation=]
+otherwise.
 
 Note:  To qualify for type-equivalency, any override expression that is not a const expression must be an **identifier**.
 See <a href="#example-workgroup-variables-sized-by-override">Workgroup variables sized by overridable constants</a>


### PR DESCRIPTION
Refs #4551

* If the array element count expression is a const-expression, invalid values should be shader-creation errors

This does not resolve the question of when type checking vs const evaluation occurs.