### PR TITLE
Detail binding size check at draw/dispatch

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5955,6 +5955,14 @@ following members:
         {{GPUExternalTexture}}, or {{GPUBufferBinding}}.
 </dl>
 
+A {{GPUBindGroupEntry}} object also has the following internal slots:
+
+<dl dfn-type=attribute dfn-for=GPUBindGroupEntry>
+    : <dfn>\[[prevalidatedSize]]</dfn>, of type boolean
+    ::
+        Whether or not this binding entry had it's buffer size validated at time of creation.
+</dl>
+
 <script type=idl>
 dictionary GPUBufferBinding {
     required GPUBuffer buffer;
@@ -6126,6 +6134,10 @@ following members:
                     |descriptor|.{{GPUBindGroupDescriptor/entries}}:
                     1. Let |internalUsage| be the [=binding usage=] for |layoutBinding|.
                     1. Each [=subresource=] seen by |resource| is added to {{GPUBindGroup/[[usedResources]]}} as |internalUsage|.
+                    1. Let |bindingDescriptor|.{{GPUBindGroupEntry/[[prevalidatedSize]]}} be `false` if the defined
+                        [=binding member=] for |layoutBinding| is {{GPUBindGroupLayoutEntry/buffer}}
+                        and |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
+                        is `0`, and `true` otherwise.
             </div>
         </div>
 </dl>
@@ -10224,11 +10236,9 @@ It must only be included by interfaces which also include those mixins.
                 - Let |bindGroup| be |encoder|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|index|].
                 - |bindGroup| must not be `null`.
                 - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
-            - For buffer bindings that weren't prevalidated with
-                {{GPUBufferBindingLayout/minBindingSize}}, the binding ranges must be large enough for
-                the [=minimum buffer binding size=].
-
-                Issue: Formalize this check.
+                - For each |entry| of |bindGroup|.{{GPUBindGroup/[[entries]]}}:
+                    - If |entry|.{{GPUBindGroupEntry/[[prevalidatedSize]]}} is `false`:
+                        - [$effective buffer binding size$](|entry|.{{GPUBindGroupEntry/resource}}) must be &ge; [=minimum buffer binding size=] of |entry|.
             - [$Encoder bind groups alias a writable resource$](|encoder|, |pipeline|) must be `false`.
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10238,7 +10238,8 @@ It must only be included by interfaces which also include those mixins.
                 - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
                 - For each |entry| of |bindGroup|.{{GPUBindGroup/[[entries]]}}:
                     - If |entry|.{{GPUBindGroupEntry/[[prevalidatedSize]]}} is `false`:
-                        - [$effective buffer binding size$](|entry|.{{GPUBindGroupEntry/resource}}) must be &ge; [=minimum buffer binding size=] of |entry|.
+                        - [$effective buffer binding size$](|entry|.{{GPUBindGroupEntry/resource}}) must be &ge; [=minimum buffer binding size=]
+                            of the binding variable in |pipeline|'s shader that corresponds to |entry|.
             - [$Encoder bind groups alias a writable resource$](|encoder|, |pipeline|) must be `false`.
         </div>
 


### PR DESCRIPTION
Fixes an inline issue. The primary thing I'm not sure about is what needs to be passed in to `minimum buffer binding size`. The algorithm says it's for a `var`, but it's really not clear to me how we get (in spec terms) from a binding entry to a WGSL variable. Stubbed it in with `|entry|` for now, and it's worth noting that previously we referenced the algorithm without "passing" anything to it.