### PR TITLE
Point to TC39 draft of source map spec instead of sourcemaps.info

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -23,19 +23,6 @@ Markup Shorthands: css no
 Assume Explicit For: yes
 </pre>
 
-<pre class=biblio>
-{
-    "SourceMap": {
-        "authors": [
-            "John Lenz",
-            "Nick Fitzgerald"
-        ],
-        "href": "https://sourcemaps.info/spec.html",
-        "title": "Source Map Revision 3 Proposal"
-    }
-}
-</pre>
-
 <pre class=link-defaults>
 spec:webidl; type:exception; text:TypeError
 spec:webidl; type:exception; text:RangeError
@@ -6346,10 +6333,16 @@ dictionary GPUShaderModuleDescriptor
 
     : <dfn>sourceMap</dfn>
     ::
-        If defined MAY be interpreted as a source-map-v3 format.
+        If defined, **may** be interpreted in the [[!SourceMap]] v3 format.
 
-        Source maps are optional, but serve as a standardized way to support dev-tool
-        integration such as source-language debugging [[SourceMap]].
+        If an implementation supports this option but is unable to process the provided value,
+        it should show a developer-visible warning but must not produce any application-observable
+        error.
+
+        Note:
+        Source map support is optional, but serves as a semi-standardized way to support dev-tool
+        integration such as source-language debugging.
+
         WGSL names (identifiers) in source maps follow the rules defined in [=WGSL identifier
         comparison=].
 


### PR DESCRIPTION
This appears to be where the spec lives now for cross-reference purposes.
https://tc39.es/source-map/
https://github.com/tc39/source-map

Also:
- Make it a normative reference as intended (add the exclamation mark in `[[!SourceMap]]`; there are no more specific terms defined in the SourceMap spec that would be better to link to directly).
- Write some text about how it's supposed to behave normatively. (Only the `Source map support is optional...` paragraph is non-normative.)