### PR TITLE
Fixes for invoke-mermaid.sh and invoke-bikeshed.sh

### DIFF
--- a/tools/check-repo-clean.sh
+++ b/tools/check-repo-clean.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 
 status=$(git status -s)
 

--- a/tools/copy-if-different.sh
+++ b/tools/copy-if-different.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 
 usage()
 {

--- a/tools/custom-action/entrypoint.sh
+++ b/tools/custom-action/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash --login
-set -eo pipefail
+set -euo pipefail
 
 source /prepare.sh # Execute the prepare script
 git init # To ensure subsequent git commands pick the workspace

--- a/tools/custom-action/prepare.sh
+++ b/tools/custom-action/prepare.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 
 source /dependency-versions.sh # Source dependency versions
 cp -r /grammar ./wgsl/

--- a/tools/install-dependencies.sh
+++ b/tools/install-dependencies.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 source ./tools/custom-action/dependency-versions.sh # Source dependency versions
 
 code=1

--- a/tools/invoke-mermaid.sh
+++ b/tools/invoke-mermaid.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 source ../tools/custom-action/dependency-versions.sh # Source dependency versions
 
 cfg_file=$(dirname "$0")/mermaid.json
@@ -8,16 +8,15 @@ cfg_puppeteer_file=$(dirname "$0")/mermaid-puppeteer.json
 # This script is meant to be run in parallel with itself, so it uses --no to
 # disable the prompt to install new packages (and avoid npx racing with itself).
 # Use tools/install-dependencies.sh to install the package explicitly.
-npx --no -- @mermaid-js/mermaid-cli@$NPM_MERMAID_CLI_VERSION --puppeteerConfigFile "$cfg_puppeteer_file" --backgroundColor black --configFile "$cfg_file" "$@"
-ret=$?
-
-if [ "$ret" != 0 ]; then
-        echo '**************** Mermaid is not installed. *****************'
-        echo '*** Please run `tools/install-dependencies.sh diagrams`. ***'
-    if [ -n "$REQUIRE_DIAGRAM_GENERATION" ]; then
+npx --no -- @mermaid-js/mermaid-cli@$NPM_MERMAID_CLI_VERSION --puppeteerConfigFile "$cfg_puppeteer_file" --backgroundColor black --configFile "$cfg_file" "$@" || {
+    echo
+    echo '**************** Mermaid is not installed. *****************'
+    echo '*** Please run `tools/install-dependencies.sh diagrams`. ***'
+    if [ -n "${REQUIRE_DIAGRAM_GENERATION:=}" ]; then
         echo '**** Failing because REQUIRE_DIAGRAM_GENERATION is set. ****'
-        exit "$ret"
+        exit 1
     else
         echo '********** Skipping mermaid diagram regeneration. **********'
     fi
-fi
+    echo
+}

--- a/tools/populate-out.sh
+++ b/tools/populate-out.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is called from the repository root. Populates out/ with everything to
 # publish on GitHub Pages and PR previews.
-set -eo pipefail
+set -euo pipefail
 
 mkdir -p out/{wgsl,wgsl/grammar,explainer,correspondence}
 


### PR DESCRIPTION
- Since we enabled `set -e`, `invoke-mermaid.sh` was no longer printing its helpful message when mermaid wasn't installed.
- The Bikeshed API changed to return `HTTP/2 200` instead of `HTTP/1.1 200` so we need to handle that. Also updated it to use verbose argument names, and bash arrays (helps with `set -u`).
- Enable `set -u` to help catch bash programming errors (using undefined variables). `${VAR:=}` is used where we need to explicitly opt out of that (for optional environment variables).