### PR TITLE
[editorial] Fix var and value table footnote

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4725,9 +4725,9 @@ effective-value-type.
     creation|pipeline-creation time=].
 4. [=Override-declarations=] are part of the shader interface, but are not
     bound resources.
-5. [=Storage buffers=] with an access mode other than [=access/read=] and
-    [=type/storage textures=] cannot be [=statically accessed=]
-    in a [=vertex shader stage=].
+5. [=Storage buffers=] and [=type/storage textures=] with an access mode other
+    than [=access/read=] cannot be [=statically accessed=] in a [=vertex shader
+    stage=].
     See WebGPU {{GPUDevice/createBindGroupLayout()}}.
 6. [=Atomic types=] can only appear in mutable storage buffers or workgroup
     variables.


### PR DESCRIPTION
* Change the footnote about vertex shader access to be consistent with the Address Space section