### PR TITLE
Fix invalid copyExternalImageToTexture origin references

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12853,11 +12853,11 @@ GPUQueue includes GPUObjectBase;
                 1. If any of the following requirements are unmet, throw an {{OperationError}} and stop.
 
                     <div class=validusage>
-                        - |source|.|origin|.[=GPUOrigin3D/x=] + |copySize|.[=GPUExtent3D/width=]
+                        - |source|.|origin|.[=GPUOrigin2D/x=] + |copySize|.[=GPUExtent3D/width=]
                             must be &le; the width of |sourceImage|.
-                        - |source|.|origin|.[=GPUOrigin3D/y=] + |copySize|.[=GPUExtent3D/height=]
+                        - |source|.|origin|.[=GPUOrigin2D/y=] + |copySize|.[=GPUExtent3D/height=]
                             must be &le; the height of |sourceImage|.
-                        - |source|.|origin|.[=GPUOrigin3D/z=] + |copySize|.[=GPUExtent3D/depthOrArrayLayers=]
+                        - |copySize|.[=GPUExtent3D/depthOrArrayLayers=]
                             must be &le; 1.
                     </div>
                 1. Let |usability| be [=?=] [=check the usability of the image argument=](|source|).


### PR DESCRIPTION
Fixes #4456

Previously was both referencing a non-existent `z` attribute and linking to `GPUOrigin3D` instead of `GPUOrigin2D`.