### PR TITLE
Indicate timeline for majority of algorithms

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -852,7 +852,7 @@ not require multiple processes, or even multiple threads.
 
     <div class=algorithm>
         <div data-timeline=const>
-            Steps which are [=timeline agnostic=] look like this.
+            Steps which are [=timeline-agnostic=] look like this.
 
             [=Immutable value example term=] usage.
         </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -573,7 +573,7 @@ interface mixin GPUObjectBase {
 <div algorithm data-timeline=content>
     To <dfn abstract-op>create a new WebGPU object</dfn>({{GPUObjectBase}} |parent|,
     interface |T|, {{GPUObjectDescriptorBase}} |descriptor|)
-    (where |T| extends {{GPUObjectBase}}) run the following steps on the [=content timeline=]:
+    (where |T| extends {{GPUObjectBase}}), run the following [=content timeline=] steps:
 
     1. Let |device| be |parent|.{{GPUObjectBase/[[device]]}}.
     1. Let |object| be a new instance of |T|.
@@ -702,9 +702,7 @@ like buffer state "[=GPUBuffer/[[internal state]]/destroyed=]".
 
 <div algorithm data-timeline=device>
     A given {{GPUObjectBase}} |object| is <dfn abstract-op>valid to use with</dfn>
-    a |targetObject| if and only if the following requirements are met.
-
-    [=Device timeline=] steps:
+    a |targetObject| if the all of the requirements in the following [=device timeline=] steps are met:
 
     <div class=validusage>
         - |object| must be [=valid=].
@@ -1135,9 +1133,9 @@ it and all objects created on it (directly, e.g.
 {{GPUDevice/createTexture()}}, or indirectly, e.g. {{GPUTexture/createView()}}) become
 implicitly [$valid to use with|unusable$].
 
-A [=device=] has the following internal slots:
+A [=device=] has the following [=immutable properties=]:
 
-<dl dfn-type=attribute dfn-for=device>
+<dl dfn-type=attribute dfn-for=device data-timeline=const>
     : <dfn>\[[adapter]]</dfn>, of type [=adapter=], readonly
     ::
         The [=adapter=] from which this device was created.
@@ -1155,7 +1153,7 @@ A [=device=] has the following internal slots:
 
 <div algorithm data-timeline=device>
     When <dfn dfn>a new device</dfn> |device| is created from [=adapter=] |adapter|
-    with {{GPUDeviceDescriptor}} |descriptor| run the following steps on the [=device timeline=]:
+    with {{GPUDeviceDescriptor}} |descriptor|, run the following [=device timeline=] steps:
 
     - Set |device|.{{device/[[adapter]]}} to |adapter|.
 
@@ -1185,7 +1183,7 @@ API tries to behave like nothing is wrong to avoid interrupting the runtime flow
 no validation errors are raised, most promises resolve normally, etc.
 
 <div algorithm data-timeline=device>
-    To <dfn dfn>lose the device</dfn>(|device|, |reason|) run the following steps on the [=device timeline=]:
+    To <dfn dfn>lose the device</dfn>(|device|, |reason|) run the following [=device timeline=] steps:
 
     1. Make |device| [=invalid=].
     1. Let |gpuDevice| be the [=content timeline=] {{GPUDevice}} corresponding to |device|.
@@ -1245,7 +1243,7 @@ and using <dfn dfn>optional API surfaces</dfn> results in the following:
 - Using a new WGSL `enable` directive always results in a {{GPUDevice/createShaderModule()}}
     [$validation error$].
 
-<div algorithm>
+<div algorithm data-timeline=const>
     A {{GPUFeatureName}} |feature| is <dfn dfn>enabled for</dfn>
     a {{GPUObjectBase}} |object| if and only if
     |object|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} [=list/contains=] |feature|.
@@ -1684,7 +1682,7 @@ interface GPUAdapterInfo {
 
 <div algorithm data-timeline=content>
     To create a <dfn abstract-op>new adapter info</dfn> for a given [=adapter=] |adapter|, run the
-    following steps on the [=content timeline=]:
+    following [=content timeline=] steps:
 
     1. Let |adapterInfo| be a new {{GPUAdapterInfo}}.
 
@@ -1885,7 +1883,7 @@ them to WGSL values (`bool`, `i32`, `u32`, `f32`, `f16`).
 
 <div algorithm data-timeline=device>
     To convert an IDL value |idlValue| of type {{double}} or {{float}} <dfn abstract-op>to WGSL type</dfn> |T|,
-    possibly throwing a {{TypeError}}, run the following steps on the [=device timeline=]:
+    possibly throwing a {{TypeError}}, run the following [=device timeline=] steps:
 
     Note: This {{TypeError}} is generated in the [=device timeline=] and never surfaced to JavaScript.
 
@@ -1936,7 +1934,7 @@ them to WGSL values (`bool`, `i32`, `u32`, `f32`, `f16`).
 
 <div algorithm data-timeline=device>
     To convert a {{GPUColor}} |color| <dfn abstract-op>to a texel value of texture format</dfn> |format|,
-    possibly throwing a {{TypeError}}, run the following steps on the [=device timeline=]:
+    possibly throwing a {{TypeError}}, run the following [=device timeline=] steps:
 
     Note: This {{TypeError}} is generated in the [=device timeline=] and never surfaced to JavaScript.
 
@@ -2659,7 +2657,7 @@ Those not defined here are defined elsewhere in this document.
         mapped memory that was just unmapped.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=const>
     A {{GPUDevice}}'s <dfn dfn>allowed buffer usages</dfn> are:
 
     - Always allowed:
@@ -2677,7 +2675,7 @@ Those not defined here are defined elsewhere in this document.
     <!-- As needed, compute more allowed usages based on the features enabled on the device. -->
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=const>
     A {{GPUDevice}}'s <dfn dfn>allowed texture usages</dfn> are:
 
     - Always allowed:
@@ -2878,7 +2876,7 @@ enum GPUBufferMapState {
 
         <div algorithm data-timeline=content>
             To <dfn abstract-op for="">initialize an active buffer mapping</dfn> with mode |mode| and
-            range |range|, run the following steps on the [=content timeline=]:
+            range |range|, run the following [=content timeline=] steps:
 
             1. Let |size| be |range|[1] - |range|[0].
             1. Let |data| be [=?=] [$CreateByteDataBlock$](|size|).
@@ -3652,7 +3650,7 @@ GPUTexture includes GPUObjectBase;
 The <dfn dfn>logical miplevel-specific texture extent</dfn> of a [=texture=] is the size of the
 [=texture=] in texels at a specific miplevel. It is calculated by this procedure:
 
-<div algorithm>
+<div algorithm data-timeline=const>
     <dfn abstract-op>Logical miplevel-specific texture extent</dfn>(descriptor, mipLevel)
 
     **Arguments:**
@@ -3661,8 +3659,6 @@ The <dfn dfn>logical miplevel-specific texture extent</dfn> of a [=texture=] is 
     - {{GPUSize32}} |mipLevel|
 
     **Returns:** {{GPUExtent3DDict}}
-
-    [=Device timeline=] steps:
 
     1. Let |extent| be a new {{GPUExtent3DDict}} object.
     1. If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
@@ -3693,7 +3689,7 @@ The <dfn dfn>physical miplevel-specific texture extent</dfn> of a [=texture=] is
 [=texture=] in texels at a specific miplevel that includes the possible extra padding
 to form complete [=texel blocks=] in the [=texture=]. It is calculated by this procedure:
 
-<div algorithm>
+<div algorithm data-timeline=const>
     <dfn abstract-op>Physical miplevel-specific texture extent</dfn>(descriptor, mipLevel)
 
     **Arguments:**
@@ -3796,7 +3792,7 @@ dictionary GPUTextureDescriptor
 
         Formats in this list must be [=texture view format compatible=] with the texture format.
 
-        <div algorithm data-timeline=device>
+        <div algorithm data-timeline=const>
             Two {{GPUTextureFormat}}s |format| and |viewFormat| are <dfn dfn for="">texture view format compatible</dfn> if:
 
             - |format| equals |viewFormat|, or
@@ -3878,7 +3874,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
         {{GPURenderPassDepthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}}.)
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=const>
     <dfn abstract-op>maximum mipLevel count</dfn>(|dimension|, |size|)
 
     **Arguments:**
@@ -4405,7 +4401,7 @@ enum GPUTextureAspect {
 
 <div algorithm data-timeline=device>
     When <dfn abstract-op>resolving GPUTextureViewDescriptor defaults</dfn> for {{GPUTextureView}}
-    |texture| with a {{GPUTextureViewDescriptor}} |descriptor| run the following steps on the [=device timeline=]:
+    |texture| with a {{GPUTextureViewDescriptor}} |descriptor|, run the following [=device timeline=] steps:
 
     1. Let |resolved| be a copy of |descriptor|.
     1. If |resolved|.{{GPUTextureViewDescriptor/format}} is not [=map/exist|provided=]:
@@ -4460,7 +4456,7 @@ enum GPUTextureAspect {
     1. Return |resolved|.
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=const>
     To determine the <dfn abstract-op>array layer count</dfn> of {{GPUTexture}} |texture|, run the
     following steps:
 
@@ -4667,7 +4663,7 @@ A format is <dfn lt="filterable|filterable format">filterable</dfn> if it suppor
 that is, it can be used with {{GPUSamplerBindingType/"filtering"}} {{GPUSampler}}s.
 See [[#texture-format-caps]].
 
-<div algorithm>
+<div algorithm data-timeline=const>
     <dfn abstract-op>resolving GPUTextureAspect</dfn>(format, aspect)
 
     **Arguments:**
@@ -4701,8 +4697,8 @@ the behavior the same as when the format is unknown to the implementation.
 See [[#texture-format-caps]] for information about which {{GPUTextureFormat}}s require features.
 
 <div algorithm class=validusage data-timeline=content>
-    <dfn abstract-op>Validate texture format required features</dfn> of a {{GPUTextureFormat}} |format|<br/>
-    with logical [=device=] |device| by running the following steps on the [=content timeline=]:
+    To <dfn abstract-op>Validate texture format required features</dfn> of a {{GPUTextureFormat}} |format|<br/>
+    with logical [=device=] |device|, run the following [=content timeline=] steps:
 
     1. If |format| requires a feature and |device|.{{device/[[features]]}} does not [=list/contain=]
         the feature:
@@ -6827,7 +6823,7 @@ unexpected bind group creation errors.
 <div algorithm="default pipeline layout creation" data-timeline=device>
 
 To create a <dfn abstract-op>default pipeline layout</dfn> for {{GPUPipelineBase}} |pipeline|,
-run the following steps on the [=device timeline=]:
+run the following [=device timeline=] steps:
 
     1. Let |groupCount| be 0.
     1. Let |groupDescs| be a sequence of |device|.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}
@@ -7080,7 +7076,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
 
 <div algorithm data-timeline=device>
     To <dfn abstract-op>get the entry point</dfn>({{GPUShaderStage}} |stage|,
-    {{GPUProgrammableStage}} |descriptor|) run the following steps on the [=device timeline=]:
+    {{GPUProgrammableStage}} |descriptor|), run the following [=device timeline=] steps:
 
     1. If |descriptor|.{{GPUProgrammableStage/entryPoint}} is [=map/exists|provided=]:
 
@@ -7141,7 +7137,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         result from the rules of the [[WGSL]] specification.
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=const>
     <dfn abstract-op>validating shader binding</dfn>(|variable|, |layout|)
 
     **Arguments:**
@@ -7287,7 +7283,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
             </dl>
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=const>
     The <dfn dfn>minimum buffer binding size</dfn> for a buffer binding variable |var| is computed as follows:
 
     1. Let |T| be the [=store type=] of |var|.
@@ -7303,7 +7299,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     within the bound region of the buffer.
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=const>
     A resource binding, [=pipeline-overridable=] constant, shader stage input, or shader stage output
     is considered to be <dfn dfn lt="statically used|static use">statically used</dfn>
     by an entry point if it is present in the [=interface of a shader
@@ -8457,10 +8453,10 @@ will affect a render pass's {{GPURenderPassDescriptor/depthStencilAttachment}}:
         The maximum depth bias of a fragment. See [$biased fragment depth$] for details.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=queue>
     The <dfn abstract-op>biased fragment depth</dfn> for a fragment being written to
     {{GPURenderPassDescriptor/depthStencilAttachment}} |attachment| when drawing using
-    {{GPUDepthStencilState}} |state| is calculated by running the following steps:
+    {{GPUDepthStencilState}} |state| is calculated by running the following [=queue timeline=] steps:
 
     1. Let |format| be |attachment|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureViewDescriptor/format}}.
     1. Let |r| be the minimum positive representable value &gt; `0` in the |format| converted to a 32-bit float.
@@ -9244,8 +9240,7 @@ The <dfn dfn>encoder state</dfn> may be one of the following:
 
 <div algorithm data-timeline=device>
     To <dfn abstract-op>Enqueue a command</dfn> on {{GPUCommandsMixin}} |encoder|
-    which issues the steps of a [=GPU Command=] |command|, run the following steps on the
-    [=device timeline=]:
+    which issues the steps of a [=GPU Command=] |command|, run the following [=device timeline=] steps:
 
         1. [=list/Append=] |command| to |encoder|.{{GPUCommandsMixin/[[commands]]}}.
         1. When |command| is executed as part of a {{GPUCommandBuffer}}:
@@ -10123,7 +10118,7 @@ It must only be included by interfaces which also include those mixins.
 
 <div algorithm data-timeline=device>
     To <dfn abstract-op>Iterate over each dynamic binding offset</dfn> in a given {{GPUBindGroup}} |bindGroup|
-    with a given list of |steps| to be executed for each dynamic offset, run the following steps on the [=device timeline=]:
+    with a given list of |steps| to be executed for each dynamic offset, run the following [=device timeline=] steps:
 
     1. Let |dynamicOffsetIndex| be `0`.
     1. Let |layout| be |bindGroup|.{{GPUBindGroup/[[layout]]}}.
@@ -10974,22 +10969,21 @@ dictionary GPURenderPassColorAttachment {
 
 <div algorithm data-timeline=device>
     A {{GPUTextureView}} |view| is a <dfn abstract-op>renderable texture view</dfn>
-    if the following requirements are met:
+    if the all of the requirements in the following [=device timeline=] steps are met:
 
-    1. Let |descriptor| be |view|.{{GPUTextureView/[[descriptor]]}}.
-    1. |view| is not renderable if any of the following conditions are unsatisfied:
-        <div class=validusage>
-            - |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/usage}}
-                must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
-            - |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be either {{GPUTextureViewDimension/"2d"}} or {{GPUTextureViewDimension/"3d"}}.
-            - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
-            - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be 1.
-            - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must refer to all [=aspects=] of
-                |view|.{{GPUTextureView/[[texture]]}}.
-        </div>
+    <div class=validusage>
+        1. Let |descriptor| be |view|.{{GPUTextureView/[[descriptor]]}}.
+        1. |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/usage}}
+            must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
+        1. |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be either {{GPUTextureViewDimension/"2d"}} or {{GPUTextureViewDimension/"3d"}}.
+        1. |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
+        1. |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be 1.
+        1. |descriptor|.{{GPUTextureViewDescriptor/aspect}} must refer to all [=aspects=] of
+            |view|.{{GPUTextureView/[[texture]]}}.
+    </div>
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=const>
     <dfn abstract-op>Calculating color attachment bytes per sample</dfn>(|formats|)
 
     **Arguments:**
@@ -11398,7 +11392,7 @@ It must only be included by interfaces which also include those mixins.
 <div algorithm data-timeline=device>
     To <dfn abstract-op>Enqueue a render command</dfn> on {{GPURenderCommandsMixin}} |encoder| which
     issues the steps of a [=GPU Command=] |command| with [=RenderState=] |renderState|, run the
-    following steps on the [=device timeline=]:
+    following [=device timeline=] steps:
 
         1. [=list/Append=] |command| to |encoder|.{{GPUCommandsMixin/[[commands]]}}.
         1. When |command| is executed as part of a {{GPUCommandBuffer}} |commandBuffer|:
@@ -11844,8 +11838,8 @@ It must only be included by interfaces which also include those mixins.
 </dl>
 
 <div algorithm data-timeline=device>
-    To determine if it's <dfn abstract-op>valid to draw</dfn> with {{GPURenderCommandsMixin}} |encoder|
-    run the following steps on the [=device timeline=]:
+    To determine if it's <dfn abstract-op>valid to draw</dfn> with {{GPURenderCommandsMixin}} |encoder|,
+    run the following [=device timeline=] steps:
 
     1. If any of the following conditions are unsatisfied, return `false`:
 
@@ -11869,8 +11863,8 @@ It must only be included by interfaces which also include those mixins.
 </div>
 
 <div algorithm data-timeline=device>
-    To determine if it's <dfn abstract-op>valid to draw indexed</dfn> with {{GPURenderCommandsMixin}} |encoder|
-    run the following steps on the [=device timeline=]:
+    To determine if it's <dfn abstract-op>valid to draw indexed</dfn> with {{GPURenderCommandsMixin}} |encoder|,
+    run the following [=device timeline=] steps:
 
     1. If any of the following conditions are unsatisfied, return `false`:
 
@@ -13012,7 +13006,7 @@ Timestamp queries are implemented using high-resolution timers (see [[#security-
 To mitigate security and privacy concerns, their precision must be reduced:
 
 <div algorithm data-timeline=queue>
-    To get the <dfn abstract-op>current queue timestamp</dfn> run the following steps on the [=queue timeline=]:
+    To get the <dfn abstract-op>current queue timestamp</dfn>, run the following [=queue timeline=] steps:
 
     - Let |fineTimestamp| be the current timestamp value of the current [=queue timeline=],
         in nanoseconds, relative to an implementation-defined point in the past.
@@ -13343,7 +13337,7 @@ interface GPUCanvasContext {
 
 <div algorithm data-timeline=content>
     To <dfn abstract-op>Replace the drawing buffer</dfn> of a {{GPUCanvasContext}} |context|, run
-    the following steps on the [=content timeline=]:
+    the following [=content timeline=] steps:
 
     1. [$Expire the current texture$] of |context|.
     1. Let |configuration| be |context|.{{GPUCanvasContext/[[configuration]]}}.
@@ -13366,7 +13360,7 @@ interface GPUCanvasContext {
 
 <div algorithm data-timeline=content>
     To <dfn abstract-op>Expire the current texture</dfn> of a {{GPUCanvasContext}} |context|, run
-    the following steps on the [=content timeline=]:
+    the following [=content timeline=] steps:
 
     1. If |context|.{{GPUCanvasContext/[[currentTexture]]}} is not `null`:
         1. Call |context|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/destroy()}}
@@ -13382,7 +13376,7 @@ specified points.
 
 <div algorithm="get the bitmap of a WebGPU canvas" data-timeline=content>
     When the "bitmap" is read from an {{HTMLCanvasElement}} or {{OffscreenCanvas}} with a
-    {{GPUCanvasContext}} |context|, run the following steps on the [=content timeline=]:
+    {{GPUCanvasContext}} |context|, run the following [=content timeline=] steps:
 
     1. Return [$get a copy of the image contents of a context|a copy of the image contents$]
         of |context|.
@@ -13410,7 +13404,7 @@ specified points.
     When <dfn abstract-op>updating the rendering of a WebGPU canvas</dfn>
     (an {{HTMLCanvasElement}} or an {{OffscreenCanvas}} with a [=placeholder canvas element=])
     with a {{GPUCanvasContext}} |context|, which occurs in the following sub-steps of the
-    [=event loop processing model=], run the following steps on the [=content timeline=]:
+    [=event loop processing model=], run the following [=content timeline=] steps:
 
     - "update the rendering or user interface of that `Document`"
     - "update the rendering of that dedicated worker"
@@ -13437,7 +13431,7 @@ specified points.
 <div algorithm="transferToImageBitmap from WebGPU" data-timeline=content>
     When {{OffscreenCanvas/transferToImageBitmap()}} is called on a canvas with
     {{GPUCanvasContext}} |context|, after creating an {{ImageBitmap}} from the canvas's bitmap,
-    run the following steps on the [=content timeline=]:
+    run the following [=content timeline=] steps:
 
     1. [$Replace the drawing buffer$] of |context|.
 
@@ -13576,8 +13570,8 @@ In WebGPU, it does so by [$Replace the drawing buffer|replacing the drawing buff
 <div algorithm data-timeline=content>
     When an {{HTMLCanvasElement}} or {{OffscreenCanvas}} |canvas| with a
     {{GPUCanvasContext}} |context| has its `width` or `height` attributes set,
-    <dfn abstract-op>update the canvas size</dfn> by running the following steps
-    on the [=content timeline=]:
+    <dfn abstract-op>update the canvas size</dfn> by running the following
+    [=content timeline=] steps:
 
     1. [$Replace the drawing buffer$] of |context|.
     1. Let |configuration| be |context|.{{GPUCanvasContext/[[configuration]]}}
@@ -13849,7 +13843,7 @@ partial interface GPUDevice {
 
 <div algorithm data-timeline=device>
     The <dfn abstract-op>current error scope</dfn> for a {{GPUError}} |error| and {{GPUDevice}}
-    |device| is determined by issuing the following steps to the [=Device timeline=] of |device|:
+    |device| is determined by issuing the following steps to the [=device timeline=] of |device|:
 
     [=Device timeline=] steps:
 
@@ -13873,7 +13867,7 @@ partial interface GPUDevice {
 
 <div algorithm>
     To <dfn abstract-op lt="Dispatch error|dispatch error">dispatch an error</dfn> {{GPUError}}
-    |error| on {{GPUDevice}} |device|, run the following steps on the [=Device timeline=]
+    |error| on {{GPUDevice}} |device|, run the following steps on the [=device timeline=]
     of |device|:
 
     <div data-timeline=device>
@@ -13886,7 +13880,7 @@ partial interface GPUDevice {
         1. If |scope| is not `undefined`:
             1. [=list/Append=] |error| to |scope|.{{GPU error scope/[[errors]]}}.
             1. Return.
-        1. Otherwise issue the following steps to the [=Content timeline=]:
+        1. Otherwise issue the following steps to the [=content timeline=]:
     </div>
     <div data-timeline=content>
         [=Content timeline=] steps:
@@ -14169,7 +14163,7 @@ blocks in hardware.
 
 The main rendering algorithm:
 
-<div algorithm>
+<div algorithm data-timeline=queue>
     <dfn abstract-op>render</dfn>(descriptor, drawCall, state)
 
         **Arguments:**
@@ -14218,7 +14212,7 @@ The main rendering algorithm:
 At the first stage of rendering, the pipeline builds
 a list of vertices to process for each instance.
 
-<div algorithm>
+<div algorithm data-timeline=queue>
     <dfn abstract-op>resolve indices</dfn>(drawCall, state)
 
     **Arguments:**
@@ -14252,7 +14246,7 @@ a list of vertices to process for each instance.
     <p class="note editorial"><span class=marker>Editorial note:</span> specify indirect commands better.
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=queue>
     <dfn abstract-op>fetch index</dfn>(i, buffer, offset, format)
 
     **Arguments:**
@@ -14285,7 +14279,7 @@ processes the vertex attribute data, and produces
 clip space positions for [[#primitive-clipping]], as well as other data for the
 [[#fragment-processing]].
 
-<div algorithm>
+<div algorithm data-timeline=queue>
     <dfn abstract-op>process vertices</dfn>(vertexIndexList, drawCall, desc, state)
 
     **Arguments:**
@@ -14380,7 +14374,7 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
 
 Primitives are assembled by a fixed-function stage of GPUs.
 
-<div algorithm>
+<div algorithm data-timeline=queue>
     <dfn abstract-op>assemble primitives</dfn>(vertexIndexList, drawCall, desc)
 
     **Arguments:**
@@ -14565,7 +14559,7 @@ Rasterization produces a list of <dfn dfn>RasterizationPoint</dfn>s, each contai
 
 <p class="note editorial"><span class=marker>Editorial note:</span> define the depth computation algorithm
 
-<div algorithm>
+<div algorithm data-timeline=queue>
     <dfn abstract-op>rasterize</dfn>(primitiveList, state)
 
     **Arguments:**
@@ -14670,7 +14664,7 @@ of a point based on the triangle it falls into.
 A polygon is <dfn dfn>front-facing</dfn> if it's oriented towards the projection.
 Otherwise, the polygon is <dfn dfn>back-facing</dfn>.
 
-<div algorithm>
+<div algorithm data-timeline=queue>
     <dfn abstract-op>rasterize polygon</dfn>()
 
     **Arguments:**
@@ -14764,7 +14758,7 @@ This stage produces a <dfn dfn>Fragment</dfn> for each [=RasterizationPoint=]:
         one for each target in {{GPURenderPassDescriptor/colorAttachments}}.
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=queue>
     <dfn abstract-op>process fragment</dfn>(rp, desc, state)
 
     **Arguments:**

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -541,7 +541,7 @@ The following special property types can be defined on [=WebGPU objects=]:
 
 : <dfn dfn data-timeline=const>immutable property</dfn>
 ::
-    A read-only slot set during initialization of the object. It can be accessed from [=any timeline=].
+    A read-only slot set during initialization of the object. It can be accessed from any timeline.
 
     Note: Since the slot is immutable, implementations may have a copy on multiple timelines, as needed.
     [=Immutable properties=] are defined in this way to avoid describing multiple copies in this spec.
@@ -820,7 +820,7 @@ not require multiple processes, or even multiple threads.
     on the compute units of the GPU. It includes actual draw, copy,
     and compute jobs that run on the GPU.
 
-: <dfn dfn lt="any timeline|timeline agnostic">Timeline agnostic</dfn>
+: <dfn dfn>Timeline-agnostic</dfn>
 :: Associated with any of the above timelines
 
     Steps may be issued to any timeline if they only operate on [=immutable properties=] or
@@ -832,7 +832,7 @@ not require multiple processes, or even multiple threads.
 
     <dl data-timeline=const>
         : <dfn>Immutable value example term</dfn> definition
-        :: Can be used on [=any timeline=].
+        :: Can be used on any timeline.
     </dl>
 
     <dl data-timeline=content>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -800,7 +800,6 @@ as the GPU itself as a separate execution unit in many implementations.
 Implementing WebGPU does not require timelines to execute in parallel, so does
 not require multiple processes, or even multiple threads.
 
-<dfn dfn lt="any timeline"></dfn>
 : <dfn dfn>Content timeline</dfn>
 :: Associated with the execution of the Web script.
     It includes calling all methods described by this specification.
@@ -820,6 +819,12 @@ not require multiple processes, or even multiple threads.
 :: Associated with the execution of operations
     on the compute units of the GPU. It includes actual draw, copy,
     and compute jobs that run on the GPU.
+
+: <dfn dfn lt="any timeline|timeline agnostic">Timeline agnostic</dfn>
+:: Associated with any of the above timelines
+
+    Steps may be issued to any timeline if they only operate on [=immutable properties=] or
+    arguments passed from the calling steps.
 
 <div class=example style="background: var(--bg)">
     The following show the styling of steps and values associated with each timeline.
@@ -847,7 +852,7 @@ not require multiple processes, or even multiple threads.
 
     <div class=algorithm>
         <div data-timeline=const>
-            Steps which can be executed on the [=any timeline=] look like this.
+            Steps which are [=timeline agnostic=] look like this.
 
             [=Immutable value example term=] usage.
         </div>
@@ -13735,11 +13740,11 @@ satisfy all validation requirements. Validation errors are always indicative of 
 error, and is expected to fail the same way across all devices assuming the same
 {{device/[[features]]}} and {{device/[[limits]]}} are in use.
 
-<div algorithm data-timeline=content>
+<div algorithm data-timeline=device>
     To <dfn abstract-op lt="Generate a validation error|generate a validation error|validation error">generate a
     validation error</dfn> for {{GPUDevice}} |device|, run the following steps:
 
-    [=Content timeline=] steps:
+    [=Device timeline=] steps:
 
     1. Let |error| be a new {{GPUValidationError}} with an appropriate error message.
     1. [$Dispatch error$] |error| to |device|.
@@ -13758,11 +13763,11 @@ memory to complete the requested operation. The operation may succeed if attempt
 lower memory requirement (like using smaller texture dimensions), or if memory used by other
 resources is released first.
 
-<div algorithm data-timeline=content>
+<div algorithm data-timeline=device>
     To <dfn abstract-op lt="Generate an out-of-memory error|generate an out-of-memory error|out-of-memory error">
     generate an out-of-memory error</dfn> for {{GPUDevice}} |device|, run the following steps:
 
-    [=Content timeline=] steps:
+    [=Device timeline=] steps:
 
     1. Let |error| be a new {{GPUOutOfMemoryError}} with an appropriate error message.
     1. [$Dispatch error$] |error| to |device|.
@@ -13782,11 +13787,11 @@ For example, the operation may exceed the capabilities of the implementation in 
 captured by the [=supported limits=]. The same operation may succeed on other devices or under
 difference circumstances.
 
-<div algorithm data-timeline=content>
+<div algorithm data-timeline=device>
     To <dfn abstract-op lt="Generate an internal error|generate an internal error|internal error">generate an
     internal error</dfn> for {{GPUDevice}} |device|, run the following steps:
 
-    [=Content timeline=] steps:
+    [=Device timeline=] steps:
 
     1. Let |error| be a new {{GPUInternalError}} with an appropriate error message.
     1. [$Dispatch error$] |error| to |device|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9229,7 +9229,7 @@ The <dfn dfn>encoder state</dfn> may be one of the following:
 
 <div algorithm class=validusage data-timeline=device>
     To <dfn abstract-op>Validate the encoder state</dfn> of {{GPUCommandsMixin}} |encoder| run the <br/>
-    following steps on the [=device timeline=]:
+    following [=device timeline=] steps:
 
     1. If |encoder|.{{GPUCommandsMixin/[[state]]}} is:
         <dl class=switch>
@@ -13077,7 +13077,7 @@ which allows changing the canvas configuration without replacing the canvas.
 <div algorithm data-timeline=content>
     To <dfn abstract-op>create a 'webgpu' context on a canvas</dfn>
     ({{HTMLCanvasElement}} or {{OffscreenCanvas}}) |canvas|, run the following
-    steps on the [=content timeline=]:
+    [=content timeline=] steps:
 
     1. Let |context| be a new {{GPUCanvasContext}}.
     1. Set |context|.{{GPUCanvasContext/canvas}} to |canvas|.
@@ -13873,8 +13873,7 @@ partial interface GPUDevice {
 
 <div algorithm>
     To <dfn abstract-op lt="Dispatch error|dispatch error">dispatch an error</dfn> {{GPUError}}
-    |error| on {{GPUDevice}} |device|, run the following steps on the [=device timeline=]
-    of |device|:
+    |error| on {{GPUDevice}} |device|, run the following [=device timeline=] steps:
 
     <div data-timeline=device>
         [=Device timeline=] steps:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -541,7 +541,7 @@ The following special property types can be defined on [=WebGPU objects=]:
 
 : <dfn dfn data-timeline=const>immutable property</dfn>
 ::
-    A read-only slot set during initialization of the object. It can be accessed from any timeline.
+    A read-only slot set during initialization of the object. It can be accessed from [=any timeline=].
 
     Note: Since the slot is immutable, implementations may have a copy on multiple timelines, as needed.
     [=Immutable properties=] are defined in this way to avoid describing multiple copies in this spec.
@@ -800,6 +800,7 @@ as the GPU itself as a separate execution unit in many implementations.
 Implementing WebGPU does not require timelines to execute in parallel, so does
 not require multiple processes, or even multiple threads.
 
+<dfn dfn lt="any timeline"></dfn>
 : <dfn dfn>Content timeline</dfn>
 :: Associated with the execution of the Web script.
     It includes calling all methods described by this specification.
@@ -826,25 +827,30 @@ not require multiple processes, or even multiple threads.
 
     <dl data-timeline=const>
         : <dfn>Immutable value example term</dfn> definition
-        :: Can be used on any timeline.
+        :: Can be used on [=any timeline=].
     </dl>
 
     <dl data-timeline=content>
         : <dfn>Content-timeline example term</dfn> definition
-        :: Can only be used on the content timeline.
+        :: Can only be used on the [=content timeline=].
     </dl>
 
     <dl data-timeline=device>
         : <dfn>Device-timeline example term</dfn> definition
-        :: Can only be used on the device timeline.
+        :: Can only be used on the [=device timeline=].
     </dl>
 
     <dl data-timeline=queue>
         : <dfn>Queue-timeline example term</dfn> definition
-        :: Can only be used on the queue timeline.
+        :: Can only be used on the [=queue timeline=].
     </dl>
 
     <div class=algorithm>
+        <div data-timeline=const>
+            Steps which can be executed on the [=any timeline=] look like this.
+
+            [=Immutable value example term=] usage.
+        </div>
         <div data-timeline=content>
             Steps executed on the [=content timeline=] look like this.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -570,18 +570,16 @@ interface mixin GPUObjectBase {
 };
 </script>
 
-<div algorithm>
-    <div data-timeline=content>
-        To <dfn abstract-op>create a new WebGPU object</dfn>({{GPUObjectBase}} |parent|,
-        interface |T|, {{GPUObjectDescriptorBase}} |descriptor|)
-        (where |T| extends {{GPUObjectBase}}):
+<div algorithm data-timeline=content>
+    To <dfn abstract-op>create a new WebGPU object</dfn>({{GPUObjectBase}} |parent|,
+    interface |T|, {{GPUObjectDescriptorBase}} |descriptor|)
+    (where |T| extends {{GPUObjectBase}}) run the following steps on the [=content timeline=]:
 
-        1. Let |device| be |parent|.{{GPUObjectBase/[[device]]}}.
-        1. Let |object| be a new instance of |T|.
-        1. Set |object|.{{GPUObjectBase/[[device]]}} to |device|.
-        1. Set |object|.{{GPUObjectBase/label}} to |descriptor|.{{GPUObjectDescriptorBase/label}}.
-        1. Return |object|.
-    </div>
+    1. Let |device| be |parent|.{{GPUObjectBase/[[device]]}}.
+    1. Let |object| be a new instance of |T|.
+    1. Set |object|.{{GPUObjectBase/[[device]]}} to |device|.
+    1. Set |object|.{{GPUObjectBase/label}} to |descriptor|.{{GPUObjectDescriptorBase/label}}.
+    1. Return |object|.
 </div>
 
 {{GPUObjectBase}} has the following [=immutable properties=]:
@@ -702,9 +700,11 @@ like buffer state "[=GPUBuffer/[[internal state]]/destroyed=]".
 [=Internal objects=] of some types *can* become [=invalid=] after they are created; specifically,
 [=devices=], [=adapters=], {{GPUCommandBuffer}}s, and command/pass/bundle encoders.
 
-<div algorithm>
+<div algorithm data-timeline=device>
     A given {{GPUObjectBase}} |object| is <dfn abstract-op>valid to use with</dfn>
-    a |targetObject| if and only if the following requirements are met:
+    a |targetObject| if and only if the following requirements are met.
+
+    [=Device timeline=] steps:
 
     <div class=validusage>
         - |object| must be [=valid=].
@@ -731,13 +731,13 @@ Several operations in WebGPU return promises.
 WebGPU does not make any guarantees about the order in which these promises settle
 (resolve or reject), except for the following:
 
-- <div algorithm="onSubmittedWorkDone ordering">
+- <div algorithm="onSubmittedWorkDone ordering" data-timeline=content>
         For some {{GPUQueue}} |q|,
         if |p1| = |q|.{{GPUQueue/onSubmittedWorkDone()}} is called before
         |p2| = |q|.{{GPUQueue/onSubmittedWorkDone()}},
         then |p1| must settle before |p2|.
     </div>
-- <div algorithm="mapAsync-onSubmittedWorkDone ordering">
+- <div algorithm="mapAsync-onSubmittedWorkDone ordering" data-timeline=content>
         For some {{GPUQueue}} |q| and {{GPUBuffer}} |b| on the same {{GPUDevice}},
         if |p1| = |b|.{{GPUBuffer/mapAsync()}} is called before
         |p2| = |q|.{{GPUQueue/onSubmittedWorkDone()}},
@@ -1153,9 +1153,9 @@ A [=device=] has the following internal slots:
         No [=limit/better=] limits can be used, even if the underlying [=adapter=] can support them.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     When <dfn dfn>a new device</dfn> |device| is created from [=adapter=] |adapter|
-    with {{GPUDeviceDescriptor}} |descriptor|:
+    with {{GPUDeviceDescriptor}} |descriptor| run the following steps on the [=device timeline=]:
 
     - Set |device|.{{device/[[adapter]]}} to |adapter|.
 
@@ -1185,7 +1185,7 @@ API tries to behave like nothing is wrong to avoid interrupting the runtime flow
 no validation errors are raised, most promises resolve normally, etc.
 
 <div algorithm data-timeline=device>
-    To <dfn dfn>lose the device</dfn>(|device|, |reason|):
+    To <dfn dfn>lose the device</dfn>(|device|, |reason|) run the following steps on the [=device timeline=]:
 
     1. Make |device| [=invalid=].
     1. Let |gpuDevice| be the [=content timeline=] {{GPUDevice}} corresponding to |device|.
@@ -1682,9 +1682,9 @@ interface GPUAdapterInfo {
         other fields when possible.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=content>
     To create a <dfn abstract-op>new adapter info</dfn> for a given [=adapter=] |adapter|, run the
-    following steps:
+    following steps on the [=content timeline=]:
 
     1. Let |adapterInfo| be a new {{GPUAdapterInfo}}.
 
@@ -1713,7 +1713,7 @@ interface GPUAdapterInfo {
     1. Return |adapterInfo|.
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=content>
     A <dfn>normalized identifier string</dfn> is one that follows the following pattern:
 
     `[a-z0-9]+(-[a-z0-9]+)*`
@@ -1771,9 +1771,9 @@ For more information on issuing CORS requests for image and video elements, cons
 WebGPU defines a new [=task source=] called the <dfn dfn>WebGPU task source</dfn>.
 It is used for the {{GPUDevice/uncapturederror}} event and {{GPUDevice}}.{{GPUDevice/lost}}.
 
-<div algorithm>
+<div algorithm data-timeline=content>
     To <dfn abstract-op>queue a global task for {{GPUDevice}}</dfn> |device|,
-    with a series of steps |steps|:
+    with a series of steps |steps| on the [=content timeline=]:
 
     1. [=Queue a global task=] on the [=WebGPU task source=], with the global object that was used
         to create |device|, and the steps |steps|.
@@ -1788,9 +1788,9 @@ It is used for the automatic, timed expiry (destruction) of certain objects:
 - {{GPUTexture}}s returned by {{GPUCanvasContext/getCurrentTexture()}}
 - {{GPUExternalTexture}}s created from {{HTMLVideoElement}}s
 
-<div algorithm>
+<div algorithm data-timeline=content>
     To <dfn abstract-op>queue an automatic expiry task</dfn>
-    with {{GPUDevice}} |device| and a series of steps |steps|:
+    with {{GPUDevice}} |device| and a series of steps |steps| on the [=content timeline=]:
 
     1. [=Queue a global task=] on the [=automatic expiry task source=], with the global object that
         was used to create |device|, and the steps |steps|.
@@ -1885,7 +1885,7 @@ them to WGSL values (`bool`, `i32`, `u32`, `f32`, `f16`).
 
 <div algorithm data-timeline=device>
     To convert an IDL value |idlValue| of type {{double}} or {{float}} <dfn abstract-op>to WGSL type</dfn> |T|,
-    possibly throwing a {{TypeError}}:
+    possibly throwing a {{TypeError}}, run the following steps on the [=device timeline=]:
 
     Note: This {{TypeError}} is generated in the [=device timeline=] and never surfaced to JavaScript.
 
@@ -1936,7 +1936,7 @@ them to WGSL values (`bool`, `i32`, `u32`, `f32`, `f16`).
 
 <div algorithm data-timeline=device>
     To convert a {{GPUColor}} |color| <dfn abstract-op>to a texel value of texture format</dfn> |format|,
-    possibly throwing a {{TypeError}}:
+    possibly throwing a {{TypeError}}, run the following steps on the [=device timeline=]:
 
     Note: This {{TypeError}} is generated in the [=device timeline=] and never surfaced to JavaScript.
 
@@ -2876,9 +2876,9 @@ enum GPUBufferMapState {
                 They are tracked so they can be detached when {{GPUBuffer/unmap()}} is called.
         </dl>
 
-        <div algorithm>
+        <div algorithm data-timeline=content>
             To <dfn abstract-op for="">initialize an active buffer mapping</dfn> with mode |mode| and
-            range |range|:
+            range |range|, run the following steps on the [=content timeline=]:
 
             1. Let |size| be |range|[1] - |range|[0].
             1. Let |data| be [=?=] [$CreateByteDataBlock$](|size|).
@@ -3630,7 +3630,7 @@ GPUTexture includes GPUObjectBase;
         and its underlying memory can be freed.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>compute render extent</dfn>(baseSize, mipLevel)
 
     **Arguments:**
@@ -3639,6 +3639,8 @@ GPUTexture includes GPUObjectBase;
     - {{GPUSize32}} |mipLevel|
 
     **Returns:** {{GPUExtent3DDict}}
+
+    [=Device timeline=] steps:
 
     1. Let |extent| be a new {{GPUExtent3DDict}} object.
     1. Set |extent|.{{GPUExtent3DDict/width}} to max(1, |baseSize|.[=GPUExtent3D/width=] &Gt; |mipLevel|).
@@ -3659,6 +3661,8 @@ The <dfn dfn>logical miplevel-specific texture extent</dfn> of a [=texture=] is 
     - {{GPUSize32}} |mipLevel|
 
     **Returns:** {{GPUExtent3DDict}}
+
+    [=Device timeline=] steps:
 
     1. Let |extent| be a new {{GPUExtent3DDict}} object.
     1. If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
@@ -3792,7 +3796,7 @@ dictionary GPUTextureDescriptor
 
         Formats in this list must be [=texture view format compatible=] with the texture format.
 
-        <div algorithm>
+        <div algorithm data-timeline=device>
             Two {{GPUTextureFormat}}s |format| and |viewFormat| are <dfn dfn for="">texture view format compatible</dfn> if:
 
             - |format| equals |viewFormat|, or
@@ -3875,12 +3879,12 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
 </dl>
 
 <div algorithm>
-    <dfn abstract-op>maximum mipLevel count</dfn>(dimension, size)
+    <dfn abstract-op>maximum mipLevel count</dfn>(|dimension|, |size|)
 
     **Arguments:**
 
-    - {{GPUTextureDescriptor/dimension}} |dimension|
-    - {{GPUTextureDescriptor/size}} |size|
+    - {{GPUTextureDimension}} |dimension|
+    - {{GPUTextureDimension}} |size|
 
     1. Calculate the max dimension value |m|:
         - If |dimension| is:
@@ -3952,70 +3956,79 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
         </div>
 </dl>
 
-<div algorithm class=validusage>
-    <dfn abstract-op>validating GPUTextureDescriptor</dfn>({{GPUDevice}} |this|, {{GPUTextureDescriptor}} |descriptor|):
+<div algorithm data-timeline=device>
+    <dfn abstract-op>validating GPUTextureDescriptor</dfn>(|this|, |descriptor|):
 
-    Return `true` if all of the following requirements are met, and `false` otherwise:
+    **Arguments:**
 
-    - |this| must be a [=valid=] {{GPUDevice}}.
-    - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
-    - |descriptor|.{{GPUTextureDescriptor/usage}} must contain only bits present in |this|'s [=allowed texture usages=].
-    - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=],
-        |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=],
-        and |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be &gt; zero.
-    - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be &gt; zero.
-    - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be either 1 or 4.
-    - If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
+    - {{GPUDevice}} |this|
+    - {{GPUTextureDescriptor}} |descriptor|
 
-        <dl class=switch>
-            : {{GPUTextureDimension/"1d"}}
-            ::
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be &le;
-                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension1D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be 1.
+    [=Device timeline=] steps:
+
+    1. Return `true` if all of the following requirements are met, and `false` otherwise:
+
+        <div class=validusage>
+            - |this| must be a [=valid=] {{GPUDevice}}.
+            - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
+            - |descriptor|.{{GPUTextureDescriptor/usage}} must contain only bits present in |this|'s [=allowed texture usages=].
+            - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=],
+                |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=],
+                and |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be &gt; zero.
+            - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be &gt; zero.
+            - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be either 1 or 4.
+            - If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
+
+                <dl class=switch>
+                    : {{GPUTextureDimension/"1d"}}
+                    ::
+                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be &le;
+                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension1D}}.
+                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be 1.
+                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be 1.
+                        - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
+
+                    : {{GPUTextureDimension/"2d"}}
+                    ::
+                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be &le;
+                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be &le;
+                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be &le;
+                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureArrayLayers}}.
+
+                    : {{GPUTextureDimension/"3d"}}
+                    ::
+                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be &le;
+                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be &le;
+                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be &le;
+                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                        - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
+                </dl>
+            - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be multiple of [=texel block width=].
+            - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be multiple of [=texel block height=].
+            - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
+                - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
                 - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be 1.
-                - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
-
-            : {{GPUTextureDimension/"2d"}}
-            ::
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be &le;
-                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be &le;
-                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be &le;
-                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureArrayLayers}}.
-
-            : {{GPUTextureDimension/"3d"}}
-            ::
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be &le;
-                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be &le;
-                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be &le;
-                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
-        </dl>
-    - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be multiple of [=texel block width=].
-    - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be multiple of [=texel block height=].
-    - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
-        - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
-        - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be 1.
-        - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE_BINDING}} bit.
-        - |descriptor|.{{GPUTextureDescriptor/usage}} must include the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit.
-        - |descriptor|.{{GPUTextureDescriptor/format}} must support multisampling according to [[#texture-format-caps]].
-    - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be &le;
-        [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).
-    - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
-        - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
-        - |descriptor|.{{GPUTextureDescriptor/dimension}} must be either {{GPUTextureDimension/"2d"}} or {{GPUTextureDimension/"3d"}}.
-    - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit:
-        - |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
-            with {{GPUTextureUsage/STORAGE_BINDING}} capability for the appropriate access mode.
-    - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
-        |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
-        [=texture view format compatible=].
+                - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE_BINDING}} bit.
+                - |descriptor|.{{GPUTextureDescriptor/usage}} must include the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit.
+                - |descriptor|.{{GPUTextureDescriptor/format}} must support multisampling according to [[#texture-format-caps]].
+            - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be &le;
+                [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).
+            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
+                - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
+                - |descriptor|.{{GPUTextureDescriptor/dimension}} must be either {{GPUTextureDimension/"2d"}} or {{GPUTextureDimension/"3d"}}.
+            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit:
+                - |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
+                    with {{GPUTextureUsage/STORAGE_BINDING}} capability for the appropriate access mode.
+            - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
+                |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
+                [=texture view format compatible=].
+        </div>
 </div>
 
 
@@ -4390,9 +4403,9 @@ enum GPUTextureAspect {
         </div>
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     When <dfn abstract-op>resolving GPUTextureViewDescriptor defaults</dfn> for {{GPUTextureView}}
-    |texture| with a {{GPUTextureViewDescriptor}} |descriptor| run the following steps:
+    |texture| with a {{GPUTextureViewDescriptor}} |descriptor| run the following steps on the [=device timeline=]:
 
     1. Let |resolved| be a copy of |descriptor|.
     1. If |resolved|.{{GPUTextureViewDescriptor/format}} is not [=map/exist|provided=]:
@@ -4687,9 +4700,9 @@ the behavior the same as when the format is unknown to the implementation.
 
 See [[#texture-format-caps]] for information about which {{GPUTextureFormat}}s require features.
 
-<div algorithm>
-    <dfn abstract-op>Validate texture format required features</dfn> of a {{GPUTextureFormat}}
-    |format| with logical [=device=] |device| by running the following steps:
+<div algorithm class=validusage data-timeline=content>
+    <dfn abstract-op>Validate texture format required features</dfn> of a {{GPUTextureFormat}} |format|<br/>
+    with logical [=device=] |device| by running the following steps on the [=content timeline=]:
 
     1. If |format| requires a feature and |device|.{{device/[[features]]}} does not [=list/contain=]
         the feature:
@@ -5436,11 +5449,13 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td>[=internal usage/constant=]
 </table>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     The [=list=] of {{GPUBindGroupLayoutEntry}} values |entries|
     <dfn>exceeds the binding slot limits</dfn> of [=supported limits=] |limits|
     if the number of slots used toward a limit exceeds the supported value in |limits|.
     Each entry may use multiple slots toward multiple limits.
+
+    [=Device timeline=] steps:
 
     1. For each |entry| in |entries|, if:
 
@@ -5727,13 +5742,16 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
 ### Compatibility ### {#bind-group-compatibility}
 
-<div algorithm>
+<div algorithm data-timeline=device>
 Two {{GPUBindGroupLayout}} objects |a| and |b| are considered <dfn dfn>group-equivalent</dfn>
 if and only if all of the following conditions are satisfied:
-    - |a|.{{GPUBindGroupLayout/[[exclusivePipeline]]}} == |b|.{{GPUBindGroupLayout/[[exclusivePipeline]]}}.
-    - for any binding number |binding|, one of the following conditions is satisfied:
-        - it's missing from both |a|.{{GPUBindGroupLayout/[[entryMap]]}} and |b|.{{GPUBindGroupLayout/[[entryMap]]}}.
-        - |a|.{{GPUBindGroupLayout/[[entryMap]]}}[|binding|] == |b|.{{GPUBindGroupLayout/[[entryMap]]}}[|binding|]
+
+    <div class=validusage>
+        - |a|.{{GPUBindGroupLayout/[[exclusivePipeline]]}} == |b|.{{GPUBindGroupLayout/[[exclusivePipeline]]}}.
+        - for any binding number |binding|, one of the following conditions is satisfied:
+            - it's missing from both |a|.{{GPUBindGroupLayout/[[entryMap]]}} and |b|.{{GPUBindGroupLayout/[[entryMap]]}}.
+            - |a|.{{GPUBindGroupLayout/[[entryMap]]}}[|binding|] == |b|.{{GPUBindGroupLayout/[[entryMap]]}}[|binding|]
+    </div>
 </div>
 
 If bind groups layouts are [=group-equivalent=] they can be interchangeably used in all contents.
@@ -5769,7 +5787,7 @@ A {{GPUBindGroup}} object has the following internal slots:
         associated with lists of the [=internal usage=] flags.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     The <dfn for=GPUBindGroup>bound buffer ranges</dfn> of a {{GPUBindGroup}} |bindGroup|,
     given [=list=]&lt;GPUBufferDynamicOffset&gt; |dynamicOffsets|, are computed as follows:
 
@@ -6016,14 +6034,21 @@ following members:
         </div>
 </dl>
 
-<div algorithm>
-    <dfn abstract-op>effective buffer binding size</dfn>(binding)
-        1. If |binding|.{{GPUBufferBinding/size}} is not [=map/exist|provided=]:
-            1. Return max(0, |binding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/size}} - |binding|.{{GPUBufferBinding/offset}});
-        1. Return |binding|.{{GPUBufferBinding/size}}.
+<div algorithm data-timeline=device>
+    <dfn abstract-op>effective buffer binding size</dfn>(|binding|)
+
+    **Arguments:**
+
+    - {{GPUBufferBinding}} |binding|
+
+    **Returns:** {{GPUSize64}}
+
+    1. If |binding|.{{GPUBufferBinding/size}} is not [=map/exist|provided=]:
+        1. Return max(0, |binding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/size}} - |binding|.{{GPUBufferBinding/offset}});
+    1. Return |binding|.{{GPUBufferBinding/size}}.
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     Two {{GPUBufferBinding}} objects |a| and |b| are considered <dfn dfn>buffer-binding-aliasing</dfn> if and only if all of the following are true:
 
     - |a|.{{GPUBufferBinding/buffer}} == |b|.{{GPUBufferBinding/buffer}}
@@ -6659,10 +6684,14 @@ enum GPUPipelineErrorReason {
     : <dfn>constructor()</dfn>
     ::
         <div algorithm="GPUPipelineError constructor">
+            **Arguments:**
+
             <pre class=argumentdef for="GPUPipelineError/constructor()">
                 |message|: Error message of the base {{DOMException}}.
                 |options|: Options specific to {{GPUPipelineError}}.
             </pre>
+
+            [=Content timeline=] steps:
 
             1. Set [=this=].[=DOMException/name=] to `"GPUPipelineError"`.
             1. Set [=this=].[=DOMException/message=] to |message|.
@@ -6778,8 +6807,8 @@ interface mixin GPUPipelineBase {
                     |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}[|index|].
 
                     Note: {{GPUBindGroupLayout}} is only ever used by-value, not by-reference,
-                    so this is equivalent to returning the same internal object in a new wrapper.
-                    A new {{GPUBindGroupLayout}} wrapper is returned each time to avoid a round-trip
+                    so this is equivalent to returning the same [=internal object=] with a new [=WebGPU interface=].
+                    A new {{GPUBindGroupLayout}} [=WebGPU interface=] is returned each time to avoid a round-trip
                     between the [=Content timeline=] and the [=Device timeline=].
             </div>
         </div>
@@ -6795,10 +6824,10 @@ is recommended in most cases. Bind groups created from default layouts cannot be
 pipelines, and the structure of the default layout may change when altering shaders, causing
 unexpected bind group creation errors.
 
-<div algorithm="default pipeline layout creation">
+<div algorithm="default pipeline layout creation" data-timeline=device>
 
 To create a <dfn abstract-op>default pipeline layout</dfn> for {{GPUPipelineBase}} |pipeline|,
-run the following steps:
+run the following steps on the [=device timeline=]:
 
     1. Let |groupCount| be 0.
     1. Let |groupDescs| be a sequence of |device|.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}
@@ -7049,9 +7078,9 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         </div>
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     To <dfn abstract-op>get the entry point</dfn>({{GPUShaderStage}} |stage|,
-    {{GPUProgrammableStage}} |descriptor|)
+    {{GPUProgrammableStage}} |descriptor|) run the following steps on the [=device timeline=]:
 
     1. If |descriptor|.{{GPUProgrammableStage/entryPoint}} is [=map/exists|provided=]:
 
@@ -7710,39 +7739,43 @@ dictionary GPURenderPipelineDescriptor
     - {{GPUPipelineLayout}} |layout|
     - {{GPUDevice}} |device|
 
-    Return `true` if all of the following conditions are satisfied:
+    [=Device timeline=] steps:
 
-    - [$validating GPUVertexState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/vertex}}, |layout|) succeeds.
-    - If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is [=map/exist|provided=]:
-        - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}}, |layout|) succeeds.
-        - If the [=builtin/sample_mask=] builtin is a [=shader stage output=] of
-            |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
-            - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
-        - If the [=builtin/frag_depth=] builtin is a [=shader stage output=] of
-            |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
-            - |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} must be
-                [=map/exist|provided=], and
-                |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.{{GPUDepthStencilState/format}}
-                must have a [=aspect/depth=] aspect.
-    - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|) succeeds.
-    - If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is [=map/exist|provided=]:
-        - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
-    - [$validating GPUMultisampleState$](|descriptor|.{{GPURenderPipelineDescriptor/multisample}}) succeeds.
-    - If |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}}
-        is true:
-        1. |descriptor|.{{GPURenderPipelineDescriptor/fragment}} must be [=map/exist|provided=].
-        1. |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}[0]
-            must [=list/exist=] and be non-null.
-        1. |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}[0].{{GPUColorTargetState/format}}
-            must be a {{GPUTextureFormat}} which is [=blendable=] and has an alpha channel.
-    - There must exist at least one attachment, either:
-        - A non-`null` value in
-            |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}, or
-        - A |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.
-    - [$validating inter-stage interfaces$](|device|, |descriptor|) returns `true`.
+    1. Return `true` if all of the following conditions are satisfied:
+
+        <div class=validusage>
+            - [$validating GPUVertexState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/vertex}}, |layout|) succeeds.
+            - If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is [=map/exist|provided=]:
+                - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}}, |layout|) succeeds.
+                - If the [=builtin/sample_mask=] builtin is a [=shader stage output=] of
+                    |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+                    - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
+                - If the [=builtin/frag_depth=] builtin is a [=shader stage output=] of
+                    |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+                    - |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} must be
+                        [=map/exist|provided=], and
+                        |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.{{GPUDepthStencilState/format}}
+                        must have a [=aspect/depth=] aspect.
+            - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|) succeeds.
+            - If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is [=map/exist|provided=]:
+                - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
+            - [$validating GPUMultisampleState$](|descriptor|.{{GPURenderPipelineDescriptor/multisample}}) succeeds.
+            - If |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}}
+                is true:
+                1. |descriptor|.{{GPURenderPipelineDescriptor/fragment}} must be [=map/exist|provided=].
+                1. |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}[0]
+                    must [=list/exist=] and be non-null.
+                1. |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}[0].{{GPUColorTargetState/format}}
+                    must be a {{GPUTextureFormat}} which is [=blendable=] and has an alpha channel.
+            - There must exist at least one attachment, either:
+                - A non-`null` value in
+                    |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}, or
+                - A |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.
+            - [$validating inter-stage interfaces$](|device|, |descriptor|) returns `true`.
+        </div>
 </div>
 
-<div algorithm>
+<div algorithm class=validusage data-timeline=device>
     <dfn abstract-op>validating inter-stage interfaces</dfn>(|device|, |descriptor|)
 
     **Arguments:**
@@ -7751,6 +7784,8 @@ dictionary GPURenderPipelineDescriptor
     - {{GPURenderPipelineDescriptor}} |descriptor|
 
     **Returns:** {{boolean}}
+
+    [=Device timeline=] steps:
 
     1. Let |maxVertexShaderOutputComponents| be
         |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
@@ -7873,20 +7908,24 @@ constructs and rasterizes primitives from its vertex inputs:
         Requires the {{GPUFeatureName/"depth-clip-control"}} feature to be enabled.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>validating GPUPrimitiveState</dfn>(|descriptor|, |device|)
         **Arguments:**
 
         - {{GPUPrimitiveState}} |descriptor|
         - {{GPUDevice}} |device|
 
-        Return `true` if all of the following conditions are satisfied:
+        [=Device timeline=] steps:
 
-        - If |descriptor|.{{GPUPrimitiveState/topology}} is not
-            {{GPUPrimitiveTopology/"line-strip"}} or {{GPUPrimitiveTopology/"triangle-strip"}}:
-            - |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} must not be [=map/exist|provided=].
-        - If |descriptor|.{{GPUPrimitiveState/unclippedDepth}} is `true`:
-            - {{GPUFeatureName/"depth-clip-control"}} must be [=enabled for=] |device|.
+        1. Return `true` if all of the following conditions are satisfied:
+
+            <div class=validusage>
+                - If |descriptor|.{{GPUPrimitiveState/topology}} is not
+                    {{GPUPrimitiveTopology/"line-strip"}} or {{GPUPrimitiveTopology/"triangle-strip"}}:
+                    - |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} must not be [=map/exist|provided=].
+                - If |descriptor|.{{GPUPrimitiveState/unclippedDepth}} is `true`:
+                    - {{GPUFeatureName/"depth-clip-control"}} must be [=enabled for=] |device|.
+            </div>
 </div>
 
 <script type=idl>
@@ -8006,15 +8045,20 @@ interacts with a render pass's multisampled attachments.
         coverage mask.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>validating GPUMultisampleState</dfn>(|descriptor|)
         **Arguments:**
 
         - {{GPUMultisampleState}} |descriptor|
 
-        Return `true` if all of the following conditions are satisfied:
-            - If |descriptor|.{{GPUMultisampleState/alphaToCoverageEnabled}} is `true`:
-                - |descriptor|.{{GPUMultisampleState/count}} &gt; 1.
+        [=Device timeline=] steps:
+
+        1. Return `true` if all of the following conditions are satisfied:
+
+            <div class=validusage>
+                - If |descriptor|.{{GPUMultisampleState/alphaToCoverageEnabled}} is `true`:
+                    - |descriptor|.{{GPUMultisampleState/count}} &gt; 1.
+            </div>
 </div>
 
 ### Fragment State ### {#fragment-state}
@@ -8033,7 +8077,7 @@ dictionary GPUFragmentState
         this pipeline writes to.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>validating GPUFragmentState</dfn>(|device|, |descriptor|, |layout|)
 
     **Arguments:**
@@ -8042,54 +8086,65 @@ dictionary GPUFragmentState
     - {{GPUFragmentState}} |descriptor|
     - {{GPUPipelineLayout}} |layout|
 
-    Return `true` if all of the following requirements are met:
+    [=Device timeline=] steps:
 
-    - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}}, |descriptor|, |layout|) succeeds.
-    - |descriptor|.{{GPUFragmentState/targets}}.length must be &le;
-        |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
-    - [=list/For each=] |index| of the [=list/indices=] of |descriptor|.{{GPUFragmentState/targets}}
-        containing a non-`null` value |colorState|:
-        - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
-            with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
-        - If |colorState|.{{GPUColorTargetState/blend}} is [=map/exist|provided=]:
-            - The |colorState|.{{GPUColorTargetState/format}} must be [=blendable=].
-            - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}
-                must be a [=valid GPUBlendComponent=].
-            - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}
-                must be a [=valid GPUBlendComponent=].
-        - |colorState|.{{GPUColorTargetState/writeMask}} must be &lt; 16.
-        - If [$get the entry point$]({{GPUShaderStage/FRAGMENT}}, |descriptor|) has a
-            [=shader stage output=] value |output| with [=location=] attribute equal to |index|:
+    1. Return `true` if all of the following requirements are met:
 
-            - For each component in |colorState|.{{GPUColorTargetState/format}}, there must be a
-                corresponding component in |output|.
-                (That is, RGBA requires vec4, RGB requires vec3 or vec4, RG requires vec2 or vec3 or vec4.)
-            - If the {{GPUTextureSampleType}}s for |colorState|.{{GPUColorTargetState/format}}
-                (defined in [[#texture-format-caps]]) are:
+        <div class=validusage>
+            - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}}, |descriptor|, |layout|) succeeds.
+            - |descriptor|.{{GPUFragmentState/targets}}.length must be &le;
+                |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
+            - [=list/For each=] |index| of the [=list/indices=] of |descriptor|.{{GPUFragmentState/targets}}
+                containing a non-`null` value |colorState|:
+                - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
+                    with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
+                - If |colorState|.{{GPUColorTargetState/blend}} is [=map/exist|provided=]:
+                    - The |colorState|.{{GPUColorTargetState/format}} must be [=blendable=].
+                    - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}
+                        must be a [=valid GPUBlendComponent=].
+                    - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}
+                        must be a [=valid GPUBlendComponent=].
+                - |colorState|.{{GPUColorTargetState/writeMask}} must be &lt; 16.
+                - If [$get the entry point$]({{GPUShaderStage/FRAGMENT}}, |descriptor|) has a
+                    [=shader stage output=] value |output| with [=location=] attribute equal to |index|:
 
-                <dl class=switch>
-                    : {{GPUTextureSampleType/"float"}} and/or {{GPUTextureSampleType/"unfilterable-float"}}
-                    :: |output| must have a floating-point scalar type.
-                    : {{GPUTextureSampleType/"sint"}}
-                    :: |output| must have a signed integer scalar type.
-                    : {{GPUTextureSampleType/"uint"}}
-                    :: |output| must have an unsigned integer scalar type.
-                </dl>
-            - If |colorState|.{{GPUColorTargetState/blend}} is [=map/exist|provided=] and
-                |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}.{{GPUBlendComponent/srcFactor}}
-                or .{{GPUBlendComponent/dstFactor}} uses the source alpha
-                (is any of {{GPUBlendFactor/"src-alpha"}}, {{GPUBlendFactor/"one-minus-src-alpha"}},
-                or {{GPUBlendFactor/"src-alpha-saturated"}}), then:
-                - |output| must have an alpha channel (that is, it must be a vec4).
+                    - For each component in |colorState|.{{GPUColorTargetState/format}}, there must be a
+                        corresponding component in |output|.
+                        (That is, RGBA requires vec4, RGB requires vec3 or vec4, RG requires vec2 or vec3 or vec4.)
+                    - If the {{GPUTextureSampleType}}s for |colorState|.{{GPUColorTargetState/format}}
+                        (defined in [[#texture-format-caps]]) are:
 
-            Otherwise, since there is no shader output for the attachment:
+                        <dl class=switch>
+                            : {{GPUTextureSampleType/"float"}} and/or {{GPUTextureSampleType/"unfilterable-float"}}
+                            :: |output| must have a floating-point scalar type.
+                            : {{GPUTextureSampleType/"sint"}}
+                            :: |output| must have a signed integer scalar type.
+                            : {{GPUTextureSampleType/"uint"}}
+                            :: |output| must have an unsigned integer scalar type.
+                        </dl>
+                    - If |colorState|.{{GPUColorTargetState/blend}} is [=map/exist|provided=] and
+                        |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}.{{GPUBlendComponent/srcFactor}}
+                        or .{{GPUBlendComponent/dstFactor}} uses the source alpha
+                        (is any of {{GPUBlendFactor/"src-alpha"}}, {{GPUBlendFactor/"one-minus-src-alpha"}},
+                        or {{GPUBlendFactor/"src-alpha-saturated"}}), then:
+                        - |output| must have an alpha channel (that is, it must be a vec4).
 
-            - |colorState|.{{GPUColorTargetState/writeMask}} must be 0.
-    - [$Validating GPUFragmentState's color attachment bytes per sample$](|device|, |descriptor|.{{GPUFragmentState/targets}}) succeeds.
+                    Otherwise, since there is no shader output for the attachment:
+
+                    - |colorState|.{{GPUColorTargetState/writeMask}} must be 0.
+            - [$Validating GPUFragmentState's color attachment bytes per sample$](|device|, |descriptor|.{{GPUFragmentState/targets}}) succeeds.
+        </div>
 </div>
 
-<div algorithm>
-    <dfn abstract-op>Validating GPUFragmentState's color attachment bytes per sample</dfn>({{GPUDevice}} |device|, [=sequence=]&lt;{{GPUColorTargetState}}?&gt; |targets|)
+<div algorithm class=validusage data-timeline=device>
+    <dfn abstract-op>Validating GPUFragmentState's color attachment bytes per sample</dfn>(|device|, |targets|)
+
+    **Arguments:**
+
+    - {{GPUDevice}} |device|
+    - [=sequence=]&lt;{{GPUColorTargetState}}?&gt; |targets|
+
+    [=Device timeline=] steps:
 
     1. Let |formats| be an empty [=list=]&lt;{{GPUTextureFormat}}?&gt;
     1. For each |target| in |targets|:
@@ -8102,13 +8157,16 @@ Note:
 The fragment shader may output more values than what the pipeline uses. If that is the case
 the values are ignored.
 
-<div algorithm>
-    |component| is a <dfn>valid GPUBlendComponent</dfn> if it meets the following requirements:
+<div algorithm data-timeline=device>
+    {{GPUBlendComponent}} |component| is a <dfn>valid GPUBlendComponent</dfn> if it meets<br/>
+    the following requirements:
 
-    - If |component|.{{GPUBlendComponent/operation}} is
-        {{GPUBlendOperation/"min"}} or {{GPUBlendOperation/"max"}}:
-        - |component|.{{GPUBlendComponent/srcFactor}} and
-            |component|.{{GPUBlendComponent/dstFactor}} must both be {{GPUBlendFactor/"one"}}.
+    <div class=validusage>
+        - If |component|.{{GPUBlendComponent/operation}} is
+            {{GPUBlendOperation/"min"}} or {{GPUBlendOperation/"max"}}:
+            - |component|.{{GPUBlendComponent/srcFactor}} and
+                |component|.{{GPUBlendComponent/dstFactor}} must both be {{GPUBlendFactor/"one"}}.
+    </div>
 </div>
 
 ### Color Target State ### {#color-target-state}
@@ -8419,31 +8477,35 @@ will affect a render pass's {{GPURenderPassDescriptor/depthStencilAttachment}}:
         1. Set the fragment depth value to <code>fragment depth value + |bias|</code>
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>validating GPUDepthStencilState</dfn>(|descriptor|)
 
     **Arguments:**
 
     - {{GPUDepthStencilState}} |descriptor|
 
-    Return `true` if, and only if, all of the following conditions are satisfied:
+    [=Device timeline=] steps:
 
-    - |descriptor|.{{GPUDepthStencilState/format}} is a [=depth-or-stencil format=].
-    - If |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true` or
-        |descriptor|.{{GPUDepthStencilState/depthCompare}} is [=map/exist|provided=] and not
-        {{GPUCompareFunction/"always"}}:
-        - |descriptor|.{{GPUDepthStencilState/format}} must have a depth component.
-    - If |descriptor|.{{GPUDepthStencilState/stencilFront}} or
-            |descriptor|.{{GPUDepthStencilState/stencilBack}} are not the default values:
-            - |descriptor|.{{GPUDepthStencilState/format}} must have a stencil component.
-    - If |descriptor|.{{GPUDepthStencilState/format}} has a depth component:
-        - |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} must be [=map/exist|provided=].
-        - |descriptor|.{{GPUDepthStencilState/depthCompare}} must be [=map/exist|provided=] if:
-            - |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true`, or
-            - |descriptor|.{{GPUDepthStencilState/stencilFront}}.{{GPUStencilFaceState/depthFailOp}}
-                is not {{GPUStencilOperation/"keep"}}, or
-            - |descriptor|.{{GPUDepthStencilState/stencilBack}}.{{GPUStencilFaceState/depthFailOp}}
-                is not {{GPUStencilOperation/"keep"}}.
+    1. Return `true` if, and only if, all of the following conditions are satisfied:
+
+        <div class=validusage>
+            - |descriptor|.{{GPUDepthStencilState/format}} is a [=depth-or-stencil format=].
+            - If |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true` or
+                |descriptor|.{{GPUDepthStencilState/depthCompare}} is [=map/exist|provided=] and not
+                {{GPUCompareFunction/"always"}}:
+                - |descriptor|.{{GPUDepthStencilState/format}} must have a depth component.
+            - If |descriptor|.{{GPUDepthStencilState/stencilFront}} or
+                    |descriptor|.{{GPUDepthStencilState/stencilBack}} are not the default values:
+                    - |descriptor|.{{GPUDepthStencilState/format}} must have a stencil component.
+            - If |descriptor|.{{GPUDepthStencilState/format}} has a depth component:
+                - |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} must be [=map/exist|provided=].
+                - |descriptor|.{{GPUDepthStencilState/depthCompare}} must be [=map/exist|provided=] if:
+                    - |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true`, or
+                    - |descriptor|.{{GPUDepthStencilState/stencilFront}}.{{GPUStencilFaceState/depthFailOp}}
+                        is not {{GPUStencilOperation/"keep"}}, or
+                    - |descriptor|.{{GPUDepthStencilState/stencilBack}}.{{GPUStencilFaceState/depthFailOp}}
+                        is not {{GPUStencilOperation/"keep"}}.
+        </div>
 
 </div>
 
@@ -8991,7 +9053,7 @@ dictionary GPUVertexAttribute {
         declared in the {{GPURenderPipelineDescriptor/vertex}}.{{GPUProgrammableStage/module|module}}.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>validating GPUVertexBufferLayout</dfn>(device, descriptor, vertexStage)
 
     **Arguments:**
@@ -9000,42 +9062,46 @@ dictionary GPUVertexAttribute {
     - {{GPUVertexBufferLayout}} |descriptor|
     - {{GPUProgrammableStage}} |vertexStage|
 
-    Return `true`, if and only if, all of the following conditions are satisfied:
+    [=Device timeline=] steps:
 
-    - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} &le;
-        |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
-    - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is a multiple of 4.
-    - For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferLayout/attributes}}:
-        - If |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is zero:
-            - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
+    1. Return `true`, if and only if, all of the following conditions are satisfied:
+
+        <div class=validusage>
+            - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} &le;
                 |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
+            - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is a multiple of 4.
+            - For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferLayout/attributes}}:
+                - If |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is zero:
+                    - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
+                        |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
 
-            Otherwise:
+                    Otherwise:
 
-            - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
-                |descriptor|.{{GPUVertexBufferLayout/arrayStride}}.
-        - |attrib|.{{GPUVertexAttribute/offset}} is a multiple of the minimum of 4 and
-            sizeof(|attrib|.{{GPUVertexAttribute/format}}).
-        - |attrib|.{{GPUVertexAttribute/shaderLocation}} is &lt;
-            |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
-    - Let |entryPoint| be [$get the entry point$]({{GPUShaderStage/VERTEX}}, |vertexStage|). [=Assert=] it is not `null`.
-        For every vertex attribute |var| [=statically used=] by |entryPoint|,
-        there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayout/attributes}} for which
-        all of the following are true:
-        - The type |T| of |var| is compatible with |attrib|.{{GPUVertexAttribute/format}}'s [=vertex data type=]:
+                    - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
+                        |descriptor|.{{GPUVertexBufferLayout/arrayStride}}.
+                - |attrib|.{{GPUVertexAttribute/offset}} is a multiple of the minimum of 4 and
+                    sizeof(|attrib|.{{GPUVertexAttribute/format}}).
+                - |attrib|.{{GPUVertexAttribute/shaderLocation}} is &lt;
+                    |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
+            - Let |entryPoint| be [$get the entry point$]({{GPUShaderStage/VERTEX}}, |vertexStage|). [=Assert=] it is not `null`.
+                For every vertex attribute |var| [=statically used=] by |entryPoint|,
+                there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayout/attributes}} for which
+                all of the following are true:
+                - The type |T| of |var| is compatible with |attrib|.{{GPUVertexAttribute/format}}'s [=vertex data type=]:
 
-            <dl class=switch>
-                : "unorm", "snorm", or "float"
-                :: |T| must be `f32` or `vecN<f32>`.
-                : "uint"
-                :: |T| must be `u32` or `vecN<u32>`.
-                : "sint"
-                :: |T| must be `i32` or `vecN<i32>`.
-            </dl>
-        - The shader location is |attrib|.{{GPUVertexAttribute/shaderLocation}}.
+                    <dl class=switch>
+                        : "unorm", "snorm", or "float"
+                        :: |T| must be `f32` or `vecN<f32>`.
+                        : "uint"
+                        :: |T| must be `u32` or `vecN<u32>`.
+                        : "sint"
+                        :: |T| must be `i32` or `vecN<i32>`.
+                    </dl>
+                - The shader location is |attrib|.{{GPUVertexAttribute/shaderLocation}}.
+        </div>
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>validating GPUVertexState</dfn>(device, descriptor, layout)
 
     **Arguments:**
@@ -9044,20 +9110,24 @@ dictionary GPUVertexAttribute {
     - {{GPUVertexState}} |descriptor|
     - {{GPUPipelineLayout}} |layout|
 
-    Return `true`, if and only if, all of the following conditions are satisfied:
+    [=Device timeline=] steps:
 
-    - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}}, |descriptor|, |layout|) succeeds.
-    - |descriptor|.{{GPUVertexState/buffers}}.length is &le;
-        |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
-    - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}
-        passes [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|, |descriptor|)
-    - The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.length,
-        over every |vertexBuffer| in |descriptor|.{{GPUVertexState/buffers}},
-        is &le;
-        |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
-    - Each |attrib| in the union of all {{GPUVertexAttribute}}
-        across |descriptor|.{{GPUVertexState/buffers}} has a distinct
-        |attrib|.{{GPUVertexAttribute/shaderLocation}} value.
+    1. Return `true`, if and only if, all of the following conditions are satisfied:
+
+        <div class=validusage>
+            - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}}, |descriptor|, |layout|) succeeds.
+            - |descriptor|.{{GPUVertexState/buffers}}.length is &le;
+                |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
+            - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}
+                passes [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|, |descriptor|)
+            - The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.length,
+                over every |vertexBuffer| in |descriptor|.{{GPUVertexState/buffers}},
+                is &le;
+                |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
+            - Each |attrib| in the union of all {{GPUVertexAttribute}}
+                across |descriptor|.{{GPUVertexState/buffers}} has a distinct
+                |attrib|.{{GPUVertexAttribute/shaderLocation}} value.
+        </div>
 </div>
 
 <pre class=include>
@@ -9155,26 +9225,27 @@ The <dfn dfn>encoder state</dfn> may be one of the following:
         Any command issued in this state will [$generate a validation error$].
 </dl>
 
-<div algorithm>
-    To <dfn abstract-op>Validate the encoder state</dfn> of {{GPUCommandsMixin}} |encoder|:
+<div algorithm class=validusage data-timeline=device>
+    To <dfn abstract-op>Validate the encoder state</dfn> of {{GPUCommandsMixin}} |encoder| run the <br/>
+    following steps on the [=device timeline=]:
 
-    If |encoder|.{{GPUCommandsMixin/[[state]]}} is:
+    1. If |encoder|.{{GPUCommandsMixin/[[state]]}} is:
+        <dl class=switch>
+            : "[=encoder state/open=]"
+            :: Return `true`.
 
-    <dl class=switch>
-        : "[=encoder state/open=]"
-        :: Return `true`.
+            : "[=encoder state/locked=]"
+            :: Make |encoder| [=invalid=], and return `false`.
 
-        : "[=encoder state/locked=]"
-        :: Make |encoder| [=invalid=], and return `false`.
-
-        : "[=encoder state/ended=]"
-        :: [$Generate a validation error$], and return `false`.
-    </dl>
+            : "[=encoder state/ended=]"
+            :: [$Generate a validation error$], and return `false`.
+        </dl>
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     To <dfn abstract-op>Enqueue a command</dfn> on {{GPUCommandsMixin}} |encoder|
-    which issues the steps of a [=GPU Command=] |command|:
+    which issues the steps of a [=GPU Command=] |command|, run the following steps on the
+    [=device timeline=]:
 
         1. [=list/Append=] |command| to |encoder|.{{GPUCommandsMixin/[[commands]]}}.
         1. When |command| is executed as part of a {{GPUCommandBuffer}}:
@@ -10050,9 +10121,9 @@ It must only be included by interfaces which also include those mixins.
         </div>
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     To <dfn abstract-op>Iterate over each dynamic binding offset</dfn> in a given {{GPUBindGroup}} |bindGroup|
-    with a given list of |steps| to be executed for each dynamic offset:
+    with a given list of |steps| to be executed for each dynamic offset, run the following steps on the [=device timeline=]:
 
     1. Let |dynamicOffsetIndex| be `0`.
     1. Let |layout| be |bindGroup|.{{GPUBindGroup/[[layout]]}}.
@@ -10066,7 +10137,7 @@ It must only be included by interfaces which also include those mixins.
             1. Let |dynamicOffsetIndex| be |dynamicOffsetIndex| + `1`
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>Validate encoder bind groups</dfn>(encoder, pipeline)
 
     **Arguments:**
@@ -10075,6 +10146,8 @@ It must only be included by interfaces which also include those mixins.
     :: Encoder whose bind groups are being validated.
     : {{GPUPipelineBase}} |pipeline|
     :: Pipeline to validate |encoder|s bind groups are compatible with.
+
+    [=Device timeline=] steps:
 
     1. If any of the following conditions are unsatisfied, return `false`:
 
@@ -10097,7 +10170,7 @@ It must only be included by interfaces which also include those mixins.
     Otherwise return `true`.
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>Encoder bind groups alias a writable resource</dfn>(|encoder|, |pipeline|)
     if any writable buffer binding range overlaps with any other binding range of the same buffer,
     or any writable texture binding overlaps in [=texture subresources=] with any other texture binding
@@ -10109,6 +10182,8 @@ It must only be included by interfaces which also include those mixins.
     :: Encoder whose bind groups are being validated.
     : {{GPUPipelineBase}} |pipeline|
     :: Pipeline to validate |encoder|s bind groups are compatible with.
+
+    [=Device timeline=] steps:
 
     1. For each |stage| in [{{GPUShaderStage/VERTEX}}, {{GPUShaderStage/FRAGMENT}}, {{GPUShaderStage/COMPUTE}}]:
         1. Let |bufferBindings| be a [=list=] of ({{GPUBufferBinding}}, `boolean`) pairs,
@@ -10782,8 +10857,15 @@ dictionary GPURenderPassDescriptor
             must return true.
 </div>
 
-<div algorithm>
-    <dfn abstract-op>Validating GPURenderPassDescriptor's color attachment bytes per sample</dfn>({{GPUDevice}} |device|, [=sequence=]&lt;{{GPURenderPassColorAttachment}}?&gt; |colorAttachments|)
+<div algorithm class=validusage data-timeline=device>
+    <dfn abstract-op>Validating GPURenderPassDescriptor's color attachment bytes per sample</dfn>(|device|, |colorAttachments|)
+
+    **Arguments:**
+
+    - {{GPUDevice}} |device|
+    - [=sequence=]&lt;{{GPURenderPassColorAttachment}}?&gt; |colorAttachments|
+
+    [=Device timeline=] steps:
 
     1. Let |formats| be an empty [=list=]&lt;{{GPUTextureFormat}}?&gt;
     1. For each |colorAttachment| in |colorAttachments|:
@@ -10846,7 +10928,7 @@ dictionary GPURenderPassColorAttachment {
         after executing the render pass.
 </dl>
 
-<div class=validusage dfn-for=GPURenderPassColorAttachment data-timeline=device>
+<div dfn-for=GPURenderPassColorAttachment data-timeline=device>
     <dfn abstract-op>GPURenderPassColorAttachment Valid Usage</dfn>
 
     Given a {{GPURenderPassColorAttachment}} |this|:
@@ -10856,52 +10938,55 @@ dictionary GPURenderPassColorAttachment {
     1. Let |renderTexture| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.
     1. Let |resolveTexture| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.
 
-    The following validation rules apply:
+    1. The following validation rules apply:
+        <div class=validusage>
+            - |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}} must be a [=color renderable format=].
+            - |this|.{{GPURenderPassColorAttachment/view}} must be a [$renderable texture view$].
+            - If |renderViewDescriptor|.{{GPUTextureViewDescriptor/dimension}} is {{GPUTextureViewDimension/"3d"}}:
+                - |this|.{{GPURenderPassColorAttachment/depthSlice}} must [=map/exist|be provided=] and must
+                    be &lt; the [=GPUExtent3D/depthOrArrayLayers=] of the [=logical miplevel-specific texture extent=]
+                    of the |renderTexture| [=subresource=] at [=mipmap level=] |renderViewDescriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}.
 
-    - |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}} must be a [=color renderable format=].
-    - |this|.{{GPURenderPassColorAttachment/view}} must be a [$renderable texture view$].
-    - If |renderViewDescriptor|.{{GPUTextureViewDescriptor/dimension}} is {{GPUTextureViewDimension/"3d"}}:
-        - |this|.{{GPURenderPassColorAttachment/depthSlice}} must [=map/exist|be provided=] and must
-            be &lt; the [=GPUExtent3D/depthOrArrayLayers=] of the [=logical miplevel-specific texture extent=]
-            of the |renderTexture| [=subresource=] at [=mipmap level=] |renderViewDescriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}.
+                Otherwise:
 
-        Otherwise:
+                - |this|.{{GPURenderPassColorAttachment/depthSlice}} must not [=map/exist|be provided=].
 
-        - |this|.{{GPURenderPassColorAttachment/depthSlice}} must not [=map/exist|be provided=].
+            - If |this|.{{GPURenderPassColorAttachment/loadOp}} is {{GPULoadOp/"clear"}}:
+                - Converting the IDL value |this|.{{GPURenderPassColorAttachment/clearValue}}
+                    [$to a texel value of texture format$] |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}}
+                    must not throw a {{TypeError}}.
 
-    - If |this|.{{GPURenderPassColorAttachment/loadOp}} is {{GPULoadOp/"clear"}}:
-        - Converting the IDL value |this|.{{GPURenderPassColorAttachment/clearValue}}
-            [$to a texel value of texture format$] |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}}
-            must not throw a {{TypeError}}.
-
-            Note: An error is not thrown if the value is out-of-range for the format but in-range for
-            the corresponding WGSL primitive type (`f32`, `i32`, or `u32`).
-    - If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is [=map/exist|provided=]:
-        - |renderTexture|.{{GPUTexture/sampleCount}} must be &gt; 1.
-        - |resolveTexture|.{{GPUTexture/sampleCount}} must be 1.
-        - |this|.{{GPURenderPassColorAttachment/resolveTarget}} must be a [$renderable texture view$].
-        - |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[renderExtent]]}} and
-            |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[renderExtent]]}} must match.
-        - |resolveViewDescriptor|.{{GPUTextureViewDescriptor/format}} must equal
-            |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}}.
-        - |resolveTexture|.{{GPUTextureDescriptor/format}} must equal
-            |renderTexture|.{{GPUTextureDescriptor/format}}.
-        - |resolveViewDescriptor|.{{GPUTextureViewDescriptor/format}} must support resolve according to [[#plain-color-formats]].
+                    Note: An error is not thrown if the value is out-of-range for the format but in-range for
+                    the corresponding WGSL primitive type (`f32`, `i32`, or `u32`).
+            - If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is [=map/exist|provided=]:
+                - |renderTexture|.{{GPUTexture/sampleCount}} must be &gt; 1.
+                - |resolveTexture|.{{GPUTexture/sampleCount}} must be 1.
+                - |this|.{{GPURenderPassColorAttachment/resolveTarget}} must be a [$renderable texture view$].
+                - |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[renderExtent]]}} and
+                    |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[renderExtent]]}} must match.
+                - |resolveViewDescriptor|.{{GPUTextureViewDescriptor/format}} must equal
+                    |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}}.
+                - |resolveTexture|.{{GPUTextureDescriptor/format}} must equal
+                    |renderTexture|.{{GPUTextureDescriptor/format}}.
+                - |resolveViewDescriptor|.{{GPUTextureViewDescriptor/format}} must support resolve according to [[#plain-color-formats]].
+        </div>
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     A {{GPUTextureView}} |view| is a <dfn abstract-op>renderable texture view</dfn>
     if the following requirements are met:
 
-    - |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/usage}}
-        must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
-    - |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be either {{GPUTextureViewDimension/"2d"}} or {{GPUTextureViewDimension/"3d"}}.
-    - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
-    - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be 1.
-    - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must refer to all [=aspects=] of
-        |view|.{{GPUTextureView/[[texture]]}}.
-
-    where |descriptor| is |view|.{{GPUTextureView/[[descriptor]]}}.
+    1. Let |descriptor| be |view|.{{GPUTextureView/[[descriptor]]}}.
+    1. |view| is not renderable if any of the following conditions are unsatisfied:
+        <div class=validusage>
+            - |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/usage}}
+                must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
+            - |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be either {{GPUTextureViewDimension/"2d"}} or {{GPUTextureViewDimension/"3d"}}.
+            - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
+            - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be 1.
+            - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must refer to all [=aspects=] of
+                |view|.{{GPUTextureView/[[texture]]}}.
+        </div>
 </div>
 
 <div algorithm>
@@ -10999,7 +11084,7 @@ dictionary GPURenderPassDepthStencilAttachment {
         is read only.
 </dl>
 
-<div class=validusage dfn-for=GPURenderPassDepthStencilAttachment>
+<div class=validusage dfn-for=GPURenderPassDepthStencilAttachment data-timeline=device>
     <dfn abstract-op>GPURenderPassDepthStencilAttachment Valid Usage</dfn>
 
     Given a {{GPURenderPassDepthStencilAttachment}} |this|, the following validation
@@ -11119,7 +11204,7 @@ dictionary GPURenderPassLayout
     - Their {{GPURenderPassLayout/colorFormats}} are equal ignoring any trailing `null`s.
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>derive render targets layout from pass</dfn>
 
     **Arguments:**
@@ -11127,6 +11212,8 @@ dictionary GPURenderPassLayout
     - {{GPURenderPassDescriptor}} |descriptor|
 
     **Returns:** {{GPURenderPassLayout}}
+
+    [=Device timeline=] steps:
 
     1. Let |layout| be a new {{GPURenderPassLayout}} object.
     1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
@@ -11144,7 +11231,7 @@ dictionary GPURenderPassLayout
     1. Return |layout|.
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>derive render targets layout from pipeline</dfn>
 
     **Arguments:**
@@ -11152,6 +11239,8 @@ dictionary GPURenderPassLayout
     - {{GPURenderPipelineDescriptor}} |descriptor|
 
     **Returns:** {{GPURenderPassLayout}}
+
+    [=Device timeline=] steps:
 
     1. Let |layout| be a new {{GPURenderPassLayout}} object.
     1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}.
@@ -11306,9 +11395,10 @@ It must only be included by interfaces which also include those mixins.
         The number of draw commands recorded in this encoder.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     To <dfn abstract-op>Enqueue a render command</dfn> on {{GPURenderCommandsMixin}} |encoder| which
-    issues the steps of a [=GPU Command=] |command| with [=RenderState=] |renderState|:
+    issues the steps of a [=GPU Command=] |command| with [=RenderState=] |renderState|, run the
+    following steps on the [=device timeline=]:
 
         1. [=list/Append=] |command| to |encoder|.{{GPUCommandsMixin/[[commands]]}}.
         1. When |command| is executed as part of a {{GPUCommandBuffer}} |commandBuffer|:
@@ -11363,23 +11453,28 @@ It must only be included by interfaces which also include those mixins.
         Sets the current index buffer.
 
         <div algorithm=GPURenderCommandsMixin.setIndexBuffer>
-            **Called on:** {{GPURenderCommandsMixin}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderCommandsMixin}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderCommandsMixin/setIndexBuffer(buffer, indexFormat, offset, size)">
-                |buffer|: Buffer containing index data to use for subsequent drawing commands.
-                |indexFormat|: Format of the index data contained in |buffer|.
-                |offset|: Offset in bytes into |buffer| where the index data begins. Defaults to `0`.
-                |size|: Size in bytes of the index data in |buffer|.
-                    Defaults to the size of the buffer minus the offset.
-            </pre>
+                <pre class=argumentdef for="GPURenderCommandsMixin/setIndexBuffer(buffer, indexFormat, offset, size)">
+                    |buffer|: Buffer containing index data to use for subsequent drawing commands.
+                    |indexFormat|: Format of the index data contained in |buffer|.
+                    |offset|: Offset in bytes into |buffer| where the index data begins. Defaults to `0`.
+                    |size|: Size in bytes of the index data in |buffer|.
+                        Defaults to the size of the buffer minus the offset.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
             <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
@@ -11403,23 +11498,28 @@ It must only be included by interfaces which also include those mixins.
         Sets the current vertex buffer for the given slot.
 
         <div algorithm=GPURenderCommandsMixin.setVertexBuffer>
-            **Called on:** {{GPURenderCommandsMixin}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderCommandsMixin}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderCommandsMixin/setVertexBuffer(slot, buffer, offset, size)">
-                |slot|: The vertex buffer slot to set the vertex buffer for.
-                |buffer|: Buffer containing vertex data to use for subsequent drawing commands.
-                |offset|: Offset in bytes into |buffer| where the vertex data begins. Defaults to `0`.
-                |size|: Size in bytes of the vertex data in |buffer|.
-                    Defaults to the size of the buffer minus the offset.
-            </pre>
+                <pre class=argumentdef for="GPURenderCommandsMixin/setVertexBuffer(slot, buffer, offset, size)">
+                    |slot|: The vertex buffer slot to set the vertex buffer for.
+                    |buffer|: Buffer containing vertex data to use for subsequent drawing commands.
+                    |offset|: Offset in bytes into |buffer| where the vertex data begins. Defaults to `0`.
+                    |size|: Size in bytes of the vertex data in |buffer|.
+                        Defaults to the size of the buffer minus the offset.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
             <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Let |bufferSize| be 0 if |buffer| is `null`, or |buffer|.{{GPUBuffer/size}} if not.
                 1. If |size| is missing, set |size| to max(0, |bufferSize| - |offset|).
@@ -11455,22 +11555,27 @@ It must only be included by interfaces which also include those mixins.
         See [[#rendering-operations]] for the detailed specification.
 
         <div algorithm=GPURenderCommandsMixin.draw>
-            **Called on:** {{GPURenderCommandsMixin}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderCommandsMixin}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderCommandsMixin/draw(vertexCount, instanceCount, firstVertex, firstInstance)">
-                |vertexCount|: The number of vertices to draw.
-                |instanceCount|: The number of instances to draw.
-                |firstVertex|: Offset into the vertex buffers, in vertices, to begin drawing from.
-                |firstInstance|: First instance to draw.
-            </pre>
+                <pre class=argumentdef for="GPURenderCommandsMixin/draw(vertexCount, instanceCount, firstVertex, firstInstance)">
+                    |vertexCount|: The number of vertices to draw.
+                    |instanceCount|: The number of instances to draw.
+                    |firstVertex|: Offset into the vertex buffers, in vertices, to begin drawing from.
+                    |firstInstance|: First instance to draw.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
             <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. All of the requirements in the following steps |must| be met.
                     If any are unmet, make |this| [=invalid=] and stop.
@@ -11518,23 +11623,28 @@ It must only be included by interfaces which also include those mixins.
         See [[#rendering-operations]] for the detailed specification.
 
         <div algorithm=GPURenderCommandsMixin.drawIndexed>
-            **Called on:** {{GPURenderCommandsMixin}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderCommandsMixin}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderCommandsMixin/drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)">
-                |indexCount|: The number of indices to draw.
-                |instanceCount|: The number of instances to draw.
-                |firstIndex|: Offset into the index buffer, in indices, begin drawing from.
-                |baseVertex|: Added to each index value before indexing into the vertex buffers.
-                |firstInstance|: First instance to draw.
-            </pre>
+                <pre class=argumentdef for="GPURenderCommandsMixin/drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)">
+                    |indexCount|: The number of indices to draw.
+                    |instanceCount|: The number of instances to draw.
+                    |firstIndex|: Offset into the index buffer, in indices, begin drawing from.
+                    |baseVertex|: Added to each index value before indexing into the vertex buffers.
+                    |firstInstance|: First instance to draw.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
             <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -11598,20 +11708,25 @@ It must only be included by interfaces which also include those mixins.
         `firstInstance` is not zero the {{GPURenderCommandsMixin/drawIndirect()}} call will be treated as a no-op.
 
         <div algorithm=GPURenderCommandsMixin.drawIndirect>
-            **Called on:** {{GPURenderCommandsMixin}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderCommandsMixin}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderCommandsMixin/drawIndirect(indirectBuffer, indirectOffset)">
-                |indirectBuffer|: Buffer containing the [=indirect draw parameters=].
-                |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
-            </pre>
+                <pre class=argumentdef for="GPURenderCommandsMixin/drawIndirect(indirectBuffer, indirectOffset)">
+                    |indirectBuffer|: Buffer containing the [=indirect draw parameters=].
+                    |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
             <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -11670,20 +11785,25 @@ It must only be included by interfaces which also include those mixins.
         `firstInstance` is not zero the {{GPURenderCommandsMixin/drawIndexedIndirect()}} call will be treated as a no-op.
 
         <div algorithm=GPURenderCommandsMixin.drawIndexedIndirect>
-            **Called on:** {{GPURenderCommandsMixin}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderCommandsMixin}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderCommandsMixin/drawIndexedIndirect(indirectBuffer, indirectOffset)">
-                |indirectBuffer|: Buffer containing the [=indirect drawIndexed parameters=].
-                |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
-            </pre>
+                <pre class=argumentdef for="GPURenderCommandsMixin/drawIndexedIndirect(indirectBuffer, indirectOffset)">
+                    |indirectBuffer|: Buffer containing the [=indirect drawIndexed parameters=].
+                    |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
             <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -11723,9 +11843,9 @@ It must only be included by interfaces which also include those mixins.
         </div>
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     To determine if it's <dfn abstract-op>valid to draw</dfn> with {{GPURenderCommandsMixin}} |encoder|
-    run the following steps:
+    run the following steps on the [=device timeline=]:
 
     1. If any of the following conditions are unsatisfied, return `false`:
 
@@ -11748,9 +11868,9 @@ It must only be included by interfaces which also include those mixins.
     1. Otherwise return `true`.
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     To determine if it's <dfn abstract-op>valid to draw indexed</dfn> with {{GPURenderCommandsMixin}} |encoder|
-    run the following steps:
+    run the following steps on the [=device timeline=]:
 
     1. If any of the following conditions are unsatisfied, return `false`:
 
@@ -12891,8 +13011,8 @@ timestamps cause an application failure.
 Timestamp queries are implemented using high-resolution timers (see [[#security-timing-device]]).
 To mitigate security and privacy concerns, their precision must be reduced:
 
-<div algorithm>
-    To get the <dfn abstract-op>current queue timestamp</dfn>:
+<div algorithm data-timeline=queue>
+    To get the <dfn abstract-op>current queue timestamp</dfn> run the following steps on the [=queue timeline=]:
 
     - Let |fineTimestamp| be the current timestamp value of the current [=queue timeline=],
         in nanoseconds, relative to an implementation-defined point in the past.
@@ -12902,20 +13022,28 @@ To mitigate security and privacy concerns, their precision must be reduced:
     [=queue timeline=], `crossOriginIsolatedCapability` is never set to `true`.
 </div>
 
-<div algorithm class=validusage>
-    <dfn abstract-op>Validate timestampWrites</dfn>({{GPUDevice}} |device|,
-    <code>({{GPUComputePassTimestampWrites}} or {{GPURenderPassTimestampWrites}})</code> |timestampWrites|)
+<div algorithm data-timeline=device>
+    <dfn abstract-op>Validate timestampWrites</dfn>(|device|, |timestampWrites|)
 
-    Return `true` if the following requirements are met, and `false` if not.
+    **Arguments:**
 
-    - {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |device|.
-    - |timestampWrites|.`querySet` must be [$valid to use with$] |device|.
-    - |timestampWrites|.`querySet`.{{GPUQuerySet/type}} must be {{GPUQueryType/"timestamp"}}.
-    - Of the write index members in |timestampWrites| (`beginningOfPassWriteIndex`, `endOfPassWriteIndex`):
-        - At least one must be [=map/exist|provided=].
-        - Of those which are [=map/exist|provided=]:
-            - No two may be equal.
-            - Each must be &lt; |timestampWrites|.`querySet`.{{GPUQuerySet/count}}.
+    - {{GPUDevice}} |device|
+    - <code>({{GPUComputePassTimestampWrites}} or {{GPURenderPassTimestampWrites}})</code> |timestampWrites|
+
+    [=Device timeline=] steps:
+
+    1. Return `true` if the following requirements are met, and `false` if not:
+
+        <div class=validusage>
+            - {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |device|.
+            - |timestampWrites|.`querySet` must be [$valid to use with$] |device|.
+            - |timestampWrites|.`querySet`.{{GPUQuerySet/type}} must be {{GPUQueryType/"timestamp"}}.
+            - Of the write index members in |timestampWrites| (`beginningOfPassWriteIndex`, `endOfPassWriteIndex`):
+                - At least one must be [=map/exist|provided=].
+                - Of those which are [=map/exist|provided=]:
+                    - No two may be equal.
+                    - Each must be &lt; |timestampWrites|.`querySet`.{{GPUQuerySet/count}}.
+        </div>
 
     <!-- editorial note: any additional timestamp write locations that are compute- or
     render-specific could either be written here conditionally, or written at the call sites
@@ -12946,9 +13074,10 @@ the context creation attribute dictionary `options`, is ignored.
 Instead, use {{GPUCanvasContext/configure()|GPUCanvasContext.configure()}},
 which allows changing the canvas configuration without replacing the canvas.
 
-<div algorithm>
+<div algorithm data-timeline=content>
     To <dfn abstract-op>create a 'webgpu' context on a canvas</dfn>
-    ({{HTMLCanvasElement}} or {{OffscreenCanvas}}) |canvas|:
+    ({{HTMLCanvasElement}} or {{OffscreenCanvas}}) |canvas|, run the following
+    steps on the [=content timeline=]:
 
     1. Let |context| be a new {{GPUCanvasContext}}.
     1. Set |context|.{{GPUCanvasContext/canvas}} to |canvas|.
@@ -13176,7 +13305,7 @@ interface GPUCanvasContext {
         runs, even if that {{GPUTexture}} is destroyed, failed validation, or failed to allocate.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=content>
     To <dfn abstract-op>get a copy of the image contents of a context</dfn>:
 
     **Arguments:**
@@ -13184,6 +13313,8 @@ interface GPUCanvasContext {
     - |context|: the {{GPUCanvasContext}}
 
     **Returns:** image contents
+
+    [=Content timeline=] steps:
 
     1. Ensure that all submitted work items (e.g. queue submissions) have
         completed writing to the image (via |context|.{{GPUCanvasContext/[[currentTexture]]}}).
@@ -13210,8 +13341,9 @@ interface GPUCanvasContext {
     <!-- POSTV1(desynchronized): If a "desynchronized" option is added, explicitly describe its behavior here. -->
 </div>
 
-<div algorithm>
-    To <dfn abstract-op>Replace the drawing buffer</dfn> of a {{GPUCanvasContext}} |context|:
+<div algorithm data-timeline=content>
+    To <dfn abstract-op>Replace the drawing buffer</dfn> of a {{GPUCanvasContext}} |context|, run
+    the following steps on the [=content timeline=]:
 
     1. [$Expire the current texture$] of |context|.
     1. Let |configuration| be |context|.{{GPUCanvasContext/[[configuration]]}}.
@@ -13232,8 +13364,9 @@ interface GPUCanvasContext {
         and has the correct configuration.
 </div>
 
-<div algorithm>
-    To <dfn abstract-op>Expire the current texture</dfn> of a {{GPUCanvasContext}} |context|:
+<div algorithm data-timeline=content>
+    To <dfn abstract-op>Expire the current texture</dfn> of a {{GPUCanvasContext}} |context|, run
+    the following steps on the [=content timeline=]:
 
     1. If |context|.{{GPUCanvasContext/[[currentTexture]]}} is not `null`:
         1. Call |context|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/destroy()}}
@@ -13247,9 +13380,9 @@ interface GPUCanvasContext {
 The following algorithms "hook" into algorithms in the HTML specification, and must run at the
 specified points.
 
-<div algorithm="get the bitmap of a WebGPU canvas">
+<div algorithm="get the bitmap of a WebGPU canvas" data-timeline=content>
     When the "bitmap" is read from an {{HTMLCanvasElement}} or {{OffscreenCanvas}} with a
-    {{GPUCanvasContext}} |context|:
+    {{GPUCanvasContext}} |context|, run the following steps on the [=content timeline=]:
 
     1. Return [$get a copy of the image contents of a context|a copy of the image contents$]
         of |context|.
@@ -13273,11 +13406,11 @@ specified points.
     </div>
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=content>
     When <dfn abstract-op>updating the rendering of a WebGPU canvas</dfn>
     (an {{HTMLCanvasElement}} or an {{OffscreenCanvas}} with a [=placeholder canvas element=])
     with a {{GPUCanvasContext}} |context|, which occurs in the following sub-steps of the
-    [=event loop processing model=]:
+    [=event loop processing model=], run the following steps on the [=content timeline=]:
 
     - "update the rendering or user interface of that `Document`"
     - "update the rendering of that dedicated worker"
@@ -13301,9 +13434,10 @@ specified points.
     This does not happen for standalone {{OffscreenCanvas}}es (created by `new OffscreenCanvas()`).
 </div>
 
-<div algorithm="transferToImageBitmap from WebGPU">
+<div algorithm="transferToImageBitmap from WebGPU" data-timeline=content>
     When {{OffscreenCanvas/transferToImageBitmap()}} is called on a canvas with
-    {{GPUCanvasContext}} |context|, after creating an {{ImageBitmap}} from the canvas's bitmap:
+    {{GPUCanvasContext}} |context|, after creating an {{ImageBitmap}} from the canvas's bitmap,
+    run the following steps on the [=content timeline=]:
 
     1. [$Replace the drawing buffer$] of |context|.
 
@@ -13392,7 +13526,7 @@ dictionary GPUCanvasConfiguration {
     </pre>
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=content>
     The <dfn abstract-op>GPUTextureDescriptor for the canvas and configuration</dfn>(
     ({{HTMLCanvasElement}} or {{OffscreenCanvas}}) |canvas|,
     {{GPUCanvasConfiguration}} |configuration|)
@@ -13439,10 +13573,11 @@ Note:
 Like WebGL and 2d canvas, resizing a WebGPU canvas loses the current contents of the drawing buffer.
 In WebGPU, it does so by [$Replace the drawing buffer|replacing the drawing buffer$].
 
-<div algorithm>
+<div algorithm data-timeline=content>
     When an {{HTMLCanvasElement}} or {{OffscreenCanvas}} |canvas| with a
     {{GPUCanvasContext}} |context| has its `width` or `height` attributes set,
-    <dfn abstract-op>update the canvas size</dfn>:
+    <dfn abstract-op>update the canvas size</dfn> by running the following steps
+    on the [=content timeline=]:
 
     1. [$Replace the drawing buffer$] of |context|.
     1. Let |configuration| be |context|.{{GPUCanvasContext/[[configuration]]}}
@@ -13600,16 +13735,14 @@ satisfy all validation requirements. Validation errors are always indicative of 
 error, and is expected to fail the same way across all devices assuming the same
 {{device/[[features]]}} and {{device/[[limits]]}} are in use.
 
-<div algorithm>
+<div algorithm data-timeline=content>
     To <dfn abstract-op lt="Generate a validation error|generate a validation error|validation error">generate a
     validation error</dfn> for {{GPUDevice}} |device|, run the following steps:
 
-    <div data-timeline=content>
-        [=Content timeline=] steps:
+    [=Content timeline=] steps:
 
-        1. Let |error| be a new {{GPUValidationError}} with an appropriate error message.
-        1. [$Dispatch error$] |error| to |device|.
-    </div>
+    1. Let |error| be a new {{GPUValidationError}} with an appropriate error message.
+    1. [$Dispatch error$] |error| to |device|.
 </div>
 
 <script type=idl>
@@ -13625,16 +13758,14 @@ memory to complete the requested operation. The operation may succeed if attempt
 lower memory requirement (like using smaller texture dimensions), or if memory used by other
 resources is released first.
 
-<div algorithm>
+<div algorithm data-timeline=content>
     To <dfn abstract-op lt="Generate an out-of-memory error|generate an out-of-memory error|out-of-memory error">
     generate an out-of-memory error</dfn> for {{GPUDevice}} |device|, run the following steps:
 
-    <div data-timeline=content>
-        [=Content timeline=] steps:
+    [=Content timeline=] steps:
 
-        1. Let |error| be a new {{GPUOutOfMemoryError}} with an appropriate error message.
-        1. [$Dispatch error$] |error| to |device|.
-    </div>
+    1. Let |error| be a new {{GPUOutOfMemoryError}} with an appropriate error message.
+    1. [$Dispatch error$] |error| to |device|.
 </div>
 
 <script type=idl>
@@ -13651,16 +13782,14 @@ For example, the operation may exceed the capabilities of the implementation in 
 captured by the [=supported limits=]. The same operation may succeed on other devices or under
 difference circumstances.
 
-<div algorithm>
+<div algorithm data-timeline=content>
     To <dfn abstract-op lt="Generate an internal error|generate an internal error|internal error">generate an
     internal error</dfn> for {{GPUDevice}} |device|, run the following steps:
 
-    <div data-timeline=content>
-        [=Content timeline=] steps:
+    [=Content timeline=] steps:
 
-        1. Let |error| be a new {{GPUInternalError}} with an appropriate error message.
-        1. [$Dispatch error$] |error| to |device|.
-    </div>
+    1. Let |error| be a new {{GPUInternalError}} with an appropriate error message.
+    1. [$Dispatch error$] |error| to |device|.
 </div>
 
 ## Error Scopes ## {#error-scopes}
@@ -13718,30 +13847,28 @@ partial interface GPUDevice {
         A [=stack=] of [=GPU error scopes=] that have been pushed to the {{GPUDevice}}.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     The <dfn abstract-op>current error scope</dfn> for a {{GPUError}} |error| and {{GPUDevice}}
     |device| is determined by issuing the following steps to the [=Device timeline=] of |device|:
 
-    <div data-timeline=device>
-        [=Device timeline=] steps:
+    [=Device timeline=] steps:
 
-        1. If |error| is an instance of:
+    1. If |error| is an instance of:
 
-            <dl class=switch>
-                : {{GPUValidationError}}
-                :: Let |type| be "validation".
-                : {{GPUOutOfMemoryError}}
-                :: Let |type| be "out-of-memory".
-                : {{GPUInternalError}}
-                :: Let |type| be "internal".
-            </dl>
-        1. Let |scope| be the last [=list/item=] of |device|.{{GPUDevice/[[errorScopeStack]]}}.
-        1. While |scope| is not `undefined`:
-            1. If |scope|.{{GPU error scope/[[filter]]}} is |type|, return |scope|.
-            1. Set |scope| to the previous [=list/item=] of
-                |device|.{{GPUDevice/[[errorScopeStack]]}}.
-        1. Return `undefined`.
-    </div>
+        <dl class=switch>
+            : {{GPUValidationError}}
+            :: Let |type| be "validation".
+            : {{GPUOutOfMemoryError}}
+            :: Let |type| be "out-of-memory".
+            : {{GPUInternalError}}
+            :: Let |type| be "internal".
+        </dl>
+    1. Let |scope| be the last [=list/item=] of |device|.{{GPUDevice/[[errorScopeStack]]}}.
+    1. While |scope| is not `undefined`:
+        1. If |scope|.{{GPU error scope/[[filter]]}} is |type|, return |scope|.
+        1. Set |scope| to the previous [=list/item=] of
+            |device|.{{GPUDevice/[[errorScopeStack]]}}.
+    1. Return `undefined`.
 </div>
 
 <div algorithm>
@@ -14825,14 +14952,16 @@ integers and single-precision floats.
         either {{GPUColorDict}}.{{GPUColorDict/a}}
         or the fourth item of the sequence ([=assert|asserting=] there is such an item).
 </div>
-<div algorithm>
+<div algorithm data-timeline=content>
     <dfn abstract-op>validate GPUColor shape</dfn>(color)
 
     **Arguments:**
 
     - |color|: The {{GPUColor}} to validate.
 
-   **Returns:** {{undefined}}
+    **Returns:** {{undefined}}
+
+    [=Content timeline=] steps:
 
     1. Throw a {{TypeError}} if |color| is a sequence and |color|.length &ne; 4.
 </div>
@@ -14855,14 +14984,16 @@ typedef (sequence<GPUIntegerCoordinate> or GPUOrigin2DDict) GPUOrigin2D;
         either {{GPUOrigin2DDict}}.{{GPUOrigin2DDict/y}}
         or the second item of the sequence (0 if not present).
 </div>
-<div algorithm>
+<div algorithm data-timeline=content>
     <dfn abstract-op>validate GPUOrigin2D shape</dfn>(origin)
 
     **Arguments:**
 
     - |origin|: The {{GPUOrigin2D}} to validate.
 
-   **Returns:** {{undefined}}
+    **Returns:** {{undefined}}
+
+    [=Content timeline=] steps:
 
     1. Throw a {{TypeError}} if |origin| is a sequence and |origin|.length &gt; 2.
 </div>
@@ -14889,14 +15020,16 @@ typedef (sequence<GPUIntegerCoordinate> or GPUOrigin3DDict) GPUOrigin3D;
         either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/z}}
         or the third item of the sequence (0 if not present).
 </div>
-<div algorithm>
+<div algorithm data-timeline=content>
     <dfn abstract-op>validate GPUOrigin3D shape</dfn>(origin)
 
     **Arguments:**
 
     - |origin|: The {{GPUOrigin3D}} to validate.
 
-   **Returns:** {{undefined}}
+    **Returns:** {{undefined}}
+
+    [=Content timeline=] steps:
 
     1. Throw a {{TypeError}} if |origin| is a sequence and |origin|.length &gt; 3.
 </div>
@@ -14940,14 +15073,16 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depthOrArrayLayers}}
         or the third item of the sequence (1 if not present).
 </div>
-<div algorithm>
+<div algorithm data-timeline=content>
     <dfn abstract-op>validate GPUExtent3D shape</dfn>(extent)
 
     **Arguments:**
 
     - |extent|: The {{GPUExtent3D}} to validate.
 
-   **Returns:** {{undefined}}
+    **Returns:** {{undefined}}
+
+    [=Content timeline=] steps:
 
     1. Throw a {{TypeError}} if:
 


### PR DESCRIPTION
Also normalizing some formatting, though there's still a lot of variance in how the algorithms are presented.

Primary goal is to make it clearer when modifying algorithms which values you can safely interact with, specifically with the goal of turning `valid` into an internal slot in mind.

FWIW this changes up a couple of formatting choices that I remember discussing in the past and saying "yeah, that's probably OK" but which I'm now updating for consistency. For example: The setIndexBuffer/setVertexBuffer/etc methods now have the first step of the algorithm explicitly wrapped in a `content` timeline section even though it immediately kicks things over the the `device` timeline. This is simply because that's what most other algorithms do.

Some algorithms I still haven't associated with a specific timeline because either they're called from multiple timelines ([`enabled for`](https://gpuweb.github.io/gpuweb/#enabled-for), need to look into that) or because the data that they deal with is entirely passed by value to the "function" with no side effects and thus the timeline doesn't matter much. Most of the time these are still called exclusively from one timeline, though, so we could still probably link them to that timeline if we wanted.