### PR TITLE
Fix 2d-array texture view as a renderable texture view

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10967,7 +10967,7 @@ dictionary GPURenderPassColorAttachment {
             - If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is [=map/exist|provided=]:
                 - |renderTexture|.{{GPUTexture/sampleCount}} must be &gt; 1.
                 - |resolveTexture|.{{GPUTexture/sampleCount}} must be 1.
-                - |this|.{{GPURenderPassColorAttachment/resolveTarget}} must be a [$renderable texture view$].
+                - |this|.{{GPURenderPassColorAttachment/resolveTarget}} must be a non-3d [$renderable texture view$].
                 - |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[renderExtent]]}} and
                     |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[renderExtent]]}} must match.
                 - |resolveViewDescriptor|.{{GPUTextureViewDescriptor/format}} must equal
@@ -10986,7 +10986,8 @@ dictionary GPURenderPassColorAttachment {
         1. Let |descriptor| be |view|.{{GPUTextureView/[[descriptor]]}}.
         1. |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/usage}}
             must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
-        1. |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be either {{GPUTextureViewDimension/"2d"}} or {{GPUTextureViewDimension/"3d"}}.
+        1. |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be {{GPUTextureViewDimension/"2d"}}
+            or {{GPUTextureViewDimension/"2d-array"}} or {{GPUTextureViewDimension/"3d"}}.
         1. |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
         1. |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be 1.
         1. |descriptor|.{{GPUTextureViewDescriptor/aspect}} must refer to all [=aspects=] of


### PR DESCRIPTION
Fixes #4607, #4600
- Allow 2d-array texture view as renderable texture view
- Disallow 3d texture view used in resolve target