### PR TITLE
Remove resolved TODOs

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2044,14 +2044,12 @@ interface GPUAdapterInfo {
     A <dfn>normalized identifier string</dfn> is one that follows the following pattern:
 
     `[a-z0-9]+(-[a-z0-9]+)*`
-    <!-- TODO(tabatkins/bikeshed#2319): Railroad diagrams are broken right now.
     <pre class=railroad>
         OneOrMore:
             OneOrMore:
                 T: a-z 0-9
             T: -
     </pre>
-    -->
 
     <div class=example>
         Examples of valid normalized identifier strings include:
@@ -6934,8 +6932,6 @@ There are two ways to create pipelines:
     When this fails, the `Promise` rejects with a {{GPUPipelineError}}.
 
 <dfn interface>GPUPipelineError</dfn> describes a pipeline creation failure.
-
-<!--TODO(gpuweb/gpuweb#3709): Change `message` to optional, defaulting to `""`. -->
 
 <script type=idl>
 [Exposed=(Window, Worker), SecureContext, Serializable]


### PR DESCRIPTION
There were a couple of TODOs in the spec that referred to things that have already been resolved, so removing them. Also uncomments the normalized identifier string railroad diagram, since it appears that Bikeshed has fixed the issue with rendering it.