### PR TITLE
Making valid, invalid, and expired regular properties

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -646,7 +646,7 @@ interface mixin GPUObjectBase {
 
 {{GPUObjectBase}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUObjectBase data-timeline=const>
+<dl dfn-type=attribute dfn-for=GPUObjectBase data-timeline=device>
     : <dfn>\[[valid]]</dfn>, of type boolean, initially `true`.
     ::
         If `true`, indicates that the [=internal object=] is valid to use.
@@ -1194,12 +1194,8 @@ An [=adapter=] has the following internal slots:
 [=Adapters=] are exposed via {{GPUAdapter}}.
 
 <div algorithm data-timeline=device>
-    A given {{GPUAdapter}} |adapter| is <dfn abstract-op>expired</dfn> if all of the requirements of
-    the following [=device timeline=] steps are met:
-
-    <div class=validusage>
-        - |adapter|.{{GPUAdapter/[[adapter]]}}.{{adapter/[[expired]]}} must be `true`
-    </div>
+    A given {{GPUAdapter}} |adapter| is <dfn abstract-op>expired</dfn> if
+    |adapter|.{{GPUAdapter/[[adapter]]}}.{{adapter/[[expired]]}} is `true`.
 </div>
 
 <div algorithm data-timeline=device>
@@ -2472,7 +2468,7 @@ interface GPUAdapter {
                     1. [=Lose the device=](|device|, {{GPUDeviceLostReason/"unknown"}}).
 
                         Note:
-                        This [$expires$] |adapter|, if it wasn't already.
+                        This [$expires$] |adapter|, if it wasn't already expired.
 
                         Note:
                         User agents should consider issuing developer-visible warnings in
@@ -7567,7 +7563,7 @@ dictionary GPUComputePipelineDescriptor
                         : [$invalid$] due to an [$internal error$]
                         :: [=Reject=] |promise| with a {{GPUPipelineError}} with
                             {{GPUPipelineErrorInit/reason}} {{GPUPipelineErrorReason/"internal"}}.
-                        : [$invalid$] due to an [$validation error$]
+                        : [$invalid$] due to a [$validation error$]
                         :: [=Reject=] |promise| with a {{GPUPipelineError}} with
                             {{GPUPipelineErrorInit/reason}} {{GPUPipelineErrorReason/"validation"}}.
                     </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12782,8 +12782,8 @@ GPUQueue includes GPUObjectBase;
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. If any of the following requirements are unmet, [$generate a validation error$], make each
-                    {{GPUCommandBuffer}} in |commandBuffers| [=invalid=], and stop.
+                1. If any of the following requirements are unmet, [$generate a validation error$],
+                    [$invalidate$] each {{GPUCommandBuffer}} in |commandBuffers| and stop.
 
                     <div class=validusage>
                         - Every {{GPUCommandBuffer}} in |commandBuffers| must be [$valid to use with$] |this|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -717,16 +717,13 @@ like buffer state "[=GPUBuffer/[[internal state]]/destroyed=]".
 [=devices=], [=adapters=], {{GPUCommandBuffer}}s, and command/pass/bundle encoders.
 
 <div algorithm data-timeline=device>
-    A given {{GPUObjectBase}} |object| is <dfn abstract-op>valid</dfn> if the all of the
-    requirements in the following [=device timeline=] steps are met:
-
-    <div class=validusage>
-        - |object|.{{GPUObjectBase/[[valid]]}} must be `true`.
-    </div>
+    A given {{GPUObjectBase}} |object| is <dfn abstract-op>valid</dfn> if
+    |object|.{{GPUObjectBase/[[valid]]}} is `true`.
 </div>
 
 <div algorithm data-timeline=device>
-    A given {{GPUObjectBase}} object is <dfn abstract-op>invalid</dfn> if it is not [$valid$].
+    A given {{GPUObjectBase}} |object| is <dfn abstract-op>invalid</dfn> if
+    |object|.{{GPUObjectBase/[[valid]]}} is `false`.
 </div>
 
 <div algorithm data-timeline=device>
@@ -1270,7 +1267,7 @@ no validation errors are raised, most promises resolve normally, etc.
 <div algorithm data-timeline=device>
     To <dfn dfn>lose the device</dfn>(|device|, |reason|) run the following [=device timeline=] steps:
 
-    1. Set |device|.{{GPUObjectBase/[[valid]]}} to `false`.
+    1. [$Invalidate$] |device|.
     1. Let |gpuDevice| be the [=content timeline=] {{GPUDevice}} corresponding to |device|.
 
         Issue: Define this more rigorously.
@@ -3180,7 +3177,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                     [$generate a validation error$], [$invalidate$] |b|, and stop.
 
                     <div class=validusage>
-                        - |this| must be [$valid$].
+                        - |this| must not be [$invalid|lost$].
                         - |descriptor|.{{GPUBufferDescriptor/usage}} must not be 0.
                         - |descriptor|.{{GPUBufferDescriptor/usage}} must be a subset of the
                             [=allowed buffer usages=] for |this|.
@@ -3410,7 +3407,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 1. Set |this|.{{GPUBuffer/[[internal state]]}} to "[=GPUBuffer/[[internal state]]/unavailable=]".
 
                     Note: Since the buffer is mapped, its contents cannot change between this completion and {{GPUBuffer/unmap()}}.
-                1. If |this|.{{GPUObjectBase/[[device]]}} is lost, or when it [=lose the device|becomes lost=]:
+                1. If |this|.{{GPUObjectBase/[[device]]}} is [$invalid|lost$], or when it [=lose the device|becomes lost=]:
 
                     1. Issue the <var data-timeline=content>map failure steps</var> on
                         <var data-timeline=content>contentTimeline</var>.
@@ -4056,7 +4053,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
     1. Return `true` if all of the following requirements are met, and `false` otherwise:
 
         <div class=validusage>
-            - |this| must be [$valid$].
+            - |this| must not be [$invalid|lost$].
             - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
             - |descriptor|.{{GPUTextureDescriptor/usage}} must contain only bits present in |this|'s [=allowed texture usages=].
             - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=],
@@ -5302,7 +5299,7 @@ enum GPUCompareFunction {
                     [$generate a validation error$], [$invalidate$] |s|, and stop.
 
                     <div class=validusage>
-                        - |this| must be [$valid$].
+                        - |this| must not be [$invalid|lost$].
                         - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} &ge; 0.
                         - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} &ge;
                             |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
@@ -5777,7 +5774,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                     [$generate a validation error$], [$invalidate$] |layout|, and stop.
 
                     <div class=validusage>
-                        - |this| must be [$valid$].
+                        - |this| must not be [$invalid|lost$].
                         - Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                         - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
                         - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| must be &lt;
@@ -6422,7 +6419,7 @@ dictionary GPUShaderModuleDescriptor
                     [$generate a validation error$], [$invalidate$] |sm|, and return.
 
                     <div class=validusage>
-                        - |this| must be [$valid$].
+                        - |this| must not be [$invalid|lost$].
                         - |result| must not be a [=shader-creation error|shader-creation=] [=program error=].
                     </div>
 
@@ -7550,20 +7547,21 @@ dictionary GPUComputePipelineDescriptor
                 1. Let |pipeline| be a new {{GPUComputePipeline}} created as if
                     |this|.{{GPUDevice/createComputePipeline()}} was called with |descriptor|;
 
-                1. When |pipeline| is ready to be used or has been [$invalidated$], issue the
-                    subsequent steps on <var data-timeline=content>contentTimeline</var>.
+                1. When |pipeline| is ready to be used or has been [$invalidated$]:
+                    1. Let |valid| be |pipeline|'s [$valid$] state.
+                    1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
             <div data-timeline=content>
                 [=Content timeline=] steps:
 
-                1. If |pipeline|...
+                1. If |valid| is...
                     <dl class=switch>
-                        : [$valid$]
+                        : `true`
                         :: [=Resolve=] |promise| with |pipeline|.
-                        : [$invalid$] due to an [$internal error$]
+                        : `false` due to an [$internal error$]
                         :: [=Reject=] |promise| with a {{GPUPipelineError}} with
                             {{GPUPipelineErrorInit/reason}} {{GPUPipelineErrorReason/"internal"}}.
-                        : [$invalid$] due to a [$validation error$]
+                        : `false` due to a [$validation error$]
                         :: [=Reject=] |promise| with a {{GPUPipelineError}} with
                             {{GPUPipelineErrorInit/reason}} {{GPUPipelineErrorReason/"validation"}}.
                     </dl>
@@ -7799,20 +7797,21 @@ dictionary GPURenderPipelineDescriptor
                 1. Let |pipeline| be a new {{GPURenderPipeline}} created as if
                     |this|.{{GPUDevice/createRenderPipeline()}} was called with |descriptor|;
 
-                1. When |pipeline| is ready to be used or has been [$invalidated$], issue the
-                    subsequent steps on <var data-timeline=content>contentTimeline</var>.
+                1. When |pipeline| is ready to be used or has been [$invalidated$]:
+                    1. Let |valid| be |pipeline|'s [$valid$] state.
+                    1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
             <div data-timeline=content>
                 [=Content timeline=] steps:
 
-                1. If |pipeline| is...
+                1. If |valid| is...
                     <dl class=switch>
-                        : [$valid$]
+                        : `true`
                         :: [=Resolve=] |promise| with |pipeline|.
-                        : [$invalid$] due to an [$internal error$]
+                        : `false` due to an [$internal error$]
                         :: [=Reject=] |promise| with a {{GPUPipelineError}} with
                             {{GPUPipelineErrorInit/reason}} {{GPUPipelineErrorReason/"internal"}}.
-                        : [$invalid$] due to an [$validation error$]
+                        : `false` due to a [$validation error$]
                         :: [=Reject=] |promise| with a {{GPUPipelineError}} with
                             {{GPUPipelineErrorInit/reason}} {{GPUPipelineErrorReason/"validation"}}.
                     </dl>
@@ -9430,7 +9429,7 @@ dictionary GPUCommandEncoderDescriptor
                     [$generate a validation error$], [$invalidate$] |e|, and stop.
 
                     <div class=validusage>
-                        - |this| must be [$valid$].
+                        - |this| must not be [$invalid|lost$].
                     </div>
 
                 Issue: Describe remaining {{GPUDevice/createCommandEncoder()}} validation and
@@ -12379,7 +12378,7 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                     [$generate a validation error$], [$invalidate$] |e|, and stop.
 
                     <div class=validusage>
-                        - |this| must be [$valid$].
+                        - |this| must not be [$invalid|lost$].
                         - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be &le;
                             |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
                         - For each non-`null` |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:
@@ -12848,7 +12847,7 @@ GPUQueue includes GPUObjectBase;
 
                 1. When the [=device timeline=] becomes informed of the completion of all
                     <span data-timeline=queue>currently-enqueued operations</span> on |this|, or
-                    if |this| is lost, or when |this| [=lose the device|becomes lost=]:
+                    if |this| is [$invalid|lost$], or when |this| [=lose the device|becomes lost=]:
                     1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
             <div data-timeline=content>
@@ -12964,7 +12963,7 @@ dictionary GPUQuerySetDescriptor
                     [$invalidate$] |q|, and stop.
 
                     <div class=validusage>
-                        - |this| must be [$valid$].
+                        - |this| must not be [$invalid|lost$].
                         - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 4096.
                     </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -598,7 +598,7 @@ interface mixin GPUObjectBase {
         The [=device=] that owns the [=internal object=].
 
         Operations on the contents of this object [=assert=] they are running on the
-        [=device timeline=], and that the device is [=valid=].
+        [=device timeline=], and that the device is [$valid$].
 </dl>
 
 {{GPUObjectBase}} has the following [=content timeline properties=]:
@@ -642,6 +642,14 @@ interface mixin GPUObjectBase {
             It is defined as a {{USVString}} because some user agents may
             supply it to the debug facilities of the underlying native APIs.
         </div>
+</dl>
+
+{{GPUObjectBase}} has the following [=device timeline properties=]:
+
+<dl dfn-type=attribute dfn-for=GPUObjectBase data-timeline=const>
+    : <dfn>\[[valid]]</dfn>, of type boolean, initially `true`.
+    ::
+        If `true`, indicates that the [=internal object=] is valid to use.
 </dl>
 
 <div class=note heading>
@@ -688,11 +696,11 @@ asynchronous. Returned objects refer to [=internal objects=] which are manipulat
 [=device timeline=]. Rather than fail with exceptions or rejections, most errors that occur on a
 [=device timeline=] are communicated through {{GPUError}}s generated on the associated [=device=].
 
-[=Internal objects=] are either <dfn dfn>valid</dfn> or <dfn dfn>invalid</dfn>.
-An [=invalid=] object will never become [=valid=] at a later time,
-but some [=valid=] objects may become [=invalid=].
+[=Internal objects=] are either [$valid$] or [$invalid$].
+An [$invalid$] object will never become [$valid$] at a later time,
+but some [$valid$] objects may be [$invalidated$].
 
-Objects are [=invalid=] from creation if it wasn't possible to create them.
+Objects are [$invalid$] from creation if it wasn't possible to create them.
 This can happen, for example, if the [=object descriptor=] doesn't describe a valid
 object, or if there is not enough memory to allocate a resource.
 It can also happen if an object is created with or from another invalid object
@@ -700,23 +708,43 @@ It can also happen if an object is created with or from another invalid object
 (for example the {{GPUTexture}} of a {{GPUTexture/createView()}} call):
 this case is referred to as <dfn dfn noexport>contagious invalidity</dfn>.
 
-[=Internal objects=] of *most* types cannot become [=invalid=] after they are created, but still
+[=Internal objects=] of *most* types cannot become [$invalid$] after they are created, but still
 may become unusable, e.g. if the owning device is [=lose the device|lost=] or
 {{GPUDevice/destroy()|destroyed}}, or the object has a special internal state,
 like buffer state "[=GPUBuffer/[[internal state]]/destroyed=]".
 
-[=Internal objects=] of some types *can* become [=invalid=] after they are created; specifically,
+[=Internal objects=] of some types *can* become [$invalid$] after they are created; specifically,
 [=devices=], [=adapters=], {{GPUCommandBuffer}}s, and command/pass/bundle encoders.
+
+<div algorithm data-timeline=device>
+    A given {{GPUObjectBase}} |object| is <dfn abstract-op>valid</dfn> if the all of the
+    requirements in the following [=device timeline=] steps are met:
+
+    <div class=validusage>
+        - |object|.{{GPUObjectBase/[[valid]]}} must be `true`.
+    </div>
+</div>
+
+<div algorithm data-timeline=device>
+    A given {{GPUObjectBase}} object is <dfn abstract-op>invalid</dfn> if it is not [$valid$].
+</div>
 
 <div algorithm data-timeline=device>
     A given {{GPUObjectBase}} |object| is <dfn abstract-op>valid to use with</dfn>
     a |targetObject| if the all of the requirements in the following [=device timeline=] steps are met:
 
     <div class=validusage>
-        - |object| must be [=valid=].
-        - |object|.{{GPUObjectBase/[[device]]}} must be [=valid=].
+        - |object|.{{GPUObjectBase/[[valid]]}} must be `true`.
+        - |object|.{{GPUObjectBase/[[device]]}}.{{GPUObjectBase/[[valid]]}} must be `true`.
         - |object|.{{GPUObjectBase/[[device]]}} must equal |targetObject|.{{GPUObjectBase/[[device]]}}.
     </div>
+</div>
+
+<div algorithm data-timeline=device>
+    To <dfn abstract-op lt='invalidate|Invalidate|invalidated|invalidates'>invalidate</dfn> a {{GPUObjectBase}}
+    |object|, run the following [=device timeline=] steps:
+
+    1. |object|.{{GPUObjectBase/[[valid]]}} to `false`.
 </div>
 
 ### Promise Ordering ### {#promise-ordering}
@@ -1127,8 +1155,8 @@ calling {{GPU/requestAdapter()}} multiple times returns a different [=adapter=]
 object each time.
 
 Each [=adapter=] object can only be used to create one [=device=]:
-upon a successful {{GPUAdapter/requestDevice()}}, the adapter becomes [=invalid=].
-Additionally, [=adapter=] objects may [=adapter/expire=] at any time.
+upon a successful {{GPUAdapter/requestDevice()}} call, the adapter [$expires$].
+Additionally, [=adapter=] objects may [$expire$] at any time.
 
 Note:
 This ensures applications use the latest system state for adapter selection when creating a device.
@@ -1143,6 +1171,10 @@ improved privacy. It is not required that a [=fallback adapter=] is available on
 An [=adapter=] has the following internal slots:
 
 <dl dfn-type=attribute dfn-for=adapter>
+    : <dfn>\[[expired]]</dfn>, of type boolean, initially `false`
+    ::
+        If set to `true` indicates that the adapter can no longer be used to create a [=device=].
+
     : <dfn>\[[features]]</dfn>, of type [=ordered set=]&lt;{{GPUFeatureName}}&gt;, readonly
     ::
         The [=features=] which can be used to create devices on this adapter.
@@ -1161,6 +1193,22 @@ An [=adapter=] has the following internal slots:
 
 [=Adapters=] are exposed via {{GPUAdapter}}.
 
+<div algorithm data-timeline=device>
+    A given {{GPUAdapter}} |adapter| is <dfn abstract-op>expired</dfn> if all of the requirements of
+    the following [=device timeline=] steps are met:
+
+    <div class=validusage>
+        - |adapter|.{{GPUAdapter/[[adapter]]}}.{{adapter/[[expired]]}} must be `true`
+    </div>
+</div>
+
+<div algorithm data-timeline=device>
+    To <dfn abstract-op lt='expire|Expire|expires'>expire</dfn> a {{GPUAdapter}} |adapter|, run the
+    following [=device timeline=] steps:
+
+    1. Set |adapter|.{{GPUAdapter/[[adapter]]}}.{{adapter/[[expired]]}} to `true`
+</div>
+
 ### Devices ### {#devices}
 
 A <dfn dfn>device</dfn> is the logical instantiation of an [=adapter=],
@@ -1168,7 +1216,7 @@ through which [=internal objects=] are created.
 It can be shared across multiple [=agents=] (e.g. dedicated workers).
 
 A [=device=] is the exclusive owner of all [=internal objects=] created from it:
-when the [=device=] becomes [=invalid=]
+when the [=device=] becomes [$invalid$]
 (is [=lose the device|lost=] or {{GPUDevice/destroy()|destroyed}}),
 it and all objects created on it (directly, e.g.
 {{GPUDevice/createTexture()}}, or indirectly, e.g. {{GPUTexture/createView()}}) become
@@ -1226,7 +1274,7 @@ no validation errors are raised, most promises resolve normally, etc.
 <div algorithm data-timeline=device>
     To <dfn dfn>lose the device</dfn>(|device|, |reason|) run the following [=device timeline=] steps:
 
-    1. Make |device| [=invalid=].
+    1. Set |device|.{{GPUObjectBase/[[valid]]}} to `false`.
     1. Let |gpuDevice| be the [=content timeline=] {{GPUDevice}} corresponding to |device|.
 
         Issue: Define this more rigorously.
@@ -2075,7 +2123,7 @@ interface GPU {
 
                 1. Let |adapter| be `null`.
                 1. If the user agent chooses to return an adapter, it should:
-                    1. Set |adapter| to a [=valid=] [=adapter=], chosen according to
+                    1. Set |adapter| to an [=adapter=] chosen according to
                         the rules in [[#adapter-selection]] and the criteria in |options|,
                         adhering to [[#adapter-capability-guarantees]].
 
@@ -2131,15 +2179,15 @@ interface GPU {
         Supported language extensions are automatically enabled.
 </dl>
 
-[=Adapters=] **may** become [=invalid=] ("<dfn dfn for=adapter>expire</dfn>") at any time.
-Upon any change in the system's state that could affect the result of any {{GPU/requestAdapter()}}
-call, the user agent **should** expire all previously-returned adapters. For example:
+[=Adapters=] **may** [$expire$] at any time. Upon any change in the system's state that could affect
+the result of any {{GPU/requestAdapter()}} call, the user agent **should** [$expire$] all
+previously-returned [=adapters=]. For example:
 
 - A physical adapter is added/removed (via plug/unplug, driver update, hang recovery, etc.)
 - The system's power configuration has changed (laptop unplugged, power settings changed, etc.)
 
 Note:
-User agents may choose to [=adapter/expire=] adapters often, even when there has been no system
+User agents may choose to [$expire$] [=adapters=] often, even when there has been no system
 state change (e.g. seconds or minutes after the adapter was created).
 This can help obfuscate real system state changes, and make developers more aware that calling
 {{GPU/requestAdapter()}} again is always necessary before calling {{GPUAdapter/requestDevice()}}.
@@ -2348,7 +2396,7 @@ interface GPUAdapter {
         Requests a [=device=] from the [=adapter=].
 
         This is a one-time action: if a device is returned successfully,
-        the adapter becomes [=invalid=].
+        the adapter [$expires$].
 
         <div algorithm=GPUAdapter.requestDevice>
             <div data-timeline=content>
@@ -2417,14 +2465,14 @@ interface GPUAdapter {
                         1. [=Reject=] |promise| with an {{OperationError}}.
                     </div>
 
-                1. If |adapter| is [=invalid=],
+                1. If |adapter| is [$expired$],
                     or the user agent otherwise cannot fulfill the request:
 
                     1. Let |device| be a new [=device=].
                     1. [=Lose the device=](|device|, {{GPUDeviceLostReason/"unknown"}}).
 
                         Note:
-                        This makes |adapter| [=invalid=], if it wasn't already.
+                        This [$expires$] |adapter|, if it wasn't already.
 
                         Note:
                         User agents should consider issuing developer-visible warnings in
@@ -2434,7 +2482,7 @@ interface GPUAdapter {
                     Otherwise:
 
                     1. Let |device| be [=a new device=] with the capabilities described by |descriptor|.
-                    1. Make |adapter|.{{GPUAdapter/[[adapter]]}} [=invalid=].
+                    1. [$Expire$] |adapter|.
 
                 1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
@@ -2964,7 +3012,7 @@ enum GPUBufferMapState {
         <dl dfn-type=dfn dfn-for="GPUBuffer/[[internal state]]">
             : "<dfn>available</dfn>"
             ::
-                The buffer may be used in queue operations (unless it is [=invalid=]).
+                The buffer may be used in queue operations (unless it is [$invalid$]).
 
             : "<dfn>unavailable</dfn>"
             ::
@@ -3133,13 +3181,13 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following requirements are unmet,
-                    [$generate a validation error$], make |b| [=invalid=], and stop.
+                    [$generate a validation error$], [$invalidate$] |b|, and stop.
 
                     <div class=validusage>
-                        - |device| must be [=valid=].
+                        - |this| must be [$valid$].
                         - |descriptor|.{{GPUBufferDescriptor/usage}} must not be 0.
-                        - |descriptor|.{{GPUBufferDescriptor/usage}} must be a subset of |device|'s
-                            [=allowed buffer usages=].
+                        - |descriptor|.{{GPUBufferDescriptor/usage}} must be a subset of the
+                            [=allowed buffer usages=] for |this|.
                         - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_READ}}:
                             - |descriptor|.{{GPUBufferDescriptor/usage}} must contain no other flags
                                 except {{GPUBufferUsage/COPY_DST}}.
@@ -3147,7 +3195,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                             - |descriptor|.{{GPUBufferDescriptor/usage}} must contain no other flags
                                 except {{GPUBufferUsage/COPY_SRC}}.
                         - If |descriptor|.{{GPUBufferDescriptor/size}} must be &le;
-                            |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBufferSize}}.
+                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBufferSize}}.
                         - If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
                             - |descriptor|.{{GPUBufferDescriptor/size}} must be a multiple of 4.
                     </div>
@@ -3167,7 +3215,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
 
                     If the allocation fails without side-effects,
                     [$generate an out-of-memory error$],
-                    make |b| [=invalid=], and return.
+                    make [$invalidate$] |b|, and return.
             </div>
         </div>
 </dl>
@@ -3345,7 +3393,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 1. If any of the following conditions are unsatisfied:
 
                     <div class=validusage>
-                        - |this| is a [=valid=] {{GPUBuffer}}.
+                        - |this| must be [$valid$].
                         - |this|.{{GPUBuffer/[[internal state]]}} is "[=GPUBuffer/[[internal state]]/available=]".
                         - |offset| is a multiple of 8.
                         - |rangeSize| is a multiple of 4.
@@ -3468,7 +3516,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                             |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/views=].
 
                         Note: It is always valid to get mapped ranges of a {{GPUBuffer}} that is
-                        {{GPUBufferDescriptor/mappedAtCreation}}, even if it is [=invalid=], because
+                        {{GPUBufferDescriptor/mappedAtCreation}}, even if it is [$invalid$], because
                         the [=Content timeline=] might not know it is invalid.
                     </div>
 
@@ -3540,7 +3588,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. If |this|.{{GPUObjectBase/[[device]]}} is [=invalid=], return.
+                1. If |this| is [$invalid$], return.
                 1. If |bufferUpdate| is not `null`:
 
                     1. Issue the following steps on the [=Queue timeline=] of |this|.{{GPUObjectBase/[[device]]}}.{{GPUDevice/queue}}:
@@ -3987,7 +4035,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], make |t| [=invalid=], and stop.
+                    [$generate a validation error$], [$invalidate$] |t|, and stop.
 
                     <div class=validusage>
                         - [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns `true`.
@@ -4012,7 +4060,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
     1. Return `true` if all of the following requirements are met, and `false` otherwise:
 
         <div class=validusage>
-            - |this| must be a [=valid=] {{GPUDevice}}.
+            - |this| must be [$valid$].
             - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
             - |descriptor|.{{GPUTextureDescriptor/usage}} must contain only bits present in |this|'s [=allowed texture usages=].
             - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=],
@@ -4373,10 +4421,10 @@ enum GPUTextureAspect {
                 1. Set |descriptor| to the result of [$resolving GPUTextureViewDescriptor defaults$]
                     for |this| with |descriptor|.
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], make |view| [=invalid=], and stop.
+                    [$generate a validation error$], [$invalidate$] |view|, and stop.
 
                     <div class=validusage>
-                        - |this| is [=valid=].
+                        - |this| must be [$valid$].
                         - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must be present in |this|.{{GPUTexture/format}}.
                         - If the |descriptor|.{{GPUTextureViewDescriptor/aspect}} is {{GPUTextureAspect/"all"}}:
                             - |descriptor|.{{GPUTextureViewDescriptor/format}} must equal either
@@ -4906,7 +4954,7 @@ dictionary GPUExternalTextureDescriptor
 
                     1. If |usability| is not `good`:
                         1. [$Generate a validation error$].
-                        1. Return an [=invalid=] {{GPUExternalTexture}}.
+                        1. Return an [$invalidated$] {{GPUExternalTexture}}.
 
                     1. Let |data| be the result of converting the current image contents of |source| into
                         the color space |descriptor|.{{GPUExternalTextureDescriptor/colorSpace}}
@@ -5255,10 +5303,10 @@ enum GPUCompareFunction {
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], make |s| [=invalid=], and stop.
+                    [$generate a validation error$], [$invalidate$] |s|, and stop.
 
                     <div class=validusage>
-                        - |this| is [=valid=].
+                        - |this| must be [$valid$].
                         - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} &ge; 0.
                         - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} &ge;
                             |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
@@ -5730,10 +5778,10 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], make |layout| [=invalid=], and stop.
+                    [$generate a validation error$], [$invalidate$] |layout|, and stop.
 
                     <div class=validusage>
-                        - |this| is [=valid=].
+                        - |this| must be [$valid$].
                         - Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                         - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
                         - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| must be &lt;
@@ -5960,7 +6008,7 @@ following members:
 
                 1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], make |bindGroup| [=invalid=], and stop.
+                    [$generate a validation error$], [$invalidate$] |bindGroup|, and stop.
 
                     <div class=validusage>
                         - |descriptor|.{{GPUBindGroupDescriptor/layout}} is [$valid to use with$] |this|.
@@ -6206,7 +6254,7 @@ pipeline, and have the following members:
                     |bgl|.{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
                     for all |bgl| in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], make |pl| [=invalid=], and stop.
+                    [$generate a validation error$], [$invalidate$] |pl|, and stop.
 
                     <div class=validusage>
                         - Every {{GPUBindGroupLayout}} in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -6375,10 +6423,10 @@ dictionary GPUShaderModuleDescriptor
                 1. Let |result| be the result of [=shader module creation=] with the WGSL source
                     |descriptor|.{{GPUShaderModuleDescriptor/code}}.
                 1. If any of the following requirements are unmet,
-                    [$generate a validation error$], make |sm| [=invalid=], and return.
+                    [$generate a validation error$], [$invalidate$] |sm|, and return.
 
                     <div class=validusage>
-                        - |this| must be [=valid=].
+                        - |this| must be [$valid$].
                         - |result| must not be a [=shader-creation error|shader-creation=] [=program error=].
                     </div>
 
@@ -6840,10 +6888,10 @@ interface mixin GPUPipelineBase {
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], make |layout| [=invalid=], and stop.
+                    [$generate a validation error$], [$invalidate$] |layout|, and stop.
 
                     <div class=validusage>
-                        - |this| is [=valid=].
+                        - |this| must be [$valid$].
                         - |index| &lt; the [=list/size=] of
                             |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}
                     </div>
@@ -7156,7 +7204,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     All of the requirements in the following steps |must| be met.
     If any are unmet, return `false`; otherwise, return `true`.
 
-    1. |descriptor|.{{GPUProgrammableStage/module}} |must| be a [=valid=] {{GPUShaderModule}}.
+    1. |descriptor|.{{GPUProgrammableStage/module}} |must| be [$valid$].
     1. Let |entryPoint| be [$get the entry point$](|stage|, |descriptor|).
     1. |entryPoint| |must| not be `null`.
     1. For each |binding| that is [=statically used=] by |entryPoint|:
@@ -7433,7 +7481,7 @@ dictionary GPUComputePipelineDescriptor
                     and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
 
                 1. All of the requirements in the following steps |must| be met.
-                    If any are unmet, [$generate a validation error$], make |pipeline| [=invalid=], and stop.
+                    If any are unmet, [$generate a validation error$], [$invalidate$] |pipeline|, and stop.
 
                     <div class=validusage>
                         1. |layout| |must| be [$valid to use with$] |this|.
@@ -7460,7 +7508,7 @@ dictionary GPUComputePipelineDescriptor
 
                 1. If any [=pipeline-creation error|pipeline-creation=] [=uncategorized errors=]
                     result from the implementation of pipeline creation,
-                    [$generate an internal error$], make |pipeline| [=invalid=], and stop.
+                    [$generate an internal error$], [$invalidate$] |pipeline|, and stop.
 
                     Note:
                     Even if the implementation detected [=uncategorized errors=] in shader module
@@ -7506,7 +7554,7 @@ dictionary GPUComputePipelineDescriptor
                 1. Let |pipeline| be a new {{GPUComputePipeline}} created as if
                     |this|.{{GPUDevice/createComputePipeline()}} was called with |descriptor|;
 
-                1. When |pipeline| is ready to be used or has been made [=invalid=], issue the
+                1. When |pipeline| is ready to be used or has been [$invalidated$], issue the
                     subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
             <div data-timeline=content>
@@ -7514,12 +7562,12 @@ dictionary GPUComputePipelineDescriptor
 
                 1. If |pipeline|...
                     <dl class=switch>
-                        : [=valid=]
+                        : [$valid$]
                         :: [=Resolve=] |promise| with |pipeline|.
-                        : [=invalid=] due to an [$internal error$]
+                        : [$invalid$] due to an [$internal error$]
                         :: [=Reject=] |promise| with a {{GPUPipelineError}} with
                             {{GPUPipelineErrorInit/reason}} {{GPUPipelineErrorReason/"internal"}}.
-                        : [=invalid=] due to an [$validation error$]
+                        : [$invalid$] due to an [$validation error$]
                         :: [=Reject=] |promise| with a {{GPUPipelineError}} with
                             {{GPUPipelineErrorInit/reason}} {{GPUPipelineErrorReason/"validation"}}.
                     </dl>
@@ -7678,7 +7726,7 @@ dictionary GPURenderPipelineDescriptor
                     |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
                     and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
                 1. If any of the following conditions are unsatisfied:
-                    [$generate a validation error$], make |pipeline| [=invalid=], and stop.
+                    [$generate a validation error$], [$invalidate$] |pipeline|, and stop.
 
                     <div class=validusage>
                         - |layout| is [$valid to use with$] |this|.
@@ -7689,7 +7737,7 @@ dictionary GPURenderPipelineDescriptor
                     </div>
                 1. If any [=pipeline-creation error|pipeline-creation=] [=uncategorized errors=]
                     result from the implementation of pipeline creation,
-                    [$generate an internal error$], make |pipeline| [=invalid=], and stop.
+                    [$generate an internal error$], [$invalidate$] |pipeline|, and stop.
 
                     Note:
                     Even if the implementation detected [=uncategorized errors=] in shader module
@@ -7755,7 +7803,7 @@ dictionary GPURenderPipelineDescriptor
                 1. Let |pipeline| be a new {{GPURenderPipeline}} created as if
                     |this|.{{GPUDevice/createRenderPipeline()}} was called with |descriptor|;
 
-                1. When |pipeline| is ready to be used or has been made [=invalid=], issue the
+                1. When |pipeline| is ready to be used or has been [$invalidated$], issue the
                     subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
             <div data-timeline=content>
@@ -7763,12 +7811,12 @@ dictionary GPURenderPipelineDescriptor
 
                 1. If |pipeline| is...
                     <dl class=switch>
-                        : [=valid=]
+                        : [$valid$]
                         :: [=Resolve=] |promise| with |pipeline|.
-                        : [=invalid=] due to an [$internal error$]
+                        : [$invalid$] due to an [$internal error$]
                         :: [=Reject=] |promise| with a {{GPUPipelineError}} with
                             {{GPUPipelineErrorInit/reason}} {{GPUPipelineErrorReason/"internal"}}.
-                        : [=invalid=] due to an [$validation error$]
+                        : [$invalid$] due to an [$validation error$]
                         :: [=Reject=] |promise| with a {{GPUPipelineError}} with
                             {{GPUPipelineErrorInit/reason}} {{GPUPipelineErrorReason/"validation"}}.
                     </dl>
@@ -9186,7 +9234,7 @@ Command buffers are pre-recorded lists of [=GPU commands=] that can be submitted
 for execution. Each <dfn dfn>GPU command</dfn> represents a task to be performed on the GPU, such as
 setting state, drawing, copying resources, etc.
 
-A {{GPUCommandBuffer}} can only be submitted once, at which point it becomes [=invalid=].
+A {{GPUCommandBuffer}} can only be submitted once, at which point it becomes [$invalidated$].
 To reuse rendering commands across multiple submissions, use {{GPURenderBundle}}.
 
 <h3 id=gpucommandbuffer data-dfn-type=interface>`GPUCommandBuffer`
@@ -9262,7 +9310,7 @@ The <dfn dfn>encoder state</dfn> may be one of the following:
         {{GPUCommandEncoder}}, and a {{GPURenderPassEncoder}} or {{GPUComputePassEncoder}} is active.
         The encoder becomes "[=encoder state/open=]" again when the pass is ended.
 
-        Any command issued in this state makes the encoder [=invalid=].
+        Any command issued in this state [$invalidates$] the encoder.
 
     : "<dfn>ended</dfn>"
     ::
@@ -9281,7 +9329,7 @@ The <dfn dfn>encoder state</dfn> may be one of the following:
             :: Return `true`.
 
             : "[=encoder state/locked=]"
-            :: Make |encoder| [=invalid=], and return `false`.
+            :: [$Invalidate$] |encoder| and return `false`.
 
             : "[=encoder state/ended=]"
             :: [$Generate a validation error$], and return `false`.
@@ -9383,10 +9431,10 @@ dictionary GPUCommandEncoderDescriptor
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], make |e| [=invalid=], and stop.
+                    [$generate a validation error$], [$invalidate$] |e|, and stop.
 
                     <div class=validusage>
-                        - |this| is [=valid=].
+                        - |this| must be [$valid$].
                     </div>
 
                 Issue: Describe remaining {{GPUDevice/createCommandEncoder()}} validation and
@@ -9439,7 +9487,7 @@ dictionary GPUCommandEncoderDescriptor
                 [=Device timeline=] |initialization steps|:
 
                 1. [$Validate the encoder state$] of |this|.
-                    If it returns false, make |pass| [=invalid=] and return.
+                    If it returns false, [$invalidate$] |pass| and return.
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
                 1. Let |attachmentRegions| be a [=list=] of [[=texture subresource=], {{GPURenderPassColorAttachment/depthSlice}}?]
                     pairs, initially empty. Each pair describes the region of the texture to be rendered to, which
@@ -9450,7 +9498,7 @@ dictionary GPUCommandEncoderDescriptor
                     1. If |colorAttachment|.{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
                         1. Add [|colorAttachment|.{{GPURenderPassColorAttachment/resolveTarget}},
                             `undefined`] to |attachmentRegions|.
-                1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
+                1. If any of the following requirements are unmet, [$invalidate$] |pass| and return.
                     <div class=validusage>
                         - |descriptor| must meet the [$GPURenderPassDescriptor/Valid Usage$] rules
                             given device |this|.{{GPUObjectBase/[[device]]}}.
@@ -9543,9 +9591,9 @@ dictionary GPUCommandEncoderDescriptor
                 [=Device timeline=] |initialization steps|:
 
                 1. [$Validate the encoder state$] of |this|.
-                    If it returns false, make |pass| [=invalid=] and return.
+                    If it returns false, [$invalidate$] |pass| and return.
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
-                1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
+                1. If any of the following requirements are unmet, [$invalidate$] |pass| and return.
                     <div class=validusage>
                         - If |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is [=map/exist|provided=]:
                             - [$Validate timestampWrites$](|this|.{{GPUObjectBase/[[device]]}},
@@ -9612,7 +9660,7 @@ dictionary GPUCommandEncoderDescriptor
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - |source| is [$valid to use with$] |this|.
@@ -9667,7 +9715,7 @@ dictionary GPUCommandEncoderDescriptor
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If |size| is missing, set |size| to `max(0, |buffer|.{{GPUBuffer/size}} - |offset|)`.
-                1. If any of the following conditions are unsatisfied make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
@@ -9723,7 +9771,7 @@ dictionary GPUCommandEncoderDescriptor
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Let |aligned| be `true`.
                 1. Let |dataLength| be |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}}.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
@@ -9774,7 +9822,7 @@ dictionary GPUCommandEncoderDescriptor
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Let |aligned| be `true`.
                 1. Let |dataLength| be |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}}.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
@@ -9825,7 +9873,7 @@ dictionary GPUCommandEncoderDescriptor
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - Let |srcTexture| be |source|.{{GPUImageCopyTexture/texture}}.
@@ -9889,7 +9937,7 @@ dictionary GPUCommandEncoderDescriptor
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - |querySet| is [$valid to use with$] |this|.
@@ -9954,7 +10002,7 @@ command encoder can no longer be used.
                 1. Let |validationSucceeded| be `true` if all of the following requirements are met, and `false` otherwise.
 
                     <div class=validusage>
-                        - |this| must be [=valid=].
+                        - |this| must be [$valid$].
                         - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
                         - Every [=usage scope=] contained in |this| must satisfy the [=usage scope validation=].
@@ -9962,7 +10010,7 @@ command encoder can no longer be used.
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
                 1. If |validationSucceeded| is `false`, then:
                     1. [$Generate a validation error$].
-                    1. Return a new [=invalid=] {{GPUCommandBuffer}}.
+                    1. Return an [$invalidated$] {{GPUCommandBuffer}}.
                 1. Set |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} to
                     |this|.{{GPUCommandsMixin/[[commands]]}}.
             </div>
@@ -10054,7 +10102,7 @@ It must only be included by interfaces which also include those mixins.
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Let |dynamicOffsetCount| be 0 if `bindGroup` is `null`, or
                     |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}} if not.
-                1. If any of the following requirements are unmet, make |this| [=invalid=] and stop.
+                1. If any of the following requirements are unmet, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - |index| must be &lt;
@@ -10067,7 +10115,7 @@ It must only be included by interfaces which also include those mixins.
 
                     Otherwise:
 
-                    1. If any of the following requirements are unmet, make |this| [=invalid=] and stop.
+                    1. If any of the following requirements are unmet, [$invalidate$] |this| and stop.
 
                         <div class=validusage>
                             - |bindGroup| must be [$valid to use with$] |this|.
@@ -10316,7 +10364,7 @@ It must only be included by interfaces which also include those mixins.
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following requirements are unmet, make |this| [=invalid=], and stop.
+                1. If any of the following requirements are unmet, [$invalidate$] |this|, and stop.
 
                     <div class=validusage>
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must not [=list/is empty|be empty=].
@@ -10462,7 +10510,7 @@ dictionary GPUComputePassDescriptor
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - |pipeline| is [$valid to use with$] |this|.
@@ -10513,7 +10561,7 @@ dictionary GPUComputePassDescriptor
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
@@ -10575,7 +10623,7 @@ dictionary GPUComputePassDescriptor
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
@@ -10646,11 +10694,10 @@ called the compute pass encoder can no longer be used.
                     </div>
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
                 1. Set |parentEncoder|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
-                1. If any of the following requirements are unmet, make
-                    |parentEncoder| [=invalid=] and stop.
+                1. If any of the following requirements are unmet, [$invalidate$] |parentEncoder| and stop.
 
                     <div class=validusage>
-                        - |this| must be [=valid=].
+                        - |this| must be [$valid$].
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
                     </div>
                 1. [=list/Extend=] |parentEncoder|.{{GPUCommandsMixin/[[commands]]}}
@@ -11299,11 +11346,10 @@ called the render pass encoder can no longer be used.
                     </div>
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
                 1. Set |parentEncoder|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
-                1. If any of the following requirements are unmet, make
-                    |parentEncoder| [=invalid=] and stop.
+                1. If any of the following requirements are unmet, [$invalidate$] |parentEncoder| and stop.
 
                     <div class=validusage>
-                        - |this| must be [=valid=].
+                        - |this| must be [$valid$].
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} must be `false`.
                         - |this|.{{GPURenderCommandsMixin/[[drawCount]]}} must be &le; |this|.{{GPURenderPassEncoder/[[maxDrawCount]]}}.
@@ -11445,7 +11491,7 @@ It must only be included by interfaces which also include those mixins.
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Let |pipelineTargetsLayout| be [$derive render targets layout from pipeline$](|pipeline|.{{GPURenderPipeline/[[descriptor]]}}).
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - |pipeline| is [$valid to use with$] |this|.
@@ -11488,7 +11534,7 @@ It must only be included by interfaces which also include those mixins.
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
@@ -11534,7 +11580,7 @@ It must only be included by interfaces which also include those mixins.
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Let |bufferSize| be 0 if |buffer| is `null`, or |buffer|.{{GPUBuffer/size}} if not.
                 1. If |size| is missing, set |size| to max(0, |bufferSize| - |offset|).
-                1. If any of the following requirements are unmet, make |this| [=invalid=] and stop.
+                1. If any of the following requirements are unmet, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - |slot| must be &lt;
@@ -11548,7 +11594,7 @@ It must only be included by interfaces which also include those mixins.
 
                     Otherwise:
 
-                    1. If any of the following requirements are unmet, make |this| [=invalid=] and stop.
+                    1. If any of the following requirements are unmet, [$invalidate$] |this| and stop.
 
                         <div class=validusage>
                             - |buffer| must be [$valid to use with$] |this|.
@@ -11589,7 +11635,7 @@ It must only be included by interfaces which also include those mixins.
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. All of the requirements in the following steps |must| be met.
-                    If any are unmet, make |this| [=invalid=] and stop.
+                    If any are unmet, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         1. It |must| be [$valid to draw$] with |this|.
@@ -11657,7 +11703,7 @@ It must only be included by interfaces which also include those mixins.
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - It is [$valid to draw indexed$] with |this|.
@@ -11739,7 +11785,7 @@ It must only be included by interfaces which also include those mixins.
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - It is [$valid to draw$] with |this|.
@@ -11816,7 +11862,7 @@ It must only be included by interfaces which also include those mixins.
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - It is [$valid to draw indexed$] with |this|.
@@ -11933,8 +11979,7 @@ attachments used by this encoder.
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=]
-                    and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - |x| &ge; `0`
@@ -11989,8 +12034,7 @@ attachments used by this encoder.
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=]
-                    and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - |x|+|width| &le;
@@ -12109,7 +12153,7 @@ attachments used by this encoder.
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is not `null`.
@@ -12146,7 +12190,7 @@ attachments used by this encoder.
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `true`.
@@ -12208,8 +12252,7 @@ attachments used by this encoder.
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=]
-                    and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
 
                     <div class=validusage>
                         - For each |bundle| in |bundles|:
@@ -12337,10 +12380,10 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], make |e| [=invalid=], and stop.
+                    [$generate a validation error$], [$invalidate$] |e|, and stop.
 
                     <div class=validusage>
-                        - |this| is [=valid=].
+                        - |this| must be [$valid$].
                         - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be &le;
                             |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
                         - For each non-`null` |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:
@@ -12422,7 +12465,7 @@ dictionary GPURenderBundleEncoderDescriptor
                 1. Let |validationSucceeded| be `true` if all of the following requirements are met, and `false` otherwise.
 
                     <div class=validusage>
-                        - |this| must be [=valid=].
+                        - |this| must be [$valid$].
                         - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
                         - Every [=usage scope=] contained in |this| must satisfy the [=usage scope validation=].
@@ -12430,7 +12473,7 @@ dictionary GPURenderBundleEncoderDescriptor
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
                 1. If |validationSucceeded| is `false`, then:
                     1. [$Generate a validation error$].
-                    1. Return a new [=invalid=] {{GPURenderBundle}}.
+                    1. Return an [$invalidated$] {{GPURenderBundle}}.
                 1. Set |renderBundle|.{{GPURenderBundle/[[command_list]]}} to
                     |this|.{{GPUCommandsMixin/[[commands]]}}.
                 1. Set |renderBundle|.{{GPURenderBundle/[[drawCount]]}} to
@@ -12770,7 +12813,7 @@ GPUQueue includes GPUObjectBase;
                     </div>
 
                 1. For each |commandBuffer| in |commandBuffers|:
-                    1. Make |commandBuffer| [=invalid=].
+                    1. [$Invalidate$] |commandBuffer|.
 
                 1. Issue the subsequent steps on the [=Queue timeline=] of |this|:
             </div>
@@ -12922,10 +12965,10 @@ dictionary GPUQuerySetDescriptor
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following requirements are unmet, [$generate a validation error$],
-                    make |q| [=invalid=], and stop.
+                    [$invalidate$] |q|, and stop.
 
                     <div class=validusage>
-                        - |this| is [=valid=].
+                        - |this| must be [$valid$].
                         - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 4096.
                     </div>
 
@@ -13285,7 +13328,7 @@ interface GPUCanvasContext {
 
                         Note:
                         If the texture can't be created (e.g. due to validation failure or out-of-memory),
-                        this generates and error and returns an [=invalid=] {{GPUTexture}}.
+                        this generates and error and returns an [$invalidated$] {{GPUTexture}}.
                         Some validation here is redundant with that done in {{GPUCanvasContext/configure()}}.
                         Implementations **must not** skip this redundant validation.
                 1. **Optionally**, [$queue an automatic expiry task$] with device |device| and the following steps:
@@ -13884,7 +13927,7 @@ partial interface GPUDevice {
     <div data-timeline=device>
         [=Device timeline=] steps:
 
-        1. If |device| is [=invalid|lost=], return.
+        1. If |device| is [$invalid|lost$], return.
 
             Note: No errors are generated after device loss. See [[#errors-and-debugging]].
         1. Let |scope| be the [$current error scope$] for |error| and |device|.
@@ -13967,7 +14010,7 @@ partial interface GPUDevice {
             <div data-timeline=device>
                 [=Device timeline=] |check steps|:
 
-                1. If |this| is [=invalid|lost=], issue the following steps on
+                1. If |this| is [$invalid|lost$], issue the following steps on
                     <var data-timeline=content>contentTimeline</var> and return:
 
                     <div data-timeline=content>
@@ -14003,7 +14046,7 @@ partial interface GPUDevice {
 
                     Note:
                     For example, if E1 comes from `t` = {{GPUDevice/createTexture()}}, and
-                    E2 comes from `t`.{{GPUTexture/createView()}} because `t` was [=invalid=],
+                    E2 comes from `t`.{{GPUTexture/createView()}} because `t` was [$invalid$],
                     E1 should be be preferred since it will be easier for a developer to understand
                     what went wrong.
                     Since both of these are {{GPUValidationError}}s, the only difference will be in


### PR DESCRIPTION
WIP. Removing the rather fuzzy definitions that we have for `valid` and `invalid` and replacing them with actual properties and algorithms that reference them.

Additionally, defines an explicit `expired` property for adapters rather than using it as an alias for `valid` since the new `valid` property exists on the `GPUObjectBase`, which adapters don't use.

TODO: A couple of algorithms are referencing the new `valid/invalid` algorithims from the `content` timeline, which shouldn't be allowed. Also, the definition for `invalid` is stupid. Finally, there's a couple of references to `lost` for devices which are aliases for `valid`. Feels like that should be normalized. 