### PR TITLE
Remove createShaderModule and createCommandEncoder issues

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6413,23 +6413,21 @@ dictionary GPUShaderModuleDescriptor
             <div data-timeline=device>
                 [=Device timeline=] |initialization steps|:
 
-                1. Let |result| be the result of [=shader module creation=] with the WGSL source
-                    |descriptor|.{{GPUShaderModuleDescriptor/code}}.
+                1. Let |error| be any error that results from [=shader module creation=] with the
+                    WGSL source |descriptor|.{{GPUShaderModuleDescriptor/code}}, or `null` if no
+                    errors occured.
                 1. If any of the following requirements are unmet,
                     [$generate a validation error$], [$invalidate$] |sm|, and return.
 
                     <div class=validusage>
                         - |this| must not be [$invalid|lost$].
-                        - |result| must not be a [=shader-creation error|shader-creation=] [=program error=].
+                        - |error| must not be a [=shader-creation error|shader-creation=] [=program error=].
                     </div>
 
                     Note: [=Uncategorized errors=] cannot arise from shader module creation.
                     Implementations which detect such errors during shader module creation
                     must behave as if the shader module is valid, and defer surfacing the
                     error until pipeline creation.
-
-                Issue: Describe remaining {{GPUDevice/createShaderModule()}} validation and
-                algorithm steps.
 
                 <div class=note heading>
                     User agents **should not** include detailed compiler error messages or shader text in
@@ -9431,9 +9429,6 @@ dictionary GPUCommandEncoderDescriptor
                     <div class=validusage>
                         - |this| must not be [$invalid|lost$].
                     </div>
-
-                Issue: Describe remaining {{GPUDevice/createCommandEncoder()}} validation and
-                algorithm steps.
             </div>
         </div>
 </dl>


### PR DESCRIPTION
These algorithms aren't missing any validation steps, and are as complete as other creation algorithms in terms of setting internal slots (of which they have none.) So it seems like the issues are no longer necessary.

A more detailed discussion about how the WGSL spec communicates back to the WebGPU spec and what objects it surfaces is probably warranted, but that's a larger issue that should be addressed separately.