### PR TITLE
Add missing limits to the correspondence doc

### DIFF
--- a/correspondence/index.bs
+++ b/correspondence/index.bs
@@ -152,6 +152,17 @@ User agents are not required to use these formulas and may expose whatever they 
 
             Issue: When using argument buffers: ?
     <tr>
+        <th>`maxBindGroupsPlusVertexBuffers`
+        <td>[#2749](https://github.com/gpuweb/gpuweb/issues/2749)
+        <td><p class=issue>*No documented limit?*
+        <td>*Strategy-dependent.* When using argument buffers, `Maximum number of _____ you can access, per stage, from an argument buffer`
+        <td><p class=issue>*No documented limit?*
+    <tr>
+        <th>`maxBindingsPerBindGroup`
+        <td>[#3279](https://github.com/gpuweb/gpuweb/issues/3279),
+            [#3864](https://github.com/gpuweb/gpuweb/issues/3864)
+        <td colspan=3>Limit is arbitrary to allow implementations to treat binding space as an array.
+    <tr>
         <th>`maxSamplersPerShaderStage`
         <td>[#409](https://github.com/gpuweb/gpuweb/issues/409)
         <td>`maxPerStageDescriptorSamplers`
@@ -237,6 +248,13 @@ User agents are not required to use these formulas and may expose whatever they 
         <td>`Maximum number of color render targets per render
     pass descriptor`
         <td>8 = `D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT`
+    <tr>
+        <th>`maxColorAttachmentBytesPerSample`
+        <td>[#2965](https://github.com/gpuweb/gpuweb/issues/2965)
+        <td><p class=issue>*No documented limit?*
+        <td>Mostly `Maximum total render target size, per pixel, when using multiple color render targets`,
+            but it's [a bit more complicated than that](https://github.com/gpuweb/gpuweb/issues/2965#issuecomment-1223792432)
+        <td><p class=issue>*No documented limit?*
     <tr>
         <th>`maxComputeWorkgroupStorageSize`
         <td>[#1863](https://github.com/gpuweb/gpuweb/issues/1863)

--- a/correspondence/index.bs
+++ b/correspondence/index.bs
@@ -154,9 +154,9 @@ User agents are not required to use these formulas and may expose whatever they 
     <tr>
         <th>`maxBindGroupsPlusVertexBuffers`
         <td>[#2749](https://github.com/gpuweb/gpuweb/issues/2749)
-        <td><p class=issue>*No documented limit?*
+        <td>No limit. Choose e.g. `max(default, maxBindGroups + maxVertexBuffers)`.
         <td>*Strategy-dependent.* When using argument buffers, `Maximum number of _____ you can access, per stage, from an argument buffer`
-        <td><p class=issue>*No documented limit?*
+        <td>No limit. Choose e.g. `max(default, maxBindGroups + maxVertexBuffers)`.
     <tr>
         <th>`maxBindingsPerBindGroup`
         <td>[#3279](https://github.com/gpuweb/gpuweb/issues/3279),


### PR DESCRIPTION
Fixes #4273

The missing limits were either only applicable to Metal or arbitrary, so there's not a lot of detail to add here. Happy to add more references if I've missed some relevant D3D or Vulkan limit.