### PR TITLE
Attachment resolveTargets must also be pairwise disjoint

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9669,11 +9669,12 @@ dictionary GPUCommandEncoderDescriptor
                     <div class=validusage>
                         - |descriptor| must meet the [$GPURenderPassDescriptor/Valid Usage$] rules
                             given device |this|.{{GPUObjectBase/[[device]]}}.
-                        - The set of attachments in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}
+                        - The set of texture regions in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}
                             must be pairwise disjoint.
-                            That is, no two attachments may refer to the same region, as defined by
-                            the {{GPURenderPassColorAttachment/view}} or {{GPURenderPassColorAttachment/resolveTarget}}
-                            [=texture subresource=] range and (for {{GPUTextureViewDimension/"3d"}} attachments)
+                            That is, no two texture regions may overlap, where
+                            each attachment has 1-2 regions defined by
+                            the {{GPURenderPassColorAttachment/view}}'s and {{GPURenderPassColorAttachment/resolveTarget}}'s
+                            [=texture subresource=] ranges, and (for {{GPUTextureViewDimension/"3d"}} attachments)
                             the attachment's {{GPURenderPassColorAttachment/depthSlice}}.
                     </div>
                 1. Consider each [=texture subresource=] viewed by a non-`null` element of

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9672,8 +9672,8 @@ dictionary GPUCommandEncoderDescriptor
                         - The set of attachments in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}
                             must be pairwise disjoint.
                             That is, no two attachments may refer to the same region, as defined by
-                            the {{GPURenderPassColorAttachment/view}}'s [=texture subresource=]
-                            range and (for {{GPUTextureViewDimension/"3d"}} attachments)
+                            the {{GPURenderPassColorAttachment/view}} or {{GPURenderPassColorAttachment/resolveTarget}}
+                            [=texture subresource=] range and (for {{GPUTextureViewDimension/"3d"}} attachments)
                             the attachment's {{GPURenderPassColorAttachment/depthSlice}}.
                     </div>
                 1. Consider each [=texture subresource=] viewed by a non-`null` element of

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9667,11 +9667,11 @@ dictionary GPUCommandEncoderDescriptor
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
                 1. Let |attachmentSubresources| be an empty [=list=].
                 1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-                    1. Add the [=texture subresource=] range described by
+                    1. Add the region of the [=texture subresource=] described by
                         |colorAttachment|.{GPURenderPassColorAttachment/view}} and, for {{GPUTextureViewDimension/"3d"}}
                         attachments, |colorAttachment|.{{GPURenderPassColorAttachment/depthSlice}} to |attachmentSubresources|.
                     1. If |colorAttachment|.{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
-                        1. Add the [=texture subresource=] range described by
+                        1. Add the region of the [=texture subresource=] described by
                             |colorAttachment|.{GPURenderPassColorAttachment/resolveTarget}} to |attachmentSubresources|.
                 1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
                     <div class=validusage>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9665,20 +9665,22 @@ dictionary GPUCommandEncoderDescriptor
                 1. [$Validate the encoder state$] of |this|.
                     If it returns false, make |pass| [=invalid=] and return.
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
+                1. Let |attachmentSubresources| be an empty [=list=].
+                1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
+                    1. Add the [=texture subresource=] range described by
+                        |colorAttachment|.{GPURenderPassColorAttachment/view}} and, for {{GPUTextureViewDimension/"3d"}}
+                        attachments, |colorAttachment|.{{GPURenderPassColorAttachment/depthSlice}} to |attachmentSubresources|.
+                    1. If |colorAttachment|.{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
+                        1. Add the [=texture subresource=] range described by
+                            |colorAttachment|.{GPURenderPassColorAttachment/resolveTarget}} to |attachmentSubresources|.
                 1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
                     <div class=validusage>
                         - |descriptor| must meet the [$GPURenderPassDescriptor/Valid Usage$] rules
                             given device |this|.{{GPUObjectBase/[[device]]}}.
-                        - The set of texture regions in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}
-                            must be pairwise disjoint.
-                            That is, no two texture regions may overlap, where
-                            each attachment has 1-2 regions defined by
-                            the {{GPURenderPassColorAttachment/view}}'s and {{GPURenderPassColorAttachment/resolveTarget}}'s
-                            [=texture subresource=] ranges, and (for {{GPUTextureViewDimension/"3d"}} attachments)
-                            the attachment's {{GPURenderPassColorAttachment/depthSlice}}.
+                        - The set of texture regions in |attachmentSubresources| must be pairwise disjoint.
+                            That is, no two texture regions may overlap.
                     </div>
-                1. Consider each [=texture subresource=] viewed by a non-`null` element of
-                    |descriptor|.{{GPURenderPassDescriptor/colorAttachments}} to be used as
+                1. Consider each [=texture subresource=] in |attachmentSubresources| to be used as
                     an [=internal usage/attachment=] for the duration of the render pass.
 
                     If a subresource is seen more than once, consider it used only once.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9665,22 +9665,23 @@ dictionary GPUCommandEncoderDescriptor
                 1. [$Validate the encoder state$] of |this|.
                     If it returns false, make |pass| [=invalid=] and return.
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
-                1. Let |attachmentSubresources| be an empty [=list=].
+                1. Let |attachmentRegions| be a [=list=] of [[=texture subresource=], {{GPURenderPassColorAttachment/depthSlice}}?]
+                    pairs, initially empty. Each pair describes the region of the texture to be rendered to, which
+                    includes a single depth slice for {{GPUTextureViewDimension/"3d"}} textures only.
                 1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-                    1. Add the region of the [=texture subresource=] described by
-                        |colorAttachment|.{GPURenderPassColorAttachment/view}} and, for {{GPUTextureViewDimension/"3d"}}
-                        attachments, |colorAttachment|.{{GPURenderPassColorAttachment/depthSlice}} to |attachmentSubresources|.
+                    1. Add [|colorAttachment|.{{GPURenderPassColorAttachment/view}},
+                        |colorAttachment|.{{GPURenderPassColorAttachment/depthSlice}}] to |attachmentRegions|.
                     1. If |colorAttachment|.{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
-                        1. Add the region of the [=texture subresource=] described by
-                            |colorAttachment|.{GPURenderPassColorAttachment/resolveTarget}} to |attachmentSubresources|.
+                        1. Add [|colorAttachment|.{{GPURenderPassColorAttachment/resolveTarget}},
+                            `undefined`] to |attachmentRegions|.
                 1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
                     <div class=validusage>
                         - |descriptor| must meet the [$GPURenderPassDescriptor/Valid Usage$] rules
                             given device |this|.{{GPUObjectBase/[[device]]}}.
-                        - The set of texture regions in |attachmentSubresources| must be pairwise disjoint.
+                        - The set of texture regions in |attachmentRegions| must be pairwise disjoint.
                             That is, no two texture regions may overlap.
                     </div>
-                1. Consider each [=texture subresource=] in |attachmentSubresources| to be used as
+                1. Consider each [=texture subresource=] in |attachmentRegions| to be used as
                     an [=internal usage/attachment=] for the duration of the render pass.
 
                     If a subresource is seen more than once, consider it used only once.


### PR DESCRIPTION
Fixes #4390

Indicates that `resolveTarget` should also be considered when evaluating whether render pass attachments are pairwise disjoint.

If this is seen as too confusing, we could alternately copy the paragraph and have a separate entry that only discusses `resolveTarget`. This is fine since they can't overlap with the views on account of having different sample counts out of necessity. I personally don't think it would provide much additional clarity, though.