### PR TITLE
[editorial] Reorder attribute tables to put descriptions first

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8351,14 +8351,10 @@ path: syntax/align_attr.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`align`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
-        [=shader-creation error|Must=] be positive.
-  <tr>
-    <td>Description
-    <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
+    <td style="width:10%">Description
+    <td>Constrains the placement of a structure member in memory.
 
-    [=shader-creation error|Must=] be a power of 2.
+    [=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
     Note: This attribute influences how a value of the enclosing structure type can appear in memory:
     at which byte addresses the structure itself and its component members can appear.
@@ -8373,6 +8369,12 @@ path: syntax/align_attr.syntax.bs.include
     for some positive integer |k|.
     </p>
 
+  <tr>
+    <td>Parameters
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
+        [=shader-creation error|Must=] be positive.<br>
+        [=shader-creation error|Must=] be a power of 2.
+
 </table>
 
 ## `binding` ## {#binding-attr}
@@ -8384,15 +8386,16 @@ path: syntax/binding_attr.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`binding`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
-        [=shader-creation error|Must=] be non-negative.
-  <tr>
-    <td>Description
-    <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
-
+    <td style="width:10%">Description
+    <td>
     Specifies the binding number of the resource in a bind [=attribute/group=].
     See [[#resource-interface]].
+
+    [=shader-creation error|Must=] only be applied to a [=resource=] variable.
+  <tr>
+    <td>Parameters
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
+        [=shader-creation error|Must=] be non-negative.
 
 </table>
 
@@ -8405,15 +8408,15 @@ path: syntax/builtin_attr.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`builtin`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>[=shader-creation error|Must=] be a [=built-in value name-token=] for a [=built-in value=].
-  <tr>
-    <td>Description
-    <td>[=shader-creation error|Must=] only be applied to an entry point
-    function parameter, entry point return type, or member of a [=structure=].
-
-    Specifies that the associated object is a built-in value, as denoted by the specified [=token=].
+    <td style="width:10%">Description
+    <td>Specifies that the associated object is a built-in value, as denoted by the specified [=token=].
     See [[#builtin-inputs-outputs]].
+
+    [=shader-creation error|Must=] only be applied to an entry point
+    function parameter, entry point return type, or member of a [=structure=].
+  <tr>
+    <td>Parameters
+    <td>[=shader-creation error|Must=] be a [=built-in value name-token=] for a [=built-in value=].
 
 </table>
 
@@ -8426,18 +8429,19 @@ path: syntax/const_attr.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`const`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>*None*
-  <tr>
-    <td>Description
-    <td>[=shader-creation error|Must=] only be applied to function declarations.
-
+    <td style="width:10%">Description
+    <td>
     Specifies that the function can be used as a [=const-function=].
     This attribute [=shader-creation error|must not=] be applied to a
     user-defined function.
 
+    [=shader-creation error|Must=] only be applied to function declarations.
+
     Note: This attribute is used as a notational convention to describe which
     built-in functions can be used in [=const-expressions=].
+  <tr>
+    <td>Parameters
+    <td>*None*
 
 </table>
 
@@ -8453,20 +8457,18 @@ path: syntax/diagnostic_control.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`diagnostic`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>Two parameters.
-
-        The first parameter is a [=syntax/severity_control_name=].
-
-        The second parameter is a [=syntax/diagnostic_rule_name=] token
-        specifying a [=diagnostic/triggering rule=].
-  <tr>
-    <td>Description
+    <td style="width:10%">Description
     <td>Specifies a [=range diagnostic filter=].  See [[#diagnostics]].
 
         More than one [=attribute/diagnostic=] attribute may be specified on a syntactic form,
         but they [=shader-creation error|must=] specify different [=diagnostic/triggering rules=].
 
+  <tr>
+    <td>Parameters
+    <td>The first parameter is a [=syntax/severity_control_name=].
+
+        The second parameter is a [=syntax/diagnostic_rule_name=] token
+        specifying a [=diagnostic/triggering rule=].
 </table>
 
 ## `group` ## {#group-attr}
@@ -8478,15 +8480,16 @@ path: syntax/group_attr.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`group`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
-        [=shader-creation error|Must=] be non-negative.
-  <tr>
-    <td>Description
-    <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
-
+    <td style="width:10%">Description
+    <td>
     Specifies the binding group of the resource.
     See [[#resource-interface]].
+
+    [=shader-creation error|Must=] only be applied to a [=resource=] variable.
+  <tr>
+    <td>Parameters
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
+        [=shader-creation error|Must=] be non-negative.
 
 </table>
 
@@ -8499,15 +8502,16 @@ path: syntax/id_attr.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`id`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
-        [=shader-creation error|Must=] be non-negative.
-  <tr>
-    <td>Description
-    <td>[=shader-creation error|Must=] only be applied to an [=override-declaration=] of [=scalar=] type.
-
+    <td style="width:10%">Description
+    <td>
     Specifies a numeric identifier as an alternate name for a
     [=pipeline-overridable=] constant.
+
+    [=shader-creation error|Must=] only be applied to an [=override-declaration=] of [=scalar=] type.
+  <tr>
+    <td>Parameters
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
+        [=shader-creation error|Must=] be non-negative.
 
 </table>
 
@@ -8524,23 +8528,22 @@ path: syntax/interpolate_type_name.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`interpolate`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>One or two parameters.
+    <td style="width:10%">Description
 
-    The first parameter [=shader-creation error|must=] be an
+    <td>Specifies how the user-defined IO [=shader-creation error|must=] be interpolated.
+    The attribute is only significant on user-defined [=vertex=] outputs
+    and [=fragment=] inputs.
+    See [[#interpolation]].
+
+    [=shader-creation error|Must=] only be applied to a declaration that
+    has a [=attribute/location=] attribute applied.
+  <tr>
+    <td>Parameters
+    <td>The first parameter [=shader-creation error|must=] be an
     [=interpolation type name-token=] for an [=interpolation type=].
 
     The second parameter, if present, [=shader-creation error|must=] be
     an [=interpolation sampling name-token=] for the [=interpolation sampling=].
-  <tr>
-    <td>Description
-    <td>[=shader-creation error|Must=] only be applied to a declaration that
-    has a [=attribute/location=] attribute applied.
-
-    Specifies how the user-defined IO [=shader-creation error|must=] be interpolated.
-    The attribute is only significant on user-defined [=vertex=] outputs
-    and [=fragment=] inputs.
-    See [[#interpolation]].
 
 </table>
 
@@ -8553,22 +8556,23 @@ path: syntax/invariant_attr.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`invariant`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>*None*
-  <tr>
-    <td>Description
-    <td>[=shader-creation error|Must=] only be applied to the [=built-in values/position=] built-in value.
-
+    <td style="width:10%">Description
+    <td>
     When applied to the [=built-in values/position=] [=built-in output value=] of a vertex
     shader, the computation of the result is invariant across different
     programs and different invocations of the same entry point.
     That is, if the data and control flow match for two `position` outputs in
     different entry points, then the result values are guaranteed to be the
     same.
-    There is no affect on a `position` [=built-in input value=].
+    There is no effect on a `position` [=built-in input value=].
+
+    [=shader-creation error|Must=] only be applied to the [=built-in values/position=] built-in value.
 
     Note: This attribute maps to the `precise` qualifier in HLSL, and the
     `invariant` qualifier in GLSL.
+  <tr>
+    <td>Parameters
+    <td>*None*
 
 </table>
 
@@ -8581,19 +8585,21 @@ path: syntax/location_attr.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`location`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
-        [=shader-creation error|Must=] be non-negative.
-  <tr>
-    <td>Description
-    <td>[=shader-creation error|Must=] only be applied to an entry point function parameter, entry point
+    <td style="width:10%">Description
+    <td>
+    Specifies a part of the user-defined IO of an entry point.
+    See [[#input-output-locations]].
+ 
+    [=shader-creation error|Must=] only be applied to an entry point function parameter, entry point
     return type, or member of a [=structure=] type.
     [=shader-creation error|Must=] only be applied to declarations of objects with [=numeric scalar=]
     or [=numeric vector=] type.
     [=shader-creation error|Must not=] be used with the [=compute=] shader stage.
 
-    Specifies a part of the user-defined IO of an entry point.
-    See [[#input-output-locations]].
+  <tr>
+    <td>Parameters
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
+        [=shader-creation error|Must=] be non-negative.
 
 </table>
 
@@ -8606,14 +8612,12 @@ path: syntax/must_use_attr.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`must_use`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>*None*
-  <tr>
-    <td>Description
-    <td>[=shader-creation error|Must=] only be applied to the declaration of a [=function/function=] with a [=return type=].
-
+    <td style="width:10%">Description
+    <td>
         Specifies that a [=function call|call=] to this function [=shader-creation error|must=] be used as an [=expression=].
         That is, a call to this function [=shader-creation error|must=] not be the entirety of a [[#function-call-statement|function call statement]].
+
+        [=shader-creation error|Must=] only be applied to the declaration of a [=function/function=] with a [=return type=].
 
         Note: Many functions return a value and do not have side effects.
         It is often a programming defect to call such a function as the only thing in a function call statement.
@@ -8622,6 +8626,10 @@ path: syntax/must_use_attr.syntax.bs.include
 
         Note: To deliberately work around the `@must_use` rule, use a [=phony assignment=]
         or [=value declaration|declare a value=] using the function call as the initializer.
+
+  <tr>
+    <td>Parameters
+    <td>*None*
 
 </table>
 
@@ -8634,22 +8642,22 @@ path: syntax/size_attr.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`size`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
-        [=shader-creation error|Must=] be positive.
-  <tr>
-    <td>Description
-    <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
-    The member type [=shader-creation error|must=] have [=creation-fixed footprint=].
-
-    The number of bytes reserved in the struct for this member.
+    <td style="width:10%">Description
+    <td>Specifies the number of bytes reserved for a structure member.
 
     This number [=shader-creation error|must=] be at least the [=byte-size=] of the type of the member:
     <p algorithm="byte-size constraint">
     If `size(`|n|`)` is applied to a member with type |T|, then [=SizeOf=](|T|)&nbsp;&leq;&nbsp;|n|.
     </p>
 
-    See [[#memory-layouts]]
+    See [[#memory-layouts]].
+
+    [=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
+    The member type [=shader-creation error|must=] have [=creation-fixed footprint=].
+  <tr>
+    <td>Parameters
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
+        [=shader-creation error|Must=] be positive.
 
 </table>
 
@@ -8662,8 +8670,19 @@ path: syntax/workgroup_size_attr.syntax.bs.include
 <table class='data builtin'>
   <caption><dfn noexport dfn-for="attribute">`workgroup_size`</dfn> Attribute</caption>
   <tr>
-    <td style="width:10%">Valid Values
-    <td>One, two or three parameters.
+    <td style="width:10%">Description
+    <td>Specifies the x, y, and z dimensions of the [=workgroup grid=] for the compute shader.
+
+    The first parameter specifies the x dimension.
+    The second parameter, if provided, specifies the y dimension, otherwise is assumed to be 1.
+    The third parameter, if provided, specifies the z dimension, otherwise is assumed to be 1.
+
+    [=shader-creation error|Must=] only be applied to a [=compute shader stage|compute shader=] entry point function.
+    [=shader-creation error|Must not=] be applied to any other object.
+
+  <tr>
+    <td>Parameters
+    <td>Takes one, two, or three parameters.
 
         Each parameter [=shader-creation error|must=] be a [=const-expression=] or an [=override-expression=].
         All parameters [=shader-creation error|must=] be the same type, either [=i32=] or [=u32=].
@@ -8675,16 +8694,6 @@ path: syntax/workgroup_size_attr.syntax.bs.include
         to a non-positive value or exceeds an upper bound specified by the WebGPU
         API, or if the product of the parameter values exceeds the upper bound
         specified by the WebGPU API (see [[WebGPU#limits]]).
-  <tr>
-    <td>Description
-    <td>[=shader-creation error|Must=] only be applied to a [=compute shader stage|compute shader=] entry point function.
-    [=shader-creation error|Must not=] be applied to any other object.
-
-    Specifies the x, y, and z dimensions of the [=workgroup grid=] for the compute shader.
-
-    The first parameter specifies the x dimension.
-    The second parameter, if provided, specifies the y dimension, otherwise is assumed to be 1.
-    The third parameter, if provided, specifies the z dimension, otherwise is assumed to be 1.
 
 </table>
 
@@ -8702,7 +8711,7 @@ They take no parameters.
 path: syntax/vertex_attr.syntax.bs.include
 </pre>
 
-<dfn noexport dfn-for="attribute">`vertex`</dfn> attribute declares the function to be an
+The <dfn noexport dfn-for="attribute">`vertex`</dfn> attribute declares the function to be an
 [=entry point=] for the [=vertex shader stage=] of a [=GPURenderPipeline|render pipeline=].
 
 ### `fragment` ### {#fragment-attr}
@@ -8711,7 +8720,7 @@ path: syntax/vertex_attr.syntax.bs.include
 path: syntax/fragment_attr.syntax.bs.include
 </pre>
 
-<dfn noexport dfn-for="attribute">`fragment`</dfn> attribute declares the function to be an
+The <dfn noexport dfn-for="attribute">`fragment`</dfn> attribute declares the function to be an
 [=entry point=] for the [=fragment shader stage=] of a [=GPURenderPipeline|render pipeline=].
 
 ### `compute` ### {#compute-attr}
@@ -8720,7 +8729,7 @@ path: syntax/fragment_attr.syntax.bs.include
 path: syntax/compute_attr.syntax.bs.include
 </pre>
 
-<dfn noexport dfn-for="attribute">`compute`</dfn> attribute declares the function to be an
+The <dfn noexport dfn-for="attribute">`compute`</dfn> attribute declares the function to be an
 [=entry point=] for the [=compute shader stage=] of a [=GPUComputePipeline|compute pipeline=].
 
 # Entry Points # {#entry-points}


### PR DESCRIPTION

    
    The section for an attribute has the following structure:
    
       <grammar>
    
       <valid values><rules for the parameters>
       <description> <must-rules>
                     <describe what it is>
    
    That puts the high level information last.
    
    Reorder the sections so they have this structure:
    
       <grammar>
    
       <description> <describe what it is>
                     <must-rules>
       <parameters><rules for the parameters>
    
    I think this reads better
    
    Also, some minor fixups:
    - Add a high level description sentence for @align and @size.
    - Move the @align power-of-2 rule from description to parameters
    - "affect" -> "effect".
    - Insert "The" at the start of the sentence about each stage attribute

