### PR TITLE
Move write portion of writeBuffer onto queue timeline

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12715,6 +12715,11 @@ GPUQueue includes GPUObjectBase;
                         - |bufferOffset|, converted to bytes, is a multiple of 4 bytes.
                         - |bufferOffset| + |contentsSize|, converted to bytes, &le; |buffer|.{{GPUBuffer/size}} bytes.
                     </div>
+                1. Issue the subsequent steps on the [=Queue timeline=] of |this|.
+            </div>
+            <div data-timeline=queue>
+                [=Queue timeline=] steps:
+
                 1. Write |contents| into |buffer| starting at |bufferOffset|.
             </div>
         </div>


### PR DESCRIPTION
Fixes #4252

No functional changes, this was always how it was meant to be and how implementations currently work.