### PR TITLE
Clarify list of context compatible formats

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13493,8 +13493,8 @@ specified points.
 
 The <dfn dfn>supported context formats</dfn> are a [=set=] of {{GPUTextureFormat}}s that must be
 supported when specified as a {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/format}}
-regardless of the given {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/device}},
-initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"rgba8unorm"}},
+regardless of the given {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/device}}, set to:
+&laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"rgba8unorm"}},
 {{GPUTextureFormat/"rgba16float"}}&raquo;.
 
 Note: Canvas configuration cannot use `srgb` formats like {{GPUTextureFormat/"bgra8unorm-srgb"}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13491,7 +13491,6 @@ specified points.
 
 ## GPUCanvasConfiguration ## {#canvas-configuration}
 
-:
 The <dfn dfn>supported context formats</dfn> are the [=set=] of {{GPUTextureFormat}}s:
 &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"rgba8unorm"}},
 {{GPUTextureFormat/"rgba16float"}}&raquo;. These formats must be supported when specified as a

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13494,7 +13494,7 @@ specified points.
 :
 The <dfn dfn>supported context formats</dfn> are the [=set=] of {{GPUTextureFormat}}s:
 &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"rgba8unorm"}},
-{{GPUTextureFormat/"rgba16float"}}&raquo; These formats must be supported when specified as a
+{{GPUTextureFormat/"rgba16float"}}&raquo;. These formats must be supported when specified as a
 {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/format}} regardless of the given
 {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/device}}.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13491,11 +13491,12 @@ specified points.
 
 ## GPUCanvasConfiguration ## {#canvas-configuration}
 
-The <dfn dfn>supported context formats</dfn> are a [=set=] of {{GPUTextureFormat}}s that must be
-supported when specified as a {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/format}}
-regardless of the given {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/device}}, set to:
+:
+The <dfn dfn>supported context formats</dfn> are the [=set=] of {{GPUTextureFormat}}s:
 &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"rgba8unorm"}},
-{{GPUTextureFormat/"rgba16float"}}&raquo;.
+{{GPUTextureFormat/"rgba16float"}}&raquo; These formats must be supported when specified as a
+{{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/format}} regardless of the given
+{{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/device}}.
 
 Note: Canvas configuration cannot use `srgb` formats like {{GPUTextureFormat/"bgra8unorm-srgb"}}.
 Instead, use the non-`srgb` equivalent ({{GPUTextureFormat/"bgra8unorm"}}), specify the `srgb`


### PR DESCRIPTION
Fixes #4644

While "initially set to" is common verbiage for initializing lists in W3C specs, here it gives the impression that the list is mutable and may be changed by some other part of the API. While that is a possibility as some point down the road for the time being the list is fixed, so I think this minor verbiage change is an improvement for reader comprehension.