### PR TITLE
wgsl: Reduce shader limits

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -880,18 +880,26 @@ shader that goes beyond the specified limits.
   <thead>
     <tr><th>Limit<th>Minimum supported value
   </thead>
-    <tr><td>Maximum number of members in a [=structure=] type<td>16383
-    <tr><td>Maximum [=nesting depth=] of a [=composite=] type<td>255
+    <tr><td>Maximum number of members in a [=structure=] type<td>1024
+    <tr><td>Maximum [=nesting depth=] of a [=composite=] type<td>16
     <tr><td>Maximum nesting depth of brace-enclosed statements in a function<td>127
     <tr><td>Maximum number of [=formal parameter|parameters=] for a function<td>255
-    <tr><td>Maximum number of case selector values in a [=statement/switch=] statement<td>16383
-    <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
-            [=address spaces/function=] or [=address spaces/private=] address spaces
+    <tr><td>Maximum number of case selector values in a [=statement/switch=] statement<td>1024
+    <tr><td>Maximum combined [=byte-size=] of all [=variables=] instantiated in the
+            [=address spaces/private=] address space that are [=statically accessed=] by a single
+            [=shader=]
 
             For the purposes of this limit, [=bool=] has a size of 4 bytes.
-        <td>65535
-    <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
-            [=address spaces/workgroup=] address space.
+        <td>8192
+    <tr><td>Maximum combined [=byte-size=] of all [=variables=] instantiated in the
+            [=address spaces/function=] address space that are declared in a single
+            [=function/function=]
+
+            For the purposes of this limit, [=bool=] has a size of 4 bytes.
+        <td>8192
+    <tr><td>Maximum combined [=byte-size=] of all [=variables=] instantiated in the
+            [=address spaces/workgroup=] address space that are [=statically accessed=] by a single
+            [=shader=]
 
             For the purposes of this limit, [=bool=] has a size of 4 bytes and a
             [=fixed footprint|fixed-footprint=] array is treated as a [=creation-fixed
@@ -899,11 +907,8 @@ shader that goes beyond the specified limits.
 
             This maps the WebGPU [=supported limits/maxComputeWorkgroupStorageSize=] limit
             into a standalone WGSL limit.
-
-            Note: Several workgroup variables that individually
-            satisfy this limit can still combine to exceed the API limit.
         <td>[=supported limits/maxComputeWorkgroupStorageSize|16384=]
-    <tr><td>Maximum number of elements in [=const-expression=] of [=array=] type<td>65535
+    <tr><td>Maximum number of elements in [=const-expression=] of [=array=] type<td>2048
 </table>
 
 # Textual Structure # {#textual-structure}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -880,11 +880,11 @@ shader that goes beyond the specified limits.
   <thead>
     <tr><th>Limit<th>Minimum supported value
   </thead>
-    <tr><td>Maximum number of members in a [=structure=] type<td>1024
-    <tr><td>Maximum [=nesting depth=] of a [=composite=] type<td>16
+    <tr><td>Maximum number of members in a [=structure=] type<td>1023
+    <tr><td>Maximum [=nesting depth=] of a [=composite=] type<td>15
     <tr><td>Maximum nesting depth of brace-enclosed statements in a function<td>127
     <tr><td>Maximum number of [=formal parameter|parameters=] for a function<td>255
-    <tr><td>Maximum number of case selector values in a [=statement/switch=] statement<td>1024
+    <tr><td>Maximum number of case selector values in a [=statement/switch=] statement<td>1023
     <tr><td>Maximum combined [=byte-size=] of all [=variables=] instantiated in the
             [=address spaces/private=] address space that are [=statically accessed=] by a single
             [=shader=]
@@ -908,7 +908,7 @@ shader that goes beyond the specified limits.
             This maps the WebGPU [=supported limits/maxComputeWorkgroupStorageSize=] limit
             into a standalone WGSL limit.
         <td>[=supported limits/maxComputeWorkgroupStorageSize|16384=]
-    <tr><td>Maximum number of elements in [=const-expression=] of [=array=] type<td>2048
+    <tr><td>Maximum number of elements in [=const-expression=] of [=array=] type<td>2047
 </table>
 
 # Textual Structure # {#textual-structure}


### PR DESCRIPTION
Aside from reducing the numbers as outlined in the linked issues, I split the `function` and `private` into two separate lines to describe how their combined byte-size is considered, and changed them from considering `array types` to `variables`. For consistency I also modified the `workgroup` limit to use the combined byte-size and removed the now obsolete note.

Fixes #4545
Fixes #4546
Fixes #4547
Fixes #4548