### PR TITLE
Complete algorithm for copyTextureToTexture

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9936,21 +9936,24 @@ dictionary GPUCommandEncoderDescriptor
                 1. Let |srcBlockOriginY| be (|srcOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
 
                 1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}};
-                1. Let |dstBlockOriginX| be (|destination|.[=GPUOrigin3D/x=] &div; |blockWidth|).
-                1. Let |dstBlockOriginY| be (|destination|.[=GPUOrigin3D/y=] &div; |blockHeight|).
+                1. Let |dstBlockOriginX| be (|dstOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
+                1. Let |dstBlockOriginY| be (|dstOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
 
                 1. Let |blockColumns| be (|copySize|.[=GPUExtent3D/width=] &div; |blockWidth|).
                 1. Let |blockRows| be (|copySize|.[=GPUExtent3D/height=] &div; |blockHeight|).
 
+                1. [=Assert=] that |srcBlockOriginX|, |srcBlockOriginY|, |dstBlockOriginX|, |dstBlockOriginY|,
+                    |blockColumns|, and |blockRows| are integers.
+
                 1. For each |z| in the range [0, |copySize|.[=GPUExtent3D/depthOrArrayLayers=] &minus; 1]:
-                    1. Let |srcSubresource| be [$texture copy subresource$] (|z| &plus; |srcOrigin|.[=GPUOrigin3D/z=]) of |source|.
-                    1. Let |dstSubresource| be [$texture copy subresource$] (|z| &plus; |dstOrigin|.[=GPUOrigin3D/z=]) of |destination|.
+                    1. Let |srcSubregion| be [$texture copy sub-region$] (|z| &plus; |srcOrigin|.[=GPUOrigin3D/z=]) of |source|.
+                    1. Let |dstSubregion| be [$texture copy sub-region$] (|z| &plus; |dstOrigin|.[=GPUOrigin3D/z=]) of |destination|.
 
                     1. For each |y| in the range [0, |blockRows| &minus; 1]:
                         1. For each |x| in the range [0, |blockColumns| &minus; 1]:
                             1. Set [=texel block=] (|dstBlockOriginX| &plus; |x|, |dstBlockOriginY| &plus; |y|) of
-                                |dstSubresource| to be an [=equivalent texel representation=] to [=texel block=]
-                                (|srcBlockOriginX| &plus; |x|, |srcBlockOriginY| &plus; |y|) of |srcSubresource|.
+                                |dstSubregion| to be an [=equivalent texel representation=] to [=texel block=]
+                                (|srcBlockOriginX| &plus; |x|, |srcBlockOriginY| &plus; |y|) of |srcSubregion|.
             </div>
 
         </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9928,7 +9928,29 @@ dictionary GPUCommandEncoderDescriptor
             <div data-timeline=queue>
                 [=Queue timeline=] steps:
 
-                Issue: Define copy, including provision for snorm.
+                1. Let |blockWidth| be the [=texel block width=] of |source|.{{GPUImageCopyTexture/texture}}.
+                1. Let |blockHeight| be the [=texel block height=] of |source|.{{GPUImageCopyTexture/texture}}.
+
+                1. Let |srcOrigin| be |source|.{{GPUImageCopyTexture/origin}};
+                1. Let |srcBlockOriginX| be (|srcOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
+                1. Let |srcBlockOriginY| be (|srcOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
+
+                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}};
+                1. Let |dstBlockOriginX| be (|destination|.[=GPUOrigin3D/x=] &div; |blockWidth|).
+                1. Let |dstBlockOriginY| be (|destination|.[=GPUOrigin3D/y=] &div; |blockHeight|).
+
+                1. Let |blockColumns| be (|copySize|.[=GPUExtent3D/width=] &div; |blockWidth|).
+                1. Let |blockRows| be (|copySize|.[=GPUExtent3D/height=] &div; |blockHeight|).
+
+                1. For each |z| in the range [0, |copySize|.[=GPUExtent3D/depthOrArrayLayers=] &minus; 1]:
+                    1. Let |srcSubresource| be [$texture copy subresource$] (|z| &plus; |srcOrigin|.[=GPUOrigin3D/z=]) of |source|.
+                    1. Let |dstSubresource| be [$texture copy subresource$] (|z| &plus; |dstOrigin|.[=GPUOrigin3D/z=]) of |destination|.
+
+                    1. For each |y| in the range [0, |blockRows| &minus; 1]:
+                        1. For each |x| in the range [0, |blockColumns| &minus; 1]:
+                            1. Set [=texel block=] (|dstBlockOriginX| &plus; |x|, |dstBlockOriginY| &plus; |y|) of
+                                |dstSubresource| to be an [=equivalent texel representation=] to [=texel block=]
+                                (|srcBlockOriginX| &plus; |x|, |srcBlockOriginY| &plus; |y|) of |srcSubresource|.
             </div>
 
         </div>

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -168,22 +168,21 @@ dictionary GPUImageCopyTexture {
 </dl>
 
 <div algorithm data-timeline=const>
-    The <dfn abstract-op>texture copy subresource</dfn> for depth slice or array layer |z| of {{GPUImageCopyTexture}}
+    The <dfn abstract-op>texture copy sub-region</dfn> for depth slice or array layer |index| of {{GPUImageCopyTexture}}
     |copyTexture| is determined by running the following steps:
 
         1. Let |texture| be |copyTexture|.{{GPUImageCopyTexture/texture}}.
         1. If |texture|.{{GPUTexture/dimension}} is:
             <dl class=switch>
                 : {{GPUTextureDimension/1d}}
-                :: Let |depthSliceOrLayer| be |texture|
-
-                    Note: {{GPUTextureDimension/1d}} textures cannot have array layers.
+                ::  1. [=Assert=] |index| is `0`
+                    1. Let |depthSliceOrLayer| be |texture|
 
                 : {{GPUTextureDimension/2d}}
-                :: Let |depthSliceOrLayer| be array layer |z| of |texture|
+                :: Let |depthSliceOrLayer| be array layer |index| of |texture|
 
                 : {{GPUTextureDimension/3d}}
-                :: Let |depthSliceOrLayer| be depth slice |z| of |texture|
+                :: Let |depthSliceOrLayer| be depth slice |index| of |texture|
             </dl>
         1. Let |textureMip| be mip level |copyTexture|.{{GPUImageCopyTexture/mipLevel}} of |depthSliceOrLayer|.
         1. Return aspect |copyTexture|.{{GPUImageCopyTexture/aspect}} of |textureMip|.

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -28,8 +28,8 @@ and "immediate" {{GPUQueue}} operations:
 - {{GPUQueue/writeTexture()}}, for {{ArrayBuffer}}-to-{{GPUTexture}} writes
 - {{GPUQueue/copyExternalImageToTexture()}}, for copies from Web Platform image sources to textures
 
-Some texel values have multiple possible representations of some values,
-e.g. as `r8snorm`, -1.0 can be represented as either -127 or -128.
+Some texel values have <dfn dfn lt='equivalent texel representation'>multiple possible representations</dfn>
+of some values, e.g. as `r8snorm`, -1.0 can be represented as either -127 or -128.
 Copy commands are not guaranteed to preserve the source's bit-representation.
 
 The following definitions are used by these methods:
@@ -166,6 +166,28 @@ dictionary GPUImageCopyTexture {
     ::
         Defines which aspects of the {{GPUImageCopyTexture/texture}} to copy to/from.
 </dl>
+
+<div algorithm data-timeline=const>
+    The <dfn abstract-op>texture copy subresource</dfn> for depth slice or array layer |z| of {{GPUImageCopyTexture}}
+    |copyTexture| is determined by running the following steps:
+
+        1. Let |texture| be |copyTexture|.{{GPUImageCopyTexture/texture}}.
+        1. If |texture|.{{GPUTexture/dimension}} is:
+            <dl class=switch>
+                : {{GPUTextureDimension/1d}}
+                :: Let |depthSliceOrLayer| be |texture|
+
+                    Note: {{GPUTextureDimension/1d}} textures cannot have array layers.
+
+                : {{GPUTextureDimension/2d}}
+                :: Let |depthSliceOrLayer| be array layer |z| of |texture|
+
+                : {{GPUTextureDimension/3d}}
+                :: Let |depthSliceOrLayer| be depth slice |z| of |texture|
+            </dl>
+        1. Let |textureMip| be mip level |copyTexture|.{{GPUImageCopyTexture/mipLevel}} of |depthSliceOrLayer|.
+        1. Return aspect |copyTexture|.{{GPUImageCopyTexture/aspect}} of |textureMip|.
+</div>
 
 <div algorithm data-timeline=device>
     <dfn abstract-op>validating GPUImageCopyTexture</dfn>(|imageCopyTexture|, |copySize|)


### PR DESCRIPTION
Taking a first pass at what I hope is the simplest of these outstanding algorithms to describe. Very open to feedback on ways that this could be presented better, though I think we all knew it would end up as a nested for loop somewhere.

One open questions I have: Is there a specific hierarchy to texture layers/mips/aspects? e.g.: Does each mip have layers, or does each layer have mips? Does it matter? I've introduced an algorithm here that returns the target subresource for a copy, and I'm not sure if the order it evaluates those parts of the texture in is meaningful.

In any case, once we've hammered out the verbiage here I'm hopeful it'll be much easier to then tweak it for the remaining texture copy scenarios. 