### PR TITLE
Add a better definition for 'texture'

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3565,9 +3565,10 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
 A <dfn dfn>texture</dfn> is made up of {{GPUTextureDimension/1d}}, {{GPUTextureDimension/2d}},
 or {{GPUTextureDimension/3d}} arrays of data which can contain multiple values per-element to
-represent things like colors. Depending on the {{GPUTextureUsage}} they are created with, textures
-can be read or sampled from render pipelines, read and written to from compute pipelines, and set as
-attachments to render passes. Textures are stored in GPU memory with an layout optimized for
+represent things like colors. Textures can be read and written in many ways, depending on the
+{{GPUTextureUsage}} they are created with. For example, textures can be sampled, read, and written
+from render and compute pipeline shaders, and they can be written by render pass outputs.
+Internally, textures are often stored in GPU memory with a layout optimized for
 multidimensional access rather than linear access.
 
 One [=texture=] consists of one or more <dfn dfn>texture subresources</dfn>,

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3563,11 +3563,12 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 <span id=texture-interface></span>
 </h3>
 
-A <dfn dfn>texture</dfn> is a {{GPUTextureDimension/1d}}, {{GPUTextureDimension/2d}}, or
-{{GPUTextureDimension/3d}} array of data which can contain multiple values per-element to represent
-things like colors. Depending on the {{GPUTextureUsage}} they are created with, textures can be read
-or sampled from render pipelines, read and written to from compute pipelines, and set as attachments
-to render passes.
+A <dfn dfn>texture</dfn> is made up of {{GPUTextureDimension/1d}}, {{GPUTextureDimension/2d}},
+or {{GPUTextureDimension/3d}} arrays of data which can contain multiple values per-element to
+represent things like colors. Depending on the {{GPUTextureUsage}} they are created with, textures
+can be read or sampled from render pipelines, read and written to from compute pipelines, and set as
+attachments to render passes. Textures are stored in GPU memory with an layout optimized for
+multidimensional access rather than linear access.
 
 One [=texture=] consists of one or more <dfn dfn>texture subresources</dfn>,
 each uniquely identified by a [=mipmap level=] and,

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3563,9 +3563,13 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 <span id=texture-interface></span>
 </h3>
 
-Issue: Remove this definition: <dfn dfn>texture</dfn>
+A <dfn dfn>texture</dfn> is a {{GPUTextureDimension/1d}}, {{GPUTextureDimension/2d}}, or
+{{GPUTextureDimension/3d}} array of data which can contain multiple values per-element to represent
+things like colors. Depending on the {{GPUTextureUsage}} they are created with, textures can be read
+or sampled from render pipelines, read and written to from compute pipelines, and set as attachments
+to render passes.
 
-One texture consists of one or more <dfn dfn>texture subresources</dfn>,
+One [=texture=] consists of one or more <dfn dfn>texture subresources</dfn>,
 each uniquely identified by a [=mipmap level=] and,
 for {{GPUTextureDimension/2d}} textures only, [=array layer=] and [=aspect=].
 


### PR DESCRIPTION
Happy to hear suggestions if we want to add anything else here. Direct3D glossary points out that the memory for textures is optimized for multidimensional access, but I'm not sure if that applies to mobile. They also point out that textures are frequently used for image data, which may be worth calling out here?