### PR TITLE
Allow bitcast to flush to zero

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11968,7 +11968,8 @@ the following differences:
     with a zero value of that type.
     * Any inputs or outputs of operations listed in [[#floating-point-accuracy]] may be flushed to zero.
     * Additionally, intermediate values of operations listed in
-        [[#pack-builtin-functions]] or [[#unpack-builtin-functions]] may be flushed to zero.
+        [[#bit-reinterp-builtin-functions]], [[#pack-builtin-functions]], or
+        [[#unpack-builtin-functions]] may be flushed to zero.
     * Other operations are required to preserve denormalized numbers.
 * The accuracy of operations is given in [[#floating-point-accuracy]].
 


### PR DESCRIPTION
Fixes #4623

* Add bit reinterpretation built-in functions to list of flushable functions