### PR TITLE
Only use depthWriteEnabled if provided

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7927,7 +7927,8 @@ dictionary GPURenderPipelineDescriptor
                 1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to false.
                 1. Let |depthStencil| be |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.
                 1. If |depthStencil| is not null:
-                    1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to |depthStencil|.{{GPUDepthStencilState/depthWriteEnabled}}.
+                    1. If |depthStencil|.{{GPUDepthStencilState/depthWriteEnabled}} is [=map/exist|provided=]: 
+                        1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to |depthStencil|.{{GPUDepthStencilState/depthWriteEnabled}}.
                     1. If |depthStencil|.{{GPUDepthStencilState/stencilWriteMask}} is not 0:
                         1. Let |stencilFront| be |depthStencil|.{{GPUDepthStencilState/stencilFront}}.
                         1. Let |stencilBack| be |depthStencil|.{{GPUDepthStencilState/stencilBack}}.


### PR DESCRIPTION
Fixes #4416

Specifies that the `depthWriteEnabled` value from a `GPUDepthStencilState` should only be copied to the internal pipeline state during creation if it was actually provided.