### PR TITLE
Make `unmap()` device timeline validation explicit

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3572,9 +3572,9 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                     <div class=validusage>
                         - |this| is [$valid to use with$] |this|.{{GPUObjectBase/[[device]]}}.
-                        - |this|.{{GPUBuffer/[[internal state]]}} is "[=GPUBuffer/[[internal state]]/unavailable=]".
                     </div>
 
+                1. [=Assert=] |this|.{{GPUBuffer/[[internal state]]}} is "[=GPUBuffer/[[internal state]]/unavailable=]".
                 1. If |bufferUpdate| is not `null`:
 
                     1. Issue the following steps on the [=Queue timeline=] of |this|.{{GPUObjectBase/[[device]]}}.{{GPUDevice/queue}}:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3568,7 +3568,13 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. If |this| is [$invalid$], return.
+                1. If any of the following conditions are unsatisfied, return.
+
+                    <div class=validusage>
+                        - |this| is [$valid to use with$] |this|.{{GPUObjectBase/[[device]]}}.
+                        - |this|.{{GPUBuffer/[[internal state]]}} is "[=GPUBuffer/[[internal state]]/unavailable=]".
+                    </div>
+
                 1. If |bufferUpdate| is not `null`:
 
                     1. Issue the following steps on the [=Queue timeline=] of |this|.{{GPUObjectBase/[[device]]}}.{{GPUDevice/queue}}:


### PR DESCRIPTION
This validation is already implicitly done by the checks on the content timeline but I think it's nice to have this explicit validation on the device timeline.