### PR TITLE
[editorial] Tweak "requirements" style for clarity, in a few instances

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7659,7 +7659,7 @@ dictionary GPUComputePipelineDescriptor
                     and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
 
                 1. All of the requirements in the following steps |must| be met.
-                    If not, [$generate a validation error$], make |pipeline| [=invalid=], and stop.
+                    If any are unmet, [$generate a validation error$], make |pipeline| [=invalid=], and stop.
 
                     <div class=validusage>
                         1. |layout| |must| be [$valid to use with$] |this|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7184,7 +7184,7 @@ run the following steps:
                 1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} to |resource|'s dimension.
 
                 1. If the access mode is:
-                   
+
                     <dl class=switch>
                         : `read`
                         :: Set |textureLayout|.{{GPUStorageTextureBindingLayout/access}} to {{GPUStorageTextureAccess/"read-only"}}.
@@ -7354,22 +7354,21 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     To <dfn abstract-op>get the entry point</dfn>({{GPUShaderStage}} |stage|,
     {{GPUProgrammableStage}} |descriptor|)
 
-    -   If |descriptor|.{{GPUProgrammableStage/entryPoint}} is [=map/exists|provided=]:
+    1. If |descriptor|.{{GPUProgrammableStage/entryPoint}} is [=map/exists|provided=]:
 
-        -   If |descriptor|.{{GPUProgrammableStage/module}} contains an entry point
+        1. If |descriptor|.{{GPUProgrammableStage/module}} contains an entry point
             whose name equals |descriptor|.{{GPUProgrammableStage/entryPoint}},
             and whose shader stage equals |stage|,
             return that entry point.
 
-        -   Otherwise, return `null`.
+            Otherwise, return `null`.
 
-    -   Otherwise:
+        Otherwise:
 
-        -   If there is exactly one entry point in |descriptor|.{{GPUProgrammableStage/module}}
+        1. If there is exactly one entry point in |descriptor|.{{GPUProgrammableStage/module}}
             whose shader stage equals |stage|, return that entry point.
 
-        -   Otherwise, return `null`.
-
+            Otherwise, return `null`.
 </div>
 
 <div algorithm data-timeline=device>
@@ -7381,35 +7380,36 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     - {{GPUProgrammableStage}} |descriptor|
     - {{GPUPipelineLayout}} |layout|
 
-    Return `true` if all requirements in the following steps are satisfied, and `false` otherwise:
+    All of the requirements in the following steps |must| be met.
+    If they are met, return `true`; if not, return `false`.
 
-    - |descriptor|.{{GPUProgrammableStage/module}} must be a [=valid=] {{GPUShaderModule}}.
-    - Let |entryPoint| be [$get the entry point$](|stage|, |descriptor|).
-    - |entryPoint| must not be `null`.
-    - For each |binding| that is [=statically used=] by |entryPoint|:
-        - [$validating shader binding$](|binding|, |layout|) must return `true`.
-    - For each texture and sampler [=statically used=] together by |entryPoint| in texture sampling calls:
+    1. |descriptor|.{{GPUProgrammableStage/module}} |must| be a [=valid=] {{GPUShaderModule}}.
+    1. Let |entryPoint| be [$get the entry point$](|stage|, |descriptor|).
+    1. |entryPoint| |must| not be `null`.
+    1. For each |binding| that is [=statically used=] by |entryPoint|:
+        - [$validating shader binding$](|binding|, |layout|) |must| return `true`.
+    1. For each texture and sampler [=statically used=] together by |entryPoint| in texture sampling calls:
         1. Let |texture| be the {{GPUBindGroupLayoutEntry}} corresponding to the sampled texture in the call.
         1. Let |sampler| be the {{GPUBindGroupLayoutEntry}} corresponding to the used sampler in the call.
         1. If |sampler|.{{GPUSamplerBindingLayout/type}} is {{GPUSamplerBindingType/"filtering"}},
-            then |texture|.{{GPUTextureBindingLayout/sampleType}} must be
+            then |texture|.{{GPUTextureBindingLayout/sampleType}} |must| be
             {{GPUTextureSampleType/"float"}}.
 
         Note: {{GPUSamplerBindingType/"comparison"}} samplers can also only be used with
         {{GPUTextureSampleType/"depth"}} textures, because they are the only texture type that can
         be bound to WGSL `texture_depth_*` bindings.
-    - For each |key| &rarr; |value| in |descriptor|.{{GPUProgrammableStage/constants}}:
-        1. |key| must equal the [=pipeline-overridable constant identifier string=] of
+    1. For each |key| &rarr; |value| in |descriptor|.{{GPUProgrammableStage/constants}}:
+        1. |key| |must| equal the [=pipeline-overridable constant identifier string=] of
             some [=pipeline-overridable=] constant defined in the shader module
             |descriptor|.{{GPUProgrammableStage/module}} by the rules defined in [=WGSL identifier comparison=].
             Let the type of that constant be |T|.
-        1. Converting the IDL value |value| [$to WGSL type$] |T| must not throw a {{TypeError}}.
-    - For each [=pipeline-overridable constant identifier string=] |key| which is
+        1. Converting the IDL value |value| [$to WGSL type$] |T| |must| not throw a {{TypeError}}.
+    1. For each [=pipeline-overridable constant identifier string=] |key| which is
         [=statically used=] by |entryPoint|:
         - If the pipeline-overridable constant identified by |key|
             [=pipeline-overridable constant default value|does not have a default value=],
-            |descriptor|.{{GPUProgrammableStage/constants}} must [=map/contain=] |key|.
-    - [=pipeline-creation error|Pipeline-creation=] [=program errors=] must not
+            |descriptor|.{{GPUProgrammableStage/constants}} |must| [=map/contain=] |key|.
+    1. [=pipeline-creation error|Pipeline-creation=] [=program errors=] |must| not
         result from the rules of the [[WGSL]] specification.
 </div>
 
@@ -7658,25 +7658,27 @@ dictionary GPUComputePipelineDescriptor
                     |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
                     and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
 
-                1. If any of the requirements in the following steps are unsatisfied,
-                    [$generate a validation error$], make |pipeline| [=invalid=], and stop.
+                1. All of the requirements in the following steps |must| be met.
+                    If not, [$generate a validation error$], make |pipeline| [=invalid=], and stop.
 
                     <div class=validusage>
-                        - |layout| must be [$valid to use with$] |this|.
-                        - [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
-                            |descriptor|.{{GPUComputePipelineDescriptor/compute}}, |layout|) must succeed.
-                        - Let |entryPoint| be [$get the entry point$]({{GPUShaderStage/COMPUTE}}, |descriptor|.{{GPUComputePipelineDescriptor/compute}}). [=Assert=] |entryPoint| is not `null`.
-                        - Let |workgroupStorageUsed| be the sum of [=roundUp=](16, [$SizeOf$](|T|)) over each
+                        1. |layout| |must| be [$valid to use with$] |this|.
+                        1. [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
+                            |descriptor|.{{GPUComputePipelineDescriptor/compute}}, |layout|) |must| succeed.
+                        1. Let |entryPoint| be [$get the entry point$]({{GPUShaderStage/COMPUTE}}, |descriptor|.{{GPUComputePipelineDescriptor/compute}}).
+
+                            [=Assert=] |entryPoint| is not `null`.
+                        1. Let |workgroupStorageUsed| be the sum of [=roundUp=](16, [$SizeOf$](|T|)) over each
                             type |T| of all variables with address space "[=address spaces/workgroup=]"
                             [=statically used=] by |entryPoint|.
 
-                            |workgroupStorageUsed| must be &le;
+                            |workgroupStorageUsed| |must| be &le;
                             |device|.limits.{{supported limits/maxComputeWorkgroupStorageSize}}.
-                        - |entryPoint| must use &le;
+                        1. |entryPoint| |must| use &le;
                             |device|.limits.{{supported limits/maxComputeInvocationsPerWorkgroup}} per
                             workgroup.
-                        - Each component of |entryPoint|'s
-                            `workgroup_size` attribute must be &le; the corresponding component in
+                        1. Each component of |entryPoint|'s
+                            `workgroup_size` attribute |must| be &le; the corresponding component in
                             [|device|.limits.{{supported limits/maxComputeWorkgroupSizeX}},
                             |device|.limits.{{supported limits/maxComputeWorkgroupSizeY}},
                             |device|.limits.{{supported limits/maxComputeWorkgroupSizeZ}}].
@@ -11759,18 +11761,21 @@ It must only be included by interfaces which also include those mixins.
 
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. All of the requirements in the following steps |must| be met.
+                    If not, make |this| [=invalid=] and stop.
 
                     <div class=validusage>
-                        - It is [$valid to draw$] with |this|.
-                        - Let |buffers| be |this|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
-                        - For each {{GPUIndex32}} |slot| from `0` to |buffers|.length (non-inclusive):
-                            - If |buffers|[|slot|] is `null`, [=iteration/continue=].
-                            - Let |bufferSize| be |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|].
-                            - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
-                            - Let |lastStride| be max(|attribute|.{{GPUVertexAttribute/offset}} &plus; sizeof(|attribute|.{{GPUVertexAttribute/format}}))
-                                for each |attribute| in |buffers|[|slot|].{{GPUVertexBufferLayout/attributes}}.
-                            - Let |strideCount| be computed based on |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}}:
+                        1. It |must| be [$valid to draw$] with |this|.
+                        1. Let |buffers| be |this|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
+                        1. For each {{GPUIndex32}} |slot| from `0` to |buffers|.length (non-inclusive):
+                            1. If |buffers|[|slot|] is `null`, [=iteration/continue=].
+                            1. Let |bufferSize| be |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|].
+                            1. Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
+                            1. Let |attributes| be |buffers|[|slot|].{{GPUVertexBufferLayout/attributes}}
+                            1. Let |lastStride| be the maximum value of
+                                (|attribute|.{{GPUVertexAttribute/offset}} &plus; sizeof(|attribute|.{{GPUVertexAttribute/format}}))
+                                over each |attribute| in |attributes|, or 0 if |attributes| is [=list/empty=].
+                            1. Let |strideCount| be computed based on |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}}:
 
                                 <dl class=switch>
                                     : {{GPUVertexStepMode/"vertex"}}
@@ -11778,8 +11783,8 @@ It must only be included by interfaces which also include those mixins.
                                     : {{GPUVertexStepMode/"instance"}}
                                     :: |firstInstance| &plus; |instanceCount|
                                 </dl>
-                            - If |strideCount| &ne; `0`
-                                - Ensure (|strideCount| &minus; `1`) &times; |stride| &plus; |lastStride| &le; |bufferSize|.
+                            1. If |strideCount| &ne; `0`:
+                                1. (|strideCount| &minus; `1`) &times; |stride| &plus; |lastStride| |must| be &le; |bufferSize|.
                     </div>
                 1. Increment |this|.{{GPURenderCommandsMixin/[[drawCount]]}} by 1.
 
@@ -13170,7 +13175,7 @@ To mitigate security and privacy concerns, their precision must be reduced:
 
 <div algorithm>
     To get the <dfn abstract-op>current queue timestamp</dfn>:
-    
+
     - Let |fineTimestamp| be the current timestamp value of the current [=queue timeline=],
         in nanoseconds, relative to an implementation-defined point in the past.
     - Return the result of calling [=coarsen time=] on |fineTimestamp|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7381,7 +7381,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     - {{GPUPipelineLayout}} |layout|
 
     All of the requirements in the following steps |must| be met.
-    If they are met, return `true`; if not, return `false`.
+    If any are unmet, return `false`; otherwise, return `true`.
 
     1. |descriptor|.{{GPUProgrammableStage/module}} |must| be a [=valid=] {{GPUShaderModule}}.
     1. Let |entryPoint| be [$get the entry point$](|stage|, |descriptor|).
@@ -11762,7 +11762,7 @@ It must only be included by interfaces which also include those mixins.
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. All of the requirements in the following steps |must| be met.
-                    If not, make |this| [=invalid=] and stop.
+                    If any are unmet, make |this| [=invalid=] and stop.
 
                     <div class=validusage>
                         1. It |must| be [$valid to draw$] with |this|.


### PR DESCRIPTION
We used to try to always write validation requirements as unordered lists, but very many of them ended up needing ordered steps in them.

This tweaked style uses ordered steps while also using the clickable variable `|must|` to highlight the actual validation requirements. If we like it we should probably adopt it for all validation lists - at least, we need to do it for the ones that have ordered steps in them.

Also fixes some minor style things nearby.