### PR TITLE
Subgroups proposal: Consider subgroup_size used in compute stage uniform

### DIFF
--- a/proposals/subgroups.md
+++ b/proposals/subgroups.md
@@ -74,6 +74,8 @@ Some possibilities:
 | `subgroup_size` | u32 | Input | The size of the current subgroup |
 | `subgroup_invocation_id` | u32 | Input | The index of the invocation in the current subgroup |
 
+When used in `compute` shader stage, `subgroup_size` should be considered uniform for uniformity analysis.
+
 Note: HLSL does not expose a subgroup_id or num_subgroups equivalent.
 
 **TODO**: Can subgroup_id and/or num_subgroups be emulated efficiently and portably?


### PR DESCRIPTION
Currently only `workgroup_id` and `num_workgroups` built-in values are considered uniform according to [spec](https://gpuweb.github.io/gpuweb/wgsl/#uniformity-expressions:~:text=The%20following%20built,considered%20non%2Duniform.). 

Treating `subgroup_size` as uniform may help writing flexible kernel that fit to different actual subgroup size, and allow using functions like `workgroupBarrier` and `subgroupBroadcast` (if  requiring that the subgroup operations only be used in uniform control flow) under condition of subgroup size, like
```
    if (subgroupSize == 16) {
        ...
        workgroupBarrier();
        let a0 = subgroupBroadcast(a[0], 0u);
        ...
    } else {
        // Fall back path
        ...
    }
```


The Vulkan spec, in `SubgroupSize` of 15.9. Built-In Variables section, required that
> The value may vary across a single draw call, and for fragment shaders may vary across a single primitive. ***In compute dispatches, SubgroupSize must be uniform with command scope.***

I don't find explicit requirement in MSL/HLSL spec, but I think they should work in the same way for compute kernel.