### PR TITLE
Validate that copyExternalImageToTexture dest is not destroyed

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12862,7 +12862,8 @@ GPUQueue includes GPUObjectBase;
 
                     <div class=validusage>
                         - |usability| must be `good`.
-                        - |destination|.{{GPUImageCopyTexture/texture}} must be [$valid to use with$] |this|.
+                        - |texture|.{{GPUTexture/[[destroyed]]}} must be `false`.
+                        - |texture| must be [$valid to use with$] |this|.
                         - [$validating GPUImageCopyTexture$](destination, copySize) must return `true`.
                         - [=validating texture copy range=](destination, copySize) must return `true`.
                         - |texture|.{{GPUTexture/usage}} must include both


### PR DESCRIPTION
Fixes #4253 (`writeTexture` portion was resolved in #4567)

This was likely overlooked since every other `copy*Texture*` function is validated during submit.