### PR TITLE
Move Attribute Values out of Enumerants

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1312,6 +1312,18 @@ The spelling of the token may be the same as an [=identifier=], but the token do
 
 Section [[#context-dependent-name-tokens]] lists all such tokens.
 
+## Built-in Value Names ## {#builtin-value-names}
+
+A <dfn noexport>built-in value name-token</dfn> is a [=token=] used in the name of a [=built-in value=].
+The spelling of the token may be the same as an [=identifier=] but does not [=resolves|resolve to=] a declared object.
+The token must not be a [=keyword=] or [=reserved word=].
+
+See [[#builtin-inputs-outputs]].
+
+<pre class=include>
+path: syntax/builtin_value_name.syntax.bs.include
+</pre>
+
 ## Diagnostic Rule Names ## {#diagnostic-rule-names}
 
 A <dfn noexport>diagnostic name-token</dfn> is a [=token=] used in the name of a diagnostic [=diagnostic/triggering rule=].
@@ -1322,6 +1334,30 @@ See [[#diagnostics]].
 
 <pre class=include>
 path: syntax/diagnostic_name_token.syntax.bs.include
+</pre>
+
+## Interpolation Type Names ## {#interpolation-type-names}
+
+An <dfn noexport>interpolation type name-token</dfn> is a [=token=] used in the name of an [=interpolation type=].
+The spelling of the token may be the same as an [=identifier=] but does not [=resolves|resolve to=] a declared object.
+The token must not be a [=keyword=] or [=reserved word=].
+
+See [[#interpolation]].
+
+<pre class=include>
+path: syntax/interpolate_type_name.syntax.bs.include
+</pre>
+
+## Interpolation Sampling Names ## {#interpolation-sampling-names}
+
+An <dfn noexport>interpolation sampling name-token</dfn> is a [=token=] used in the name of an [=interpolation sampling=].
+The spelling of the token may be the same as an [=identifier=] but does not [=resolves|resolve to=] a declared object.
+The token must not be a [=keyword=] or [=reserved word=].
+
+See [[#interpolation]].
+
+<pre class=include>
+path: syntax/interpolate_sampling_name.syntax.bs.include
 </pre>
 
 ## Template Lists ## {#template-lists-sec}
@@ -1771,7 +1807,7 @@ For example, WGSL predeclares:
 * [=built-in functions=],
 * built-in types such as [=i32=] and [=f32=],
 * built-in [=type-generators=] such as `array`, `ptr`, and `texture_2d`, and
-* [=enumerants=] such as [=access/read_write=], [=interpolation type/perspective=], and [=texel format/rgba8unorm=].
+* [=enumerants=] such as [=access/read_write=], [=address spaces/workgroup=], and [=texel format/rgba8unorm=].
 
 The <dfn noexport>scope</dfn> of a declaration is the set of
 program source locations where a declared identifier potentially denotes
@@ -3134,27 +3170,6 @@ The enumeration types exist, but cannot be spelled in WGSL source.
   <tr><td>[=address spaces/workgroup=]
   <tr><td>[=address spaces/uniform=]
   <tr><td>[=address spaces/storage=]
-  <tr><td rowspan=3>[=interpolation type=]
-      <td>[=interpolation type/perspective=]
-  <tr><td>[=interpolation type/linear=]
-  <tr><td>[=interpolation type/flat=]
-  <tr><td rowspan=3>[=interpolation sampling=]
-      <td>[=interpolation sampling/center=]
-  <tr><td>[=interpolation sampling/centroid=]
-  <tr><td>[=interpolation sampling/sample=]
-  <tr><td rowspan=12>[=built-in value=]
-      <td>[=built-in values/vertex_index=]
-  <tr><td>[=built-in values/instance_index=]
-  <tr><td>[=built-in values/position=]
-  <tr><td>[=built-in values/front_facing=]
-  <tr><td>[=built-in values/frag_depth=]
-  <tr><td>[=built-in values/local_invocation_id=]
-  <tr><td>[=built-in values/local_invocation_index=]
-  <tr><td>[=built-in values/global_invocation_id=]
-  <tr><td>[=built-in values/workgroup_id=]
-  <tr><td>[=built-in values/num_workgroups=]
-  <tr><td>[=built-in values/sample_index=]
-  <tr><td>[=built-in values/sample_mask=]
   <tr><td rowspan=17>[=texel format=]
       <td>[=texel format/rgba8unorm=]
   <tr><td>[=texel format/rgba8snorm=]
@@ -8267,11 +8282,11 @@ Unless explicitly permitted below, an attribute [=shader-creation error|must not
     See [[#resource-interface]].
 
   <tr><td><dfn noexport dfn-for="attribute">`builtin`</dfn>
-    <td>[=shader-creation error|Must=] be an [=enumerant=] for a [=built-in value=].
+    <td>[=shader-creation error|Must=] be a [=built-in value name-token=] for a [=built-in value=].
     <td>[=shader-creation error|Must=] only be applied to an entry point
     function parameter, entry point return type, or member of a [=structure=].
 
-    Specifies that the associated object is a built-in value, as denoted by the specified [=enumerant=].
+    Specifies that the associated object is a built-in value, as denoted by the specified [=token=].
     See [[#builtin-inputs-outputs]].
 
   <tr><td><dfn noexport dfn-for="attribute">`const`</dfn>
@@ -8317,10 +8332,11 @@ Unless explicitly permitted below, an attribute [=shader-creation error|must not
   <tr><td><dfn noexport dfn-for="attribute">`interpolate`</dfn>
     <td>One or two parameters.
 
-    The first parameter [=shader-creation error|must=] be an [=enumerant=] for an [=interpolation type=].
+    The first parameter [=shader-creation error|must=] be an
+    [=interpolation type name-token=] for an [=interpolation type=].
 
     The second parameter, if present, [=shader-creation error|must=] be
-    an [=enumerant=] for the [=interpolation sampling=].
+    an [=interpolation sampling name-token=] for the [=interpolation sampling=].
 
     <td>[=shader-creation error|Must=] only be applied to a declaration that
     has a [=attribute/location=] attribute applied.
@@ -9210,23 +9226,23 @@ the [=attribute/interpolate=] attribute.
 WGSL offers two aspects of interpolation to control: the type of
 interpolation, and the sampling of the interpolation.
 
-The <dfn noexport>interpolation type</dfn> [=shader-creation error|must=] be one of the following [=predeclared=] [=enumerants=]:
-: <dfn for="interpolation type">perspective</dfn>
+The <dfn export>interpolation type</dfn> [=shader-creation error|must=] be one of the following [=predeclared=] [=enumerants=]:
+: <dfn for="interpolation type" export>perspective</dfn>
 :: Values are interpolated in a perspective correct manner.
-: <dfn for="interpolation type">linear</dfn>
+: <dfn for="interpolation type" export>linear</dfn>
 :: Values are interpolated in a linear, non-perspective correct manner.
-: <dfn for="interpolation type">flat</dfn>
+: <dfn for="interpolation type" export>flat</dfn>
 :: Values are not interpolated.
     Interpolation sampling is not used with `flat` interpolation.
 
-The <dfn noexport>interpolation sampling</dfn> [=shader-creation error|must=] be one of the following [=predeclared=] [=enumerants=]:
-: <dfn for="interpolation sampling">center</dfn>
+The <dfn export>interpolation sampling</dfn> [=shader-creation error|must=] be one of the following [=predeclared=] [=enumerants=]:
+: <dfn for="interpolation sampling" export>center</dfn>
 :: Interpolation is performed at the center of the pixel.
-: <dfn for="interpolation sampling">centroid</dfn>
+: <dfn for="interpolation sampling" export>centroid</dfn>
 :: Interpolation is performed at a point that lies within all the
     samples covered by the fragment within the current primitive.
     This value is the same for all samples in the primitive.
-: <dfn for="interpolation sampling">sample</dfn>
+: <dfn for="interpolation sampling" export>sample</dfn>
 :: Interpolation is performed per sample.
     The [=fragment=] shader is invoked once per sample when this attribute is
     applied.

--- a/wgsl/syntax.bnf
+++ b/wgsl/syntax.bnf
@@ -104,13 +104,13 @@ template_arg_expression :
 attribute :
   '@' 'align' '(' expression attrib_end
 | '@' 'binding' '(' expression attrib_end
-| '@' 'builtin' '(' expression attrib_end
+| '@' 'builtin' '(' builtin_value_name attrib_end
 | '@' 'const'
 | '@' 'diagnostic' diagnostic_control
 | '@' 'group' '(' expression attrib_end
 | '@' 'id' '(' expression attrib_end
-| '@' 'interpolate' '(' expression attrib_end
-| '@' 'interpolate' '(' expression ',' expression attrib_end
+| '@' 'interpolate' '(' interpolate_type_name attrib_end
+| '@' 'interpolate' '(' interpolate_type_name ',' interpolate_sampling_name attrib_end
 | '@' 'invariant'
 | '@' 'location' '(' expression attrib_end
 | '@' 'must_use'
@@ -127,8 +127,20 @@ attrib_end :
   ',' ? ')'
 ;
 
+builtin_value_name :
+  ident_pattern_token
+;
+
 diagnostic_control :
   '(' severity_control_name ',' diagnostic_rule_name attrib_end
+;
+
+interpolate_type_name :
+  ident_pattern_token
+;
+
+interpolate_sampling_name :
+  ident_pattern_token
 ;
 
 struct_decl :

--- a/wgsl/syntax/attribute.syntax.bs.include
+++ b/wgsl/syntax/attribute.syntax.bs.include
@@ -5,7 +5,7 @@
 
     <span class="choice">|</span> <a for=syntax_sym lt=attr>`'@'`</a> `'binding'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    <span class="choice">|</span> <a for=syntax_sym lt=attr>`'@'`</a> `'builtin'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
+    <span class="choice">|</span> <a for=syntax_sym lt=attr>`'@'`</a> `'builtin'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/builtin_value_name=] [=syntax/attrib_end=]
 
     <span class="choice">|</span> <a for=syntax_sym lt=attr>`'@'`</a> `'const'`
 
@@ -15,9 +15,9 @@
 
     <span class="choice">|</span> <a for=syntax_sym lt=attr>`'@'`</a> `'id'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    <span class="choice">|</span> <a for=syntax_sym lt=attr>`'@'`</a> `'interpolate'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
+    <span class="choice">|</span> <a for=syntax_sym lt=attr>`'@'`</a> `'interpolate'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/interpolate_type_name=] [=syntax/attrib_end=]
 
-    <span class="choice">|</span> <a for=syntax_sym lt=attr>`'@'`</a> `'interpolate'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/expression=] [=syntax/attrib_end=]
+    <span class="choice">|</span> <a for=syntax_sym lt=attr>`'@'`</a> `'interpolate'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/interpolate_type_name=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/interpolate_sampling_name=] [=syntax/attrib_end=]
 
     <span class="choice">|</span> <a for=syntax_sym lt=attr>`'@'`</a> `'invariant'`
 

--- a/wgsl/syntax/builtin_value_name.syntax.bs.include
+++ b/wgsl/syntax/builtin_value_name.syntax.bs.include
@@ -1,0 +1,5 @@
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>builtin_value_name</dfn> :
+
+    <span class="choice"></span> [=syntax/ident_pattern_token=]
+</div>

--- a/wgsl/syntax/interpolate_sampling_name.syntax.bs.include
+++ b/wgsl/syntax/interpolate_sampling_name.syntax.bs.include
@@ -1,0 +1,5 @@
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>interpolate_sampling_name</dfn> :
+
+    <span class="choice"></span> [=syntax/ident_pattern_token=]
+</div>

--- a/wgsl/syntax/interpolate_type_name.syntax.bs.include
+++ b/wgsl/syntax/interpolate_type_name.syntax.bs.include
@@ -1,0 +1,5 @@
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>interpolate_type_name</dfn> :
+
+    <span class="choice"></span> [=syntax/ident_pattern_token=]
+</div>

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -27,7 +27,7 @@
 
  | `'@'` `'binding'` `'('` [=recursive descent syntax/expression=] `','` ? `')'`
 
- | `'@'` `'builtin'` `'('` [=recursive descent syntax/expression=] `','` ? `')'`
+ | `'@'` `'builtin'` `'('` [=syntax/ident_pattern_token=] `','` ? `')'`
 
  | `'@'` `'compute'`
 
@@ -41,9 +41,9 @@
 
  | `'@'` `'id'` `'('` [=recursive descent syntax/expression=] `','` ? `')'`
 
- | `'@'` `'interpolate'` `'('` [=recursive descent syntax/expression=] `','` ? `')'`
+ | `'@'` `'interpolate'` `'('` [=syntax/ident_pattern_token=] `','` ? `')'`
 
- | `'@'` `'interpolate'` `'('` [=recursive descent syntax/expression=] `','` [=recursive descent syntax/expression=] `','` ? `')'`
+ | `'@'` `'interpolate'` `'('` [=syntax/ident_pattern_token=] `','` [=syntax/ident_pattern_token=] `','` ? `')'`
 
  | `'@'` `'invariant'`
 


### PR DESCRIPTION
This PR only contains the following normative changes:

  * Make attributes-related names tokens instead of pre-declared enumerants, making them similar to Diagnostic Rule Names
  * Further specialize attribute syntax per each attribute accordingly, such as prohibiting parentheses around tokens for built-ins and taking them out of name resolution

With the merge of this PR, we should be only able to mark https://github.com/gpuweb/gpuweb/issues/4539 and https://github.com/gpuweb/gpuweb/issues/4540 issues as done: no shadowing, no aliasing. For the rest of the issues, the PR https://github.com/gpuweb/gpuweb/pull/4554 does a comprehensive yet minimal editorial update.

Thank you!