### PR TITLE
Invalidate all command buffers passed to submit, whether the submit is valid or not.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12961,7 +12961,8 @@ GPUQueue includes GPUObjectBase;
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
+                1. If any of the following requirements are unmet, [$generate a validation error$], make each
+                    {{GPUCommandBuffer}} in |commandBuffers| [=invalid=], and stop.
 
                     <div class=validusage>
                         - Every {{GPUCommandBuffer}} in |commandBuffers| must be [$valid to use with$] |this|.


### PR DESCRIPTION
Fixes #4599, assuming that we agree that this should be the behavior.