### PR TITLE
Describe how comparison samplers interact with filtering

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5172,10 +5172,10 @@ enum GPUMipmapFilterMode {
 </dl>
 
 {{GPUCompareFunction}} specifies the behavior of a comparison sampler. If a comparison sampler is
-used in a shader, an input value is compared to each sampled texel value, and the result of this
+used in a shader, the `depth_ref` is compared to the fetched texel value, and the result of this
 comparison test is generated (`1.0f` for pass, or `0.0f` for fail).
 
-If texture filtering is enabled, the filtering step occurs after comparison, so that comparison
+After comparison, if texture filtering is enabled, the filtering step occurs, so that comparison
 results are mixed together resulting in values in the range `[0, 1]`. Filtering **should** behave
 as usual, however it **may** be computed with lower precision or not mix results at all.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5173,7 +5173,7 @@ enum GPUMipmapFilterMode {
 
 {{GPUCompareFunction}} specifies the behavior of a comparison sampler. If a comparison sampler is
 used in a shader, an input value is compared to each sampled texel value, and the result of this
-comparison test is generated (`0.0f` for pass, or `1.0f` for fail).
+comparison test is generated (`1.0f` for pass, or `0.0f` for fail).
 
 If texture filtering is enabled, the filtering step occurs after comparison, so that comparison
 results are mixed together resulting in values in the range `[0, 1]`. Filtering **should** behave

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5172,10 +5172,11 @@ enum GPUMipmapFilterMode {
 </dl>
 
 {{GPUCompareFunction}} specifies the behavior of a comparison sampler. If a comparison sampler is
-used in a shader, an input value is compared to the sampled texture value, and the result of this
-comparison test (0.0f for pass, or 1.0f for fail) is used in the filtering operation.
+used in a shader, an input value is compared to each sampled texel value, and the result of this
+comparison test is generated (`0.0f` for pass, or `1.0f` for fail).
 
-Issue: describe how filtering interacts with comparison sampling.
+The comparison results for each texel may be blended together with the sampler's normal
+texture filtering, with the resulting value in the range `[0..1]` returned.
 
 <script type=idl>
 enum GPUCompareFunction {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5175,8 +5175,9 @@ enum GPUMipmapFilterMode {
 used in a shader, an input value is compared to each sampled texel value, and the result of this
 comparison test is generated (`0.0f` for pass, or `1.0f` for fail).
 
-The comparison results for each texel may be blended together with the sampler's normal
-texture filtering, with the resulting value in the range `[0..1]` returned.
+If texture filtering is enabled, the filtering step occurs after comparison, so that comparison
+results are mixed together resulting in values in the range `[0, 1]`. Filtering **should** behave
+as usual, however it **may** be computed with lower precision or not mix results at all.
 
 <script type=idl>
 enum GPUCompareFunction {


### PR DESCRIPTION
Best references I could find for this behavior from each API:

**Vulkan**
https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#formats-properties
Under VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT it states
> "If the format being queried is a depth/stencil format, this bit only specifies that the depth aspect
(not the stencil aspect) of an image of this format supports linear filtering, and that linear
filtering of the depth aspect is supported whether depth compare is enabled in the sampler or not.
Where depth comparison is supported it may be linear filtered whether this bit is present or not,
but where this bit is not present the filtered value may be computed in an implementation-dependent
manner which differs from the normal rules of linear filtering. The resulting value must be in the
range [0,1] and should be proportional to, or a weighted average of, the number of comparison passes
or failures."

**D3D**
https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-to-samplecmp
> "For each texel fetched (based on the sampler configuration of the filter mode), SampleCmp performs
a comparison of the z value (3rd component of input) from the shader against the texel value (1 if
the comparison passes; otherwise 0). SampleCmp then blends these 0 and 1 results for each texel
together as in normal texture filtering (not an average) and returns the resulting [0..1] value to
the shader."

**Metal**
https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf
Section 6.12.10 2D Depth Texture
> "sample_compare performs a comparison of the compare_value value against the pixel
value (1.0 if the comparison passes and 0.0 if it fails). These comparison result values perpixel
are then blended together as in normal texture filtering and the resulting value between 0.0 and 1.0
is returned."

Unfortunately while D3D and Metal seem pretty clear about the behavior it seems that Vulkan leaves some wiggle room, which is why this PR only says that the texel results _may_ be blended.