### PR TITLE
Specify that writeTexture must fail if the texture is destroyed

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12738,6 +12738,7 @@ GPUQueue includes GPUObjectBase;
                     [$generate a validation error$] and stop.
 
                     <div class=validusage>
+                        - |texture|.{{GPUTexture/[[destroyed]]}} is `false`.
                         - [$validating GPUImageCopyTexture$](|destination|, |size|) returns `true`.
                         - |texture|.{{GPUTexture/usage}} includes {{GPUTextureUsage/COPY_DST}}.
                         - |texture|.{{GPUTexture/sampleCount}} is 1.


### PR DESCRIPTION
Fixes #4565.

For most other operations this is validated in `submit()`, but since `writeTexture()` takes place outside of a command buffer it needs to do an explicit check.