### PR TITLE
Clarify that pipeline-overrides don't have to be statically used to be set

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7137,6 +7137,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         1. |key| |must| equal the [=pipeline-overridable constant identifier string=] of
             some [=pipeline-overridable=] constant defined in the shader module
             |descriptor|.{{GPUProgrammableStage/module}} by the rules defined in [=WGSL identifier comparison=].
+            The pipeline-overridable constant is *not* required to be [=statically used=] by |entryPoint|.
             Let the type of that constant be |T|.
         1. Converting the IDL value |value| [$to WGSL type$] |T| |must| not throw a {{TypeError}}.
     1. For each [=pipeline-overridable constant identifier string=] |key| which is


### PR DESCRIPTION


Issue: #4624