### PR TITLE
[editorial] Clarify ldexp overloads

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -14385,7 +14385,7 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
     <td>[ALLFLOATINGDECL]<br>
         `I` is [ALLSIGNEDINTEGRAL]<br>
         `I` is a vector if and only if `T` is a vector<br>
-        `I` is [=type/concrete=] if and only if `T` is a [=type/concrete=]
+        `T` can only be [=type/abstract=] if `I` is also [=type/abstract=] and vice versa
   <tr>
     <td>Description
     <td>Returns `e1 * 2`<sup>`e2`</sup>, except:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -14386,6 +14386,11 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
         `I` is [ALLSIGNEDINTEGRAL]<br>
         `I` is a vector if and only if `T` is a vector<br>
         `T` can only be [=type/abstract=] if `I` is also [=type/abstract=] and vice versa
+
+        Note: If either parameter is [=type/concrete=] then the other parameter
+        will undergo [=feasible automatic conversion|automatic conversion=] to
+        a [=type/concrete=] type (if applicable) and the result will be a
+        [=type/concrete=] type.
   <tr>
     <td>Description
     <td>Returns `e1 * 2`<sup>`e2`</sup>, except:


### PR DESCRIPTION
* Both argument must be abstract to produce an abstract result, otherwise concrete types are used
* Specifically `ldexp(1.0, 1i)` is valid