### PR TITLE
Add a definition for 64-bit unsigned ints

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -104,7 +104,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: @binding; url: attribute-binding
         text: @group; url: attribute-group
         text: line break; url: line-break
-        text: u64; url: u64
+        text: 64-bit unsigned integer; url: 64-bit-integer
         for: address spaces
             text: workgroup; url: address-spaces-workgroup
         for: builtin
@@ -13154,7 +13154,7 @@ When beginning a render pass, {{GPURenderPassDescriptor}}.{{GPURenderPassDescrip
 must be set to be able to use occlusion queries during the pass. An occlusion query is begun
 and ended by calling {{GPURenderPassEncoder/beginOcclusionQuery()}} and
 {{GPURenderPassEncoder/endOcclusionQuery()}} in pairs that cannot be nested, and resolved into a
-{{GPUBuffer}} as [=u64|64-bit unsigned integer=] by {{GPUCommandEncoder}}.{{GPUCommandEncoder/resolveQuerySet()}}.
+{{GPUBuffer}} as a [=64-bit unsigned integer=] by {{GPUCommandEncoder}}.{{GPUCommandEncoder/resolveQuerySet()}}.
 
 ## Timestamp Query ## {#timestamp}
 
@@ -13163,7 +13163,7 @@ Timestamp queries allow applications to write timestamps to a {{GPUQuerySet}}, u
 - {{GPUComputePassDescriptor}}.{{GPUComputePassDescriptor/timestampWrites}}
 - {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/timestampWrites}}
 
-and then resolve timestamp values (in nanoseconds as a [=u64|64-bit unsigned integer=]) into
+and then resolve timestamp values (in nanoseconds as a [=64-bit unsigned integer=]) into
 a {{GPUBuffer}}, using {{GPUCommandEncoder}}.{{GPUCommandEncoder/resolveQuerySet()}}.
 
 Timestamp values are implementation defined and may not increase monotonically. The physical device

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -104,6 +104,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: @binding; url: attribute-binding
         text: @group; url: attribute-group
         text: line break; url: line-break
+        text: u64; url: u64
         for: address spaces
             text: workgroup; url: address-spaces-workgroup
         for: builtin
@@ -13153,7 +13154,7 @@ When beginning a render pass, {{GPURenderPassDescriptor}}.{{GPURenderPassDescrip
 must be set to be able to use occlusion queries during the pass. An occlusion query is begun
 and ended by calling {{GPURenderPassEncoder/beginOcclusionQuery()}} and
 {{GPURenderPassEncoder/endOcclusionQuery()}} in pairs that cannot be nested, and resolved into a
-{{GPUBuffer}} as 64-bit unsigned integer by {{GPUCommandEncoder}}.{{GPUCommandEncoder/resolveQuerySet()}}.
+{{GPUBuffer}} as [=u64|64-bit unsigned integer=] by {{GPUCommandEncoder}}.{{GPUCommandEncoder/resolveQuerySet()}}.
 
 ## Timestamp Query ## {#timestamp}
 
@@ -13162,7 +13163,7 @@ Timestamp queries allow applications to write timestamps to a {{GPUQuerySet}}, u
 - {{GPUComputePassDescriptor}}.{{GPUComputePassDescriptor/timestampWrites}}
 - {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/timestampWrites}}
 
-and then resolve timestamp values (in nanoseconds as a 64-bit unsigned integer) into
+and then resolve timestamp values (in nanoseconds as a [=u64|64-bit unsigned integer=]) into
 a {{GPUBuffer}}, using {{GPUCommandEncoder}}.{{GPUCommandEncoder/resolveQuerySet()}}.
 
 Timestamp values are implementation defined and may not increase monotonically. The physical device

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2674,10 +2674,6 @@ It uses a two's complementation representation, with the sign bit in the most si
     <tr><td>0x0u<td>0xffffffffu
 </table>
 
-The <dfn>u64</dfn> type is the set of 64-bit unsigned integers.
-
-Note: [=u64=] values are only used by the WebGPU API and not exposed directly to WGSL.
-
 Note: [=AbstractInt=] is also an integer type.
 
 ### Floating Point Types ### {#floating-point-types}
@@ -10253,8 +10249,9 @@ host-shared buffer, then:
 Note: Recall that [=i32=] uses twos-complement representation, so the sign bit
 is in bit position 31.
 
-When a value |V| of type [=u64=] is placed at byte offset |k| of a
-host-shared buffer, then:
+<dfn>64-bit integer</dfn> layout: Some features of the WebGPU API write 64-bit
+unsigned integer values into buffers. When such a value |V| appears at byte
+offset |k| of a host-shared buffer, then:
    * Byte |k| contains bits 0 through 7 of |V|
    * Byte |k|+1 contains bits 8 through 15 of |V|
    * Byte |k|+2 contains bits 16 through 23 of |V|
@@ -10264,7 +10261,7 @@ host-shared buffer, then:
    * Byte |k|+6 contains bits 48 through 55 of |V|
    * Byte |k|+7 contains bits 56 through 63 of |V|
 
-Note: [=u64=] values are only used by the [[!WebGPU]] API and not exposed directly to WGSL programs.
+Note: WGSL does not have a [=type/concrete=] [=64-bit integer=] type.
 
 A value |V| of type [=f32=] is represented in [[!IEEE-754|IEEE-754]] binary32 format.
 It has one sign bit, 8 exponent bits, and 23 fraction bits.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2674,6 +2674,10 @@ It uses a two's complementation representation, with the sign bit in the most si
     <tr><td>0x0u<td>0xffffffffu
 </table>
 
+The <dfn>u64</dfn> type is the set of 64-bit unsigned integers.
+
+Note: [=u64=] values are only used by the WebGPU API and not exposed directly to WGSL.
+
 Note: [=AbstractInt=] is also an integer type.
 
 ### Floating Point Types ### {#floating-point-types}
@@ -10248,6 +10252,19 @@ host-shared buffer, then:
 
 Note: Recall that [=i32=] uses twos-complement representation, so the sign bit
 is in bit position 31.
+
+When a value |V| of type [=u64=] is placed at byte offset |k| of a
+host-shared buffer, then:
+   * Byte |k| contains bits 0 through 7 of |V|
+   * Byte |k|+1 contains bits 8 through 15 of |V|
+   * Byte |k|+2 contains bits 16 through 23 of |V|
+   * Byte |k|+3 contains bits 24 through 31 of |V|
+   * Byte |k|+4 contains bits 32 through 39 of |V|
+   * Byte |k|+5 contains bits 40 through 47 of |V|
+   * Byte |k|+6 contains bits 48 through 55 of |V|
+   * Byte |k|+7 contains bits 56 through 63 of |V|
+
+Note: [=u64=] values are only used by the [[!WebGPU]] API and not exposed directly to WGSL programs.
 
 A value |V| of type [=f32=] is represented in [[!IEEE-754|IEEE-754]] binary32 format.
 It has one sign bit, 8 exponent bits, and 23 fraction bits.


### PR DESCRIPTION
Fixes #4289

Following guidance in the linked issue, I've added the definition and description of the byte layout to the WGSL spec with a note that it's not a type that can be used by WGSL and then referenced it in the WebGPU spec. If there's anything we should change here to further clarify the relationship, I'm happy to do it!