### PR TITLE
Replace asynchronous .requestAdapterInfo() with synchronous .info

### DIFF
--- a/design/AdapterIdentifiers.md
+++ b/design/AdapterIdentifiers.md
@@ -1,5 +1,10 @@
 # WebGPU Adapter Identifiers
 
+**This document is outdated. `adapter.requestAdapterInfo()` has been replaced with
+`adapter.info` and `unmaskHints` doesn't exist anymore. See:
+[#4536](https://github.com/gpuweb/gpuweb/issues/4536),
+[#4316](https://github.com/gpuweb/gpuweb/pull/4316).
+
 ## Introduction
 
 The WebGL extension [WEBGL_debug_renderer_info](https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_renderer_info/) reports identifying information about a device's graphics driver for the purposes of debugging or detection and avoidance of bugs or performance pitfalls on a particular driver or piece of hardware.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1042,7 +1042,6 @@ Several operations in WebGPU return promises.
 
 - {{GPU}}.{{GPU/requestAdapter()}}
 - {{GPUAdapter}}.{{GPUAdapter/requestDevice()}}
-- {{GPUAdapter}}.{{GPUAdapter/requestAdapterInfo()}}
 - {{GPUDevice}}.{{GPUDevice/createComputePipelineAsync()}}
 - {{GPUDevice}}.{{GPUDevice/createRenderPipelineAsync()}}
 - {{GPUBuffer}}.{{GPUBuffer/mapAsync()}}
@@ -1963,9 +1962,6 @@ including the absence of those values.
 
 The info exposed by a {{GPUAdapter}} is immutable: for a given adapter, each {{GPUAdapterInfo}}
 attribute will return the same value every time it's accessed.
-If multiple {{GPUAdapterInfo}} objects have been retrieved from a given adapter
-(via either {{GPUAdapter/info|GPUAdapter.info}} or {{GPUAdapter/requestAdapterInfo()}}),
-they must all expose the same contents.
 
 Note:
 Though the adapter info is immutable *once accessed*, an implementation may delay the decision on
@@ -2616,7 +2612,6 @@ interface GPUAdapter {
     readonly attribute boolean isFallbackAdapter;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
-    Promise<GPUAdapterInfo> requestAdapterInfo();
 };
 </script>
 
@@ -2633,12 +2628,9 @@ interface GPUAdapter {
 
     : <dfn>info</dfn>
     ::
-        The {{GPUAdapterInfo}} for this adapter. Returns the same object each time.
+        Info about the physical graphics adapter underlying this {{GPUAdapter}}.
 
-        Synchronous version of the deprecated {{GPUAdapter/requestAdapterInfo()}} method.
-
-        For a given adapter, its adapter info is constant over time, and all {{GPUAdapterInfo}}
-        objects from that adapter produce the same contents.
+        For a given adapter, its adapter info is constant over time.
 
     : <dfn>isFallbackAdapter</dfn>
     ::
@@ -2759,37 +2751,6 @@ interface GPUAdapter {
                     Note:
                     If the device is already lost because the adapter could not fulfill the request,
                     |device|.{{GPUDevice/lost}} has already resolved before |promise| resolves.
-            </div>
-        </div>
-
-    : <dfn>requestAdapterInfo()</dfn>
-    ::
-        Requests {{GPUAdapterInfo}} for this {{GPUAdapter}}.
-
-        Returns a new object each time, whereas <code>adapter.{{GPUAdapter/info}}</code>
-        returns the same object each time.
-
-        <div class=note heading>
-            This is deprecated (but not planned for removal) in favor of the newer, synchronous
-            {{GPUAdapter/info|GPUAdapter.info}} property, which reports the same info.
-            Both entry points expose the same information.
-
-            This async entry point always returns an already-resolved promise.
-            It will not perform long-running tasks (such as user permission prompts).
-        </div>
-
-        <div algorithm=GPUAdapter.requestAdapterInfo>
-            <div data-timeline=content>
-                **Called on:** {{GPUAdapter}} |this|.
-
-                **Returns:** {{Promise}}&lt;{{GPUAdapterInfo}}&gt;
-
-                [=Content timeline=] steps:
-
-                1. Let |promise| be [=a new promise=].
-                1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
-                1. [=Resolve=] |promise| with a [$new adapter info$] for |adapter|.
-                1. Return |promise|.
             </div>
         </div>
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1955,10 +1955,16 @@ interface WGSLLanguageFeatures {
 
 {{GPUAdapterInfo}} exposes various identifying information about an adapter.
 
-None of the members in {{GPUAdapterInfo}} are guaranteed to be populated. It is at the user
+None of the members in {{GPUAdapterInfo}} are guaranteed to be populated (non-empty). It is at the user
 agent's discretion which values to reveal, and it is likely that on some devices none of the values
 will be populated. As such, applications **must** be able to handle any possible {{GPUAdapterInfo}} values,
 including the absence of those values.
+
+All {{GPUAdapterInfo}} objects from a given adapter **should** produce the same contents
+at any given time, regardless of which way they're accessed.
+The contents could change over time; for example, if some call to
+{{GPUAdapter/requestAdapterInfo()}} reveals more information (though it generally **shouldn't**),
+it should be visible via {{GPUAdapter/info|GPUAdapter.info}} as well.
 
 <p tracking-vector>
 For privacy considerations, see [[#privacy-adapter-identifiers]].
@@ -2595,6 +2601,7 @@ To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 interface GPUAdapter {
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
+    [SameObject] readonly attribute GPUAdapterInfo info;
     readonly attribute boolean isFallbackAdapter;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
@@ -2612,6 +2619,14 @@ interface GPUAdapter {
     : <dfn>limits</dfn>
     ::
         The limits in `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[limits]]}}.
+
+    : <dfn>info</dfn>
+    ::
+        The {{GPUAdapterInfo}} for this adapter. Returns the same object each time, whereas
+        {{GPUAdapter/requestAdapterInfo()}} returns a new object each time.
+
+        All {{GPUAdapterInfo}} objects from a given adapter **should** produce the same contents
+        at any given time, regardless of which way they're accessed, but may change over time.
 
     : <dfn>isFallbackAdapter</dfn>
     ::
@@ -2737,10 +2752,19 @@ interface GPUAdapter {
 
     : <dfn>requestAdapterInfo()</dfn>
     ::
-        Requests the {{GPUAdapterInfo}} for this {{GPUAdapter}}.
+        Requests {{GPUAdapterInfo}} for this {{GPUAdapter}}.
 
-        Note: Adapter info values are returned with a Promise to give user agents an
-        opportunity to perform potentially long-running checks in the future.
+        Returns a new object each time, whereas <code>adapter.{{GPUAdapter/info}}</code>
+        returns the same object each time.
+
+        <div class=note heading>
+            The synchronous {{GPUAdapter/info|GPUAdapter.info}} reports the same info.
+            Generally there is no need to use the asynchronous {{GPUAdapter/requestAdapterInfo()}},
+            which **should** not reveal more information than {{GPUAdapter/info}}.
+
+            This async entry point (as defined currently) will not perform long-running checks
+            and always returns an already-resolved promise.
+        </div>
 
         <div algorithm=GPUAdapter.requestAdapterInfo>
             <div data-timeline=content>
@@ -2752,9 +2776,7 @@ interface GPUAdapter {
 
                 1. Let |promise| be [=a new promise=].
                 1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
-                1. Run the following steps [=in parallel=]:
-                    1. [=Resolve=] |promise| with a [$new adapter info$] for |adapter|.
-
+                1. [=Resolve=] |promise| with a [$new adapter info$] for |adapter|.
                 1. Return |promise|.
             </div>
         </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2632,6 +2632,8 @@ interface GPUAdapter {
 
         For a given adapter, its adapter info is constant over time.
 
+        The same object is returned each time. To create that object for the first time:
+
         <div algorithm=GPUAdapter.info>
             <div data-timeline=content>
                 **Called on:** {{GPUAdapter}} |this|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2632,6 +2632,18 @@ interface GPUAdapter {
 
         For a given adapter, its adapter info is constant over time.
 
+        <div algorithm=GPUAdapter.info>
+            <div data-timeline=content>
+                **Called on:** {{GPUAdapter}} |this|.
+
+                **Returns:** {{GPUAdapterInfo}}
+
+                [=Content timeline=] steps:
+
+                1. Return a [$new adapter info$] for |this|.{{GPUAdapter/[[adapter]]}}.
+            </div>
+        </div>
+
     : <dfn>isFallbackAdapter</dfn>
     ::
         Returns the value of {{GPUAdapter/[[adapter]]}}.{{adapter/[[fallback]]}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1963,13 +1963,19 @@ including the absence of those values.
 
 The info exposed by a {{GPUAdapter}} is immutable: for a given adapter, each {{GPUAdapterInfo}}
 attribute will return the same value every time it's accessed.
-If multiple {{GPUAdapterInfo}} objects have been retrieved from a given adapter (either via
-{{GPUAdapter/requestAdapterInfo()}} or {{GPUAdapter/info|GPUAdapter.info}}), they must all expose
-the same contents.
+If multiple {{GPUAdapterInfo}} objects have been retrieved from a given adapter
+(via either {{GPUAdapter/info|GPUAdapter.info}} or {{GPUAdapter/requestAdapterInfo()}}),
+they must all expose the same contents.
 
 Note:
 Though the adapter info is immutable *once accessed*, an implementation may delay the decision on
 what to expose for each attribute until the first time it is accessed.
+
+Note:
+Other {{GPUAdapter}} instances, even if they represent the same physical adapter, may expose
+different adapter info values. However, they **should** expose the same values unless a specific
+event has increased the amount of adapter info the page is allowed to access.
+(No such events are defined by this specification.)
 
 <p tracking-vector>
 For privacy considerations, see [[#privacy-adapter-identifiers]].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1954,23 +1954,24 @@ interface WGSLLanguageFeatures {
 
 {{GPUAdapterInfo}} exposes various identifying information about an adapter.
 
-None of the members in {{GPUAdapterInfo}} are guaranteed to be populated with any particular info;
+None of the members in {{GPUAdapterInfo}} are guaranteed to be populated with any particular value;
 if no value is provided, the attribute will return the empty string `""`. It is at the user
 agent's discretion which values to reveal, and it is likely that on some devices none of the values
 will be populated. As such, applications **must** be able to handle any possible {{GPUAdapterInfo}} values,
 including the absence of those values.
 
-The info exposed by a {{GPUAdapter}} is immutable: for a given adapter, each {{GPUAdapterInfo}}
+The information exposed by a {{GPUAdapter}} is immutable: for a given adapter, each {{GPUAdapterInfo}}
 attribute will return the same value every time it's accessed.
 
 Note:
-Though the adapter info is immutable *once accessed*, an implementation may delay the decision on
+Though the {{GPUAdapterInfo}} attributes are immutable *once accessed*, an implementation may delay the decision on
 what to expose for each attribute until the first time it is accessed.
 
 Note:
 Other {{GPUAdapter}} instances, even if they represent the same physical adapter, may expose
-different adapter info values. However, they **should** expose the same values unless a specific
-event has increased the amount of adapter info the page is allowed to access.
+different values in {{GPUAdapterInfo}}.
+However, they **should** expose the same values unless a specific
+event has increased the amount of identifying information the page is allowed to access.
 (No such events are defined by this specification.)
 
 <p tracking-vector>
@@ -2628,9 +2629,9 @@ interface GPUAdapter {
 
     : <dfn>info</dfn>
     ::
-        Info about the physical graphics adapter underlying this {{GPUAdapter}}.
+        Information about the physical adapter underlying this {{GPUAdapter}}.
 
-        For a given adapter, its adapter info is constant over time.
+        For a given {{GPUAdapter}}, the {{GPUAdapterInfo}} values exposed are constant over time.
 
         The same object is returned each time. To create that object for the first time:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1955,16 +1955,21 @@ interface WGSLLanguageFeatures {
 
 {{GPUAdapterInfo}} exposes various identifying information about an adapter.
 
-None of the members in {{GPUAdapterInfo}} are guaranteed to be populated (non-empty). It is at the user
+None of the members in {{GPUAdapterInfo}} are guaranteed to be populated with any particular info;
+if no value is provided, the attribute will return the empty string `""`. It is at the user
 agent's discretion which values to reveal, and it is likely that on some devices none of the values
 will be populated. As such, applications **must** be able to handle any possible {{GPUAdapterInfo}} values,
 including the absence of those values.
 
-All {{GPUAdapterInfo}} objects from a given adapter **should** produce the same contents
-at any given time, regardless of which way they're accessed.
-The contents could change over time; for example, if some call to
-{{GPUAdapter/requestAdapterInfo()}} reveals more information (though it generally **shouldn't**),
-it should be visible via {{GPUAdapter/info|GPUAdapter.info}} as well.
+The info exposed by a {{GPUAdapter}} is immutable: for a given adapter, each {{GPUAdapterInfo}}
+attribute will return the same value every time it's accessed.
+If multiple {{GPUAdapterInfo}} objects have been retrieved from a given adapter (either via
+{{GPUAdapter/requestAdapterInfo()}} or {{GPUAdapter/info|GPUAdapter.info}}), they must all expose
+the same contents.
+
+Note:
+Though the adapter info is immutable *once accessed*, an implementation may delay the decision on
+what to expose for each attribute until the first time it is accessed.
 
 <p tracking-vector>
 For privacy considerations, see [[#privacy-adapter-identifiers]].
@@ -2622,11 +2627,12 @@ interface GPUAdapter {
 
     : <dfn>info</dfn>
     ::
-        The {{GPUAdapterInfo}} for this adapter. Returns the same object each time, whereas
-        {{GPUAdapter/requestAdapterInfo()}} returns a new object each time.
+        The {{GPUAdapterInfo}} for this adapter. Returns the same object each time.
 
-        All {{GPUAdapterInfo}} objects from a given adapter **should** produce the same contents
-        at any given time, regardless of which way they're accessed, but may change over time.
+        Synchronous version of the deprecated {{GPUAdapter/requestAdapterInfo()}} method.
+
+        For a given adapter, its adapter info is constant over time, and all {{GPUAdapterInfo}}
+        objects from that adapter produce the same contents.
 
     : <dfn>isFallbackAdapter</dfn>
     ::
@@ -2758,12 +2764,12 @@ interface GPUAdapter {
         returns the same object each time.
 
         <div class=note heading>
-            The synchronous {{GPUAdapter/info|GPUAdapter.info}} reports the same info.
-            Generally there is no need to use the asynchronous {{GPUAdapter/requestAdapterInfo()}},
-            which **should** not reveal more information than {{GPUAdapter/info}}.
+            This is deprecated (but not planned for removal) in favor of the newer, synchronous
+            {{GPUAdapter/info|GPUAdapter.info}} property, which reports the same info.
+            Both entry points expose the same information.
 
-            This async entry point (as defined currently) will not perform long-running checks
-            and always returns an already-resolved promise.
+            This async entry point always returns an already-resolved promise.
+            It will not perform long-running tasks (such as user permission prompts).
         </div>
 
         <div algorithm=GPUAdapter.requestAdapterInfo>


### PR DESCRIPTION
Iteration on #4550.

Replaces the GPUAdapter method
`Promise<GPUAdapterInfo> requestAdapterInfo();`
with a synchronous attribute
`[SameObject] readonly attribute GPUAdapterInfo info;`

Important points:

- `requestAdapterInfo()` is removed. Chromium will deprecate and remove it and attempt to get any sites migrated off of it, so hopefully Firefox/Safari won't have to implement it at all (though the implementation is trivial so they may choose to, for compatibility with outdated sites).
- The available info about a given `GPUAdapter` may no longer change. You can only get new info by getting a new `GPUAdapter`. (The only reason this should happen is if someone adds a permission prompt for fingerprintability.)

Less important points:
- You can now only get one `GPUAdapterInfo` object per `GPUAdapter` object, since `adapter.info` returns the same object every time you access it.

Fixes #4536