### PR TITLE
Clarify valid uses for each texture dimension

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4154,6 +4154,8 @@ enum GPUTextureDimension {
     ::
         Specifies a texture that has a width, height, and depth. {{GPUTextureDimension/"3d"}}
         textures cannot be multisampled or use compressed or depth/stencil formats.
+        
+        <!-- TODO(#3183): Update this when we add 3D compressed textures -->
 </dl>
 
 ### Texture Usages ### {#texture-usage}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4142,17 +4142,18 @@ enum GPUTextureDimension {
 <dl dfn-type=enum-value dfn-for=GPUTextureDimension>
     : <dfn>"1d"</dfn>
     ::
-        Specifies a texture that has one dimension, width.
+        Specifies a texture that has one dimension, width. {{GPUTextureDimension/"1d"}} textures
+        cannot have mipmaps, be multisampled, use compressed or depth/stencil formats, or be used as
+        a render target.
 
     : <dfn>"2d"</dfn>
     ::
-        Specifies a texture that has a width and height, and may have layers. Only
-        {{GPUTextureDimension/"2d"}} textures may have mipmaps, be multisampled, use a compressed or
-        depth/stencil format, and be used as a render attachment.
+        Specifies a texture that has a width and height, and may have layers.
 
     : <dfn>"3d"</dfn>
     ::
-        Specifies a texture that has a width, height, and depth.
+        Specifies a texture that has a width, height, and depth. {{GPUTextureDimension/"3d"}}
+        textures cannot be multisampled or use compressed or depth/stencil formats.
 </dl>
 
 ### Texture Usages ### {#texture-usage}


### PR DESCRIPTION
Fixes #4491

Previously indicated that 3D textures couldn't have mipmaps or be used as render targets, but the validation rules stated otherwise. Updated to change from stating what 2D textures _can_ do to indicating separately what each dimension _cannot_ do.