### PR TITLE
Require that every submitted command buffer must be unique

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12918,6 +12918,7 @@ GPUQueue includes GPUObjectBase;
 
                     <div class=validusage>
                         - Every {{GPUCommandBuffer}} in |commandBuffers| must be [$valid to use with$] |this|.
+                        - Every {{GPUCommandBuffer}} in |commandBuffers| must be unique.
                         - For each of the following types of resources used by any command in any
                             element of |commandBuffers|:
 


### PR DESCRIPTION
Fixes #4367

Requires that every command buffer in a single submit be unique.

There's a couple of other ways that this could be handled, but this feels the most elegant. It's worth noting that this scenario doesn't appear to be tested in the CTS and I suspect that implementations may not be handling it correctly either.