### PR TITLE
Use 'create a new WebGPU Object' for all objects

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -885,12 +885,23 @@ interface mixin GPUObjectBase {
 
         1. Let |device| be |parent|.{{GPUObjectBase/[[device]]}}.
         1. Let |object| be a new instance of |T|.
-        1. Let |internals| be a new (uninitialized) instance of the type of
-            |T|.`\[[internals]]` (which may override {{GPUObjectBase}}.{{GPUObjectBase/[[internals]]}})
-            that is accessible only from the [=device timeline=] of |device|.
         1. Set |object|.{{GPUObjectBase/[[device]]}} to |device|.
-        1. Set |object|.{{GPUObjectBase/[[internals]]}} to |internals|.
         1. Set |object|.{{GPUObjectBase/label}} to |descriptor|.{{GPUObjectDescriptorBase/label}}.
+        1. Return |object|.
+    </div>
+</div>
+
+<div algorithm>
+    <div data-timeline=content>
+        To <dfn abstract-op>create a new WebGPU object with internals</dfn>({{GPUObjectBase}} |parent|,
+        interface |T|, {{GPUObjectDescriptorBase}} |descriptor|)
+        (where |T| extends {{GPUObjectBase}}):
+
+        1. Let |object| be [=!=] [$create a new WebGPU object$](|parent|, |T|, |descriptor|)
+        1. Let |internals| be a new (uninitialized) instance of the type of
+            |T|.`[[internals]]` (which may override {{GPUObjectBase}}.{{GPUObjectBase/[[internals]]}})
+            that is accessible only from the [=device timeline=] of |parent|.{{GPUObjectBase/[[device]]}}.
+        1. Set |object|.{{GPUObjectBase/[[internals]]}} to |internals|.
         1. Return [|object|, |internals|].
     </div>
 </div>
@@ -3420,7 +3431,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
 
                 [=Content timeline=] steps:
 
-                1. Let [|b|, |bi|] be [=!=] [$create a new WebGPU object$](|this|, {{GPUBuffer}}, |descriptor|).
+                1. Let [|b|, |bi|] be [=!=] [$create a new WebGPU object with internals$](|this|, {{GPUBuffer}}, |descriptor|).
                 1. Set |b|.{{GPUBuffer/size}} to |descriptor|.{{GPUBufferDescriptor/size}}.
                 1. Set |b|.{{GPUBuffer/usage}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
                 1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
@@ -4264,7 +4275,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                     |descriptor|.{{GPUTextureDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
                 1. [=?=] [$Validate texture format required features$] of each element of
                     |descriptor|.{{GPUTextureDescriptor/viewFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
-                1. Let |t| be a new {{GPUTexture}} object.
+                1. Let |t| be [=!=] [$create a new WebGPU object$](|this|, {{GPUTexture}}, |descriptor|).
                 1. Set |t|.{{GPUTexture/width}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=].
                 1. Set |t|.{{GPUTexture/height}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=].
                 1. Set |t|.{{GPUTexture/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=].
@@ -4647,7 +4658,7 @@ enum GPUTextureAspect {
 
                 1. [=?=] [$Validate texture format required features$] of
                     |descriptor|.{{GPUTextureViewDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
-                1. Let |view| be a new {{GPUTextureView}} object.
+                1. Let |view| be [=!=] [$create a new WebGPU object$](|this|, {{GPUTextureView}}, |descriptor|).
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |view|.
             </div>
@@ -5529,7 +5540,7 @@ enum GPUCompareFunction {
 
                 [=Content timeline=] steps:
 
-                1. Let |s| be a new {{GPUSampler}} object.
+                1. Let |s| be [=!=] [$create a new WebGPU object$](|this|, {{GPUSampler}}, |descriptor|).
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |s|.
             </div>
@@ -6002,7 +6013,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                         1. [=?=] [$Validate texture format required features$] for
                             |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
                             with |this|.{{GPUObjectBase/[[device]]}}.
-                1. Let |layout| be a new {{GPUBindGroupLayout}} object.
+                1. Let |layout| be [=!=] [$create a new WebGPU object$](|this|, {{GPUBindGroupLayout}}, |descriptor|).
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |layout|.
             </div>
@@ -6228,7 +6239,7 @@ following members:
 
                 [=Content timeline=] steps:
 
-                1. Let |bindGroup| be a new {{GPUBindGroup}} object.
+                1. Let |bindGroup| be [=!=] [$create a new WebGPU object$](|this|, {{GPUBindGroup}}, |descriptor|).
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |bindGroup|.
             </div>
@@ -6464,7 +6475,7 @@ pipeline, and have the following members:
 
                 [=Content timeline=] steps:
 
-                1. Let |pl| be a new {{GPUPipelineLayout}} object.
+                1. Let |pl| be [=!=] [$create a new WebGPU object$](|this|, {{GPUPipelineLayout}}, |descriptor|).
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |pl|.
             </div>
@@ -6635,7 +6646,7 @@ dictionary GPUShaderModuleDescriptor
 
                 [=Content timeline=] steps:
 
-                1. Let |sm| be a new {{GPUShaderModule}} object.
+                1. Let |sm| be [=!=] [$create a new WebGPU object$](|this|, {{GPUShaderModule}}, |descriptor|).
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |sm|.
             </div>
@@ -7686,7 +7697,7 @@ dictionary GPUComputePipelineDescriptor
 
                 [=Content timeline=] steps:
 
-                1. Let |pipeline| be a new {{GPUComputePipeline}} object.
+                1. Let |pipeline| be [=!=] [$create a new WebGPU object$](|this|, {{GPUComputePipeline}}, |descriptor|).
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |pipeline|.
             </div>
@@ -7932,7 +7943,7 @@ dictionary GPURenderPipelineDescriptor
                     1. [=?=] [$Validate texture format required features$] of
                         |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.{{GPUDepthStencilState/format}}
                         with |this|.{{GPUObjectBase/[[device]]}}.
-                1. Let |pipeline| be a new {{GPURenderPipeline}} object.
+                1. Let |pipeline| be [=!=] [$create a new WebGPU object$](|this|, {{GPURenderPipeline}}, |descriptor|).
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |pipeline|.
             </div>
@@ -9592,14 +9603,14 @@ dictionary GPUCommandEncoderDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createCommandEncoder(descriptor)">
-                    descriptor: Description of the {{GPUCommandEncoder}} to create.
+                    |descriptor|: Description of the {{GPUCommandEncoder}} to create.
                 </pre>
 
                 **Returns:** {{GPUCommandEncoder}}
 
                 [=Content timeline=] steps:
 
-                1. Let |e| be a new {{GPUCommandEncoder}} object.
+                1. Let |e| be [=!=] [$create a new WebGPU object$](|this|, {{GPUCommandEncoder}}, |descriptor|).
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |e|.
             </div>
@@ -12538,7 +12549,7 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                     |descriptor|.{{GPURenderPassLayout/colorFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
                 1. [=?=] [$Validate texture format required features$] of
                     |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} with |this|.{{GPUObjectBase/[[device]]}}.
-                1. Let |e| be a new {{GPURenderBundleEncoder}} object.
+                1. Let |e| be [=!=] [$create a new WebGPU object$](|this|, {{GPURenderBundleEncoder}}, |descriptor|).
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |e|.
             </div>
@@ -13132,7 +13143,7 @@ dictionary GPUQuerySetDescriptor
                 1. If |descriptor|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}},
                     but {{GPUFeatureName/"timestamp-query"}} is not [=enabled for=] |this|:
                     1. Throw a {{TypeError}}.
-                1. Let |q| be a new {{GPUQuerySet}} object.
+                1. Let |q| be [=!=] [$create a new WebGPU object$](|this|, {{GPUQuerySet}}, |descriptor|).
                 1. Set |q|.{{GPUQuerySet/type}} to |descriptor|.{{GPUQuerySetDescriptor/type}}.
                 1. Set |q|.{{GPUQuerySet/count}} to |descriptor|.{{GPUQuerySetDescriptor/count}}.
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.


### PR DESCRIPTION
Fixes #3332

Uses this function for all GPUObjectBase-derived types to ensure that the internal `[[device]]` and `[[label]]` are properly set on creation.

There's still a couple of things that I'd like to adjust here, so this should be treated as a first draft. Textures and Queries should have [[internals]] objects that are initialized by this creation step, but also it's not clear that we need that process to be in a variant of the create function as I have it here, or handled in a function at all given how rarely it's used.