### PR TITLE
[non-normative] Drawing buffer can also be lazily cleared

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11166,8 +11166,9 @@ enum GPUStoreOp {
         behave as if they are cleared to zero, but implementations are not required to perform a
         clear at the end of the render pass. Implementations which do not explicitly clear discarded
         attachments at the end of a pass must lazily clear them prior to the reading the attachment
-        contents (via sampling, copies, attachment to another render pass with
-        {{GPULoadOp/"load"}}, etc.)
+        contents, which occurs via sampling, copies, attaching to a later render pass with
+        {{GPULoadOp/"load"}}, displaying or reading back the canvas
+        ([$get a copy of the image contents of a context$]), etc.
 </dl>
 
 
@@ -13364,6 +13365,12 @@ interface GPUCanvasContext {
 
         Note: |configuration|.{{GPUCanvasConfiguration/alphaMode}} is ignored until
         "[$get a copy of the image contents of a context$]".
+
+        <div class=note heading>
+            A newly replaced drawing buffer image behaves as if it is cleared to transparent black,
+            but, like after {{GPUStoreOp/"discard"}}, an implementation can clear it lazily only
+            if it becomes necessary.
+        </div>
 
         Note: This will often be a no-op, if the drawing buffer is already cleared
         and has the correct configuration.


### PR DESCRIPTION
We had a non-normative implementation note about lazy clearing on `storeOp: "discard"`. This should apply to the drawing buffer, too.