### PR TITLE
Specify that textures used with alphaToCoverage must be blendable

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8034,7 +8034,7 @@ dictionary GPURenderPipelineDescriptor
         1. |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}[0]
             must [=list/exist=] and be non-null.
         1. |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}[0].{{GPUColorTargetState/format}}
-            must be a {{GPUTextureFormat}} with an alpha channel.
+            must be a {{GPUTextureFormat}} which is [=blendable=] and has an alpha channel.
     - There must exist at least one attachment, either:
         - A non-`null` value in
             |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}, or


### PR DESCRIPTION
Fixes #4506

Group resolution was to add this restriction. Unsure if anything needs to be said to account for potential int format difficulties that @kainino0x mentioned in https://github.com/gpuweb/gpuweb/issues/4506#issuecomment-1977897452