### PR TITLE
Make sure the device is valid when creating a texture view

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4404,7 +4404,7 @@ enum GPUTextureAspect {
                     [$generate a validation error$], [$invalidate$] |view|, and stop.
 
                     <div class=validusage>
-                        - |this| must be [$valid$].
+                        - |this| is [$valid to use with$] |this|.{{GPUObjectBase/[[device]]}}.
                         - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must be present in |this|.{{GPUTexture/format}}.
                         - If the |descriptor|.{{GPUTextureViewDescriptor/aspect}} is {{GPUTextureAspect/"all"}}:
                             - |descriptor|.{{GPUTextureViewDescriptor/format}} must equal either


### PR DESCRIPTION
I think this validation was missing and makes the creation APIs consistent. I think the underlying APIs also require this but I haven't seen it spelled out.