### PR TITLE
Add early evaluation errors for smoothstep

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -15285,8 +15285,12 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     [=Component-wise=] when `T` is a vector.
 
     For scalar `T`, the result is
-    `t * t * (3.0 - 2.0 * t)`,
+    `t * t * (3.0 - 2.0 * t)`,<br>
     where `t = clamp((x - low) / (high - low), 0.0, 1.0)`.
+
+    If `low >= high`:
+    * It is a [=shader-creation error=] if `low` and `high` are [=const-expressions=].
+    * It is a [=pipeline-creation error=] if `low` and `high` are [=override-expressions=].
 </table>
 
 ### `sqrt` ### {#sqrt-builtin}


### PR DESCRIPTION
Fixes #4561

* Add shader- and pipeline-creation errors to smoothstep if `low >= high`
* A line break to improve rendering of the formula