### PR TITLE
Allow compressed formats for 3D textures

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3897,9 +3897,7 @@ enum GPUTextureDimension {
     : <dfn>"3d"</dfn>
     ::
         Specifies a texture that has a width, height, and depth. {{GPUTextureDimension/"3d"}}
-        textures cannot be multisampled or use compressed or depth/stencil formats.
-
-        <!-- TODO(#3183): Update this when we add 3D compressed textures -->
+        textures cannot be multisampled or use depth/stencil formats.
 </dl>
 
 ### Texture Usages ### {#texture-usage}
@@ -4078,7 +4076,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be &le;
                             |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
                         - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
+                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=depth-or-stencil format=].
                 </dl>
             - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be multiple of [=texel block width=].
             - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be multiple of [=texel block height=].


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/issues/3183

There might be other API spec surface that I miss to implement the consensus. Thank you in advance!

CTS relevant: https://github.com/gpuweb/cts/pull/3762
Dawn relevant: https://dawn-review.googlesource.com/c/dawn/+/189981