### PR TITLE
Restrict compressed 3D to BCn

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4090,8 +4090,8 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be &le;
                             |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
                         - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=depth-or-stencil format=] or
-                            [=compressed format=] without [[#packed-formats|sliced 3D support]].
+                        - |descriptor|.{{GPUTextureDescriptor/format}} must support {{GPUTextureDimension/"3d"}}
+                            textures according to [[#texture-format-caps]].
                 </dl>
             - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be multiple of [=texel block width=].
             - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be multiple of [=texel block height=].
@@ -15378,7 +15378,9 @@ This feature adds the following [=optional API surfaces=]:
 
 ### Plain color formats ### {#plain-color-formats}
 
-All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/TEXTURE_BINDING}} usage.
+All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}},
+and {{GPUTextureUsage/TEXTURE_BINDING}} usage. Additionally, all plain color formats support
+textures with {{GPUTextureDimension/"3d"}} dimension.
 
 The {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/STORAGE_BINDING}} columns
 specify support for {{GPUTextureUsage/RENDER_ATTACHMENT|GPUTextureUsage.RENDER_ATTACHMENT}}
@@ -15796,7 +15798,8 @@ depth and stencil aspects.
 All [=depth-or-stencil formats=] support the {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}},
 {{GPUTextureUsage/TEXTURE_BINDING}}, and {{GPUTextureUsage/RENDER_ATTACHMENT}} usages.
 All of these formats support multisampling.
-However, certain copy operations also restrict the source and destination formats.
+However, certain copy operations also restrict the source and destination formats, and none of
+these formats support textures with {{GPUTextureDimension/"3d"}} dimension.
 
 Depth textures cannot be used with {{GPUSamplerBindingType/"filtering"}} samplers, but can always
 be used with {{GPUSamplerBindingType/"comparison"}} samplers even if they use filtering.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3910,8 +3910,8 @@ enum GPUTextureDimension {
     : <dfn>"3d"</dfn>
     ::
         Specifies a texture that has a width, height, and depth. {{GPUTextureDimension/"3d"}}
-        textures cannot be multisampled or use depth/stencil formats,
-        or use compressed formats without [[#packed-formats|sliced 3D support]].
+        textures cannot be multisampled, and their format must support 3d textures
+        (all [[#plain-color-formats]] and some [[#packed-formats|packed/compressed formats]]).
 </dl>
 
 ### Texture Usages ### {#texture-usage}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15954,7 +15954,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
             <th>[=Texel block copy footprint=] (Bytes)
             <th>{{GPUTextureSampleType}}
             <th>Texel block [=texel block width|width=]/[=texel block height|height=]
-            <th>Sliced 3D
+            <th>{{GPUTextureDimension/"3d"}}
             <th>[=Feature=]
     </thead>
     <tr>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3911,7 +3911,7 @@ enum GPUTextureDimension {
     ::
         Specifies a texture that has a width, height, and depth. {{GPUTextureDimension/"3d"}}
         textures cannot be multisampled, and their format must support 3d textures
-        (all [[#plain-color-formats]] and some [[#packed-formats|packed/compressed formats]]).
+        (all [[#plain-color-formats|plain color formats]] and some [[#packed-formats|packed/compressed formats]]).
 </dl>
 
 ### Texture Usages ### {#texture-usage}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3910,7 +3910,8 @@ enum GPUTextureDimension {
     : <dfn>"3d"</dfn>
     ::
         Specifies a texture that has a width, height, and depth. {{GPUTextureDimension/"3d"}}
-        textures cannot be multisampled or use depth/stencil formats.
+        textures cannot be multisampled or use depth/stencil formats,
+        or use compressed formats without [[#packed-formats|sliced 3D support]].
 </dl>
 
 ### Texture Usages ### {#texture-usage}
@@ -4089,7 +4090,8 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be &le;
                             |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
                         - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=depth-or-stencil format=].
+                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=depth-or-stencil format=] or
+                            [=compressed format=] without [[#packed-formats|sliced 3D support]].
                 </dl>
             - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be multiple of [=texel block width=].
             - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be multiple of [=texel block height=].
@@ -15225,7 +15227,7 @@ This feature adds the following [=optional API surfaces=]:
 <span id=dom-gpufeaturename-texture-compression-bc></span>
 </h3>
 
-Allows for explicit creation of textures of BC compressed formats.
+Allows for explicit creation of textures of BC compressed formats. Supports both 2D and 3D textures.
 
 This feature adds the following [=optional API surfaces=]:
 
@@ -15250,7 +15252,7 @@ This feature adds the following [=optional API surfaces=]:
 <span id=dom-gpufeaturename-texture-compression-etc2></span>
 </h3>
 
-Allows for explicit creation of textures of ETC2 compressed formats.
+Allows for explicit creation of textures of ETC2 compressed formats. Only supports 2D textures.
 
 This feature adds the following [=optional API surfaces=]:
 
@@ -15270,7 +15272,7 @@ This feature adds the following [=optional API surfaces=]:
 <span id=dom-gpufeaturename-texture-compression-astc></span>
 </h3>
 
-Allows for explicit creation of textures of ASTC compressed formats.
+Allows for explicit creation of textures of ASTC compressed formats. Only supports 2D textures.
 
 This feature adds the following [=optional API surfaces=]:
 
@@ -15952,6 +15954,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
             <th>[=Texel block copy footprint=] (Bytes)
             <th>{{GPUTextureSampleType}}
             <th>Texel block [=texel block width|width=]/[=texel block height|height=]
+            <th>Sliced 3D
             <th>[=Feature=]
     </thead>
     <tr>
@@ -15959,12 +15962,14 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>4
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>1 &times; 1
+        <td>&check;
         <td>
     <tr>
         <td>{{GPUTextureFormat/bc1-rgba-unorm}}
         <td rowspan=2>8
         <td rowspan=14>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td rowspan=14>4 &times; 4
+        <td rowspan=14>&check;
         <td rowspan=14>{{GPUFeatureName/texture-compression-bc}}
     <tr>
         <td>{{GPUTextureFormat/bc1-rgba-unorm-srgb}}
@@ -16003,6 +16008,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td rowspan=2>8
         <td rowspan=10>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td rowspan=10>4 &times; 4
+        <td rowspan=10>
         <td rowspan=10>{{GPUFeatureName/texture-compression-etc2}}
     <tr>
         <td>{{GPUTextureFormat/etc2-rgb8unorm-srgb}}
@@ -16031,6 +16037,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td rowspan=2>16
         <td rowspan=28>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td rowspan=2>4 &times; 4
+        <td rowspan=28>
         <td rowspan=28>{{GPUFeatureName/texture-compression-astc}}
     <tr>
         <td>{{GPUTextureFormat/astc-4x4-unorm-srgb}}


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/pull/4677

This PR restricts 3D textures with sliced 3D to BCn only as it turns out that ETC2 support is non-existent, and ASTC support for sliced 3D requires an OpenGL ES extension or Vulkan support that we can not assume https://opengles.gpuinfo.org/listreports.php?extension=GL_KHR_texture_compression_astc_sliced_3d&option=not for the target hardware (Adreno 5xx, Adreno 6xx, some Adreno 7xx, not to say that no driver supports for each generation as there are many counter-examples but no strong guarantee to simply assume) https://github.com/gpuweb/gpuweb/issues/1069 as listed here.