### PR TITLE
Complete remaining texture copy algorithms

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9817,7 +9817,29 @@ dictionary GPUCommandEncoderDescriptor
             <div data-timeline=queue>
                 [=Queue timeline=] steps:
 
-                Issue: Define copy, including provision for snorm.
+                1. Let |blockWidth| be the [=texel block width=] of |destination|.{{GPUImageCopyTexture/texture}}.
+                1. Let |blockHeight| be the [=texel block height=] of |destination|.{{GPUImageCopyTexture/texture}}.
+
+                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}};
+                1. Let |dstBlockOriginX| be (|dstOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
+                1. Let |dstBlockOriginY| be (|dstOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
+
+                1. Let |blockColumns| be (|copySize|.[=GPUExtent3D/width=] &div; |blockWidth|).
+                1. Let |blockRows| be (|copySize|.[=GPUExtent3D/height=] &div; |blockHeight|).
+
+                1. [=Assert=] that |dstBlockOriginX|, |dstBlockOriginY|, |blockColumns|, and |blockRows| are integers.
+
+                1. For each |z| in the range [0, |copySize|.[=GPUExtent3D/depthOrArrayLayers=] &minus; 1]:
+                    1. Let |dstSubregion| be [$texture copy sub-region$] (|z| &plus; |dstOrigin|.[=GPUOrigin3D/z=]) of |destination|.
+
+                    1. For each |y| in the range [0, |blockRows| &minus; 1]:
+                        1. For each |x| in the range [0, |blockColumns| &minus; 1]:
+                            1. Let |blockOffset| be the [$texel block byte offset$] of |source| for (|x|, |y|, |z|) of
+                                |destination|.{{GPUImageCopyTexture/texture}}.
+
+                            1. Set [=texel block=] (|dstBlockOriginX| &plus; |x|, |dstBlockOriginY| &plus; |y|) of
+                                |dstSubregion| to be an [=equivalent texel representation=] to the [=texel block=]
+                                described by |source|.{{GPUImageCopyBuffer/buffer}} at offset |blockOffset|.
             </div>
 
         </div>
@@ -9868,7 +9890,29 @@ dictionary GPUCommandEncoderDescriptor
             <div data-timeline=queue>
                 [=Queue timeline=] steps:
 
-                Issue: Define copy, including provision for snorm.
+                1. Let |blockWidth| be the [=texel block width=] of |source|.{{GPUImageCopyTexture/texture}}.
+                1. Let |blockHeight| be the [=texel block height=] of |source|.{{GPUImageCopyTexture/texture}}.
+
+                1. Let |srcOrigin| be |source|.{{GPUImageCopyTexture/origin}};
+                1. Let |srcBlockOriginX| be (|srcOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
+                1. Let |srcBlockOriginY| be (|srcOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
+
+                1. Let |blockColumns| be (|copySize|.[=GPUExtent3D/width=] &div; |blockWidth|).
+                1. Let |blockRows| be (|copySize|.[=GPUExtent3D/height=] &div; |blockHeight|).
+
+                1. [=Assert=] that |srcBlockOriginX|, |srcBlockOriginY|, |blockColumns|, and |blockRows| are integers.
+
+                1. For each |z| in the range [0, |copySize|.[=GPUExtent3D/depthOrArrayLayers=] &minus; 1]:
+                    1. Let |srcSubregion| be [$texture copy sub-region$] (|z| &plus; |srcOrigin|.[=GPUOrigin3D/z=]) of |source|.
+
+                    1. For each |y| in the range [0, |blockRows| &minus; 1]:
+                        1. For each |x| in the range [0, |blockColumns| &minus; 1]:
+                            1. Let |blockOffset| be the [$texel block byte offset$] of |destination| for (|x|, |y|, |z|) of
+                                |source|.{{GPUImageCopyTexture/texture}}.
+
+                            1. Set |destination|.{{GPUImageCopyBuffer/buffer}} at offset |blockOffset| to be an
+                                [=equivalent texel representation=] to [=texel block=]
+                                (|srcBlockOriginX| &plus; |x|, |srcBlockOriginY| &plus; |y|) of |srcSubregion|.
             </div>
 
         </div>
@@ -12678,6 +12722,10 @@ GPUQueue includes GPUObjectBase;
                 1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
                 1. [=?=] [$validate GPUExtent3D shape$](|size|).
                 1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
+                
+                    Note: This is described as copying all of |data| to the device timeline,
+                    but in practice |data| could be much larger than necessary.
+                    Implementations should optimize by copying only the necessary bytes.
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.
             </div>
             <div data-timeline=device>
@@ -12698,22 +12746,34 @@ GPUQueue includes GPUObjectBase;
                         |dataLayout|.{{GPUImageDataLayout/bytesPerRow}} or |dataLayout|.{{GPUImageDataLayout/offset}}.
                     </div>
 
-                1. Let |contents| be the contents of the [=images=] seen by
-                    viewing |dataBytes| with |dataLayout| and |size|.
-
-                    Issue: Specify more formally.
-
-                    Note: This is described as copying all of |data| to the device timeline,
-                    but in practice |data| could be much larger than necessary.
-                    Implementations should optimize by copying only the necessary bytes.
                 1. Issue the subsequent steps on the [=Queue timeline=] of |this|.
             </div>
             <div data-timeline=queue>
                 [=Queue timeline=] steps:
 
-                1. Write |contents| into |destination|.
+                1. Let |blockWidth| be the [=texel block width=] of |destination|.{{GPUImageCopyTexture/texture}}.
+                1. Let |blockHeight| be the [=texel block height=] of |destination|.{{GPUImageCopyTexture/texture}}.
 
-                    Issue: Define copy, including provision for snorm.
+                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}};
+                1. Let |dstBlockOriginX| be (|dstOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
+                1. Let |dstBlockOriginY| be (|dstOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
+
+                1. Let |blockColumns| be (|copySize|.[=GPUExtent3D/width=] &div; |blockWidth|).
+                1. Let |blockRows| be (|copySize|.[=GPUExtent3D/height=] &div; |blockHeight|).
+
+                1. [=Assert=] that |dstBlockOriginX|, |dstBlockOriginY|, |blockColumns|, and |blockRows| are integers.
+
+                1. For each |z| in the range [0, |copySize|.[=GPUExtent3D/depthOrArrayLayers=] &minus; 1]:
+                    1. Let |dstSubregion| be [$texture copy sub-region$] (|z| &plus; |dstOrigin|.[=GPUOrigin3D/z=]) of |destination|.
+
+                    1. For each |y| in the range [0, |blockRows| &minus; 1]:
+                        1. For each |x| in the range [0, |blockColumns| &minus; 1]:
+                            1. Let |blockOffset| be the [$texel block byte offset$] of |dataLayout| for (|x|, |y|, |z|) of
+                                |destination|.{{GPUImageCopyTexture/texture}}.
+
+                            1. Set [=texel block=] (|dstBlockOriginX| &plus; |x|, |dstBlockOriginY| &plus; |y|) of
+                                |dstSubregion| to be an [=equivalent texel representation=] to the [=texel block=]
+                                described by |dataBytes| at offset |blockOffset|.
             </div>
         </div>
 

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -67,8 +67,6 @@ This includes [[#copying-depth-stencil|copies]] to/from specific aspects of [=de
 stencil values are tightly packed in an array of bytes;
 depth values are tightly packed in an array of the appropriate type ("depth16unorm" or "depth32float").
 
-Issue: Define the exact copy semantics, by reference to common algorithms shared by the copy methods.
-
 <dl dfn-type=dict-member dfn-for=GPUImageDataLayout>
     : <dfn>offset</dfn>
     ::
@@ -188,6 +186,19 @@ dictionary GPUImageCopyTexture {
         1. Return aspect |copyTexture|.{{GPUImageCopyTexture/aspect}} of |textureMip|.
 </div>
 
+<div algorithm data-timeline=const>
+    The <dfn abstract-op>texel block byte offset</dfn> of data described by {{GPUImageDataLayout}} |dataLayout|
+    corresponding to [=texel block=] |x|, |y| of depth slice or array layer |z| of a {{GPUTexture}} |texture| is
+    determined by running the following steps:
+
+        1. Let |blockBytes| be the [=texel block copy footprint=] of |texture|.
+        1. Let |imageOffset| be (|z| &times; |dataLayout|.{{GPUImageDataLayout/rowsPerImage}} &times;
+            |dataLayout|.{{GPUImageDataLayout/bytesPerRow}}) &plus; |dataLayout|.{{GPUImageDataLayout/offset}}.
+        1. Let |rowOffset| be (|y| &times; |dataLayout|.{{GPUImageDataLayout/bytesPerRow}}) &plus; |imageOffset|.
+        1. Let |blockOffset| be (|x| &times; |blockBytes|) &plus; |rowOffset|.
+        1. Return |blockOffset|.
+</div>
+
 <div algorithm data-timeline=device>
     <dfn abstract-op>validating GPUImageCopyTexture</dfn>(|imageCopyTexture|, |copySize|)
 
@@ -266,8 +277,6 @@ dictionary GPUImageCopyTexture {
                 |copySize|) succeeds.
         </div>
 </div>
-
-Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and {{GPUTextureDimension/3d}} textures.
 
 <h4 id=gpuimagecopytexturetagged data-dfn-type=dictionary>`GPUImageCopyTextureTagged`
 <span id=gpu-image-copy-texture-tagged></span>

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -191,7 +191,7 @@ dictionary GPUImageCopyTexture {
     corresponding to [=texel block=] |x|, |y| of depth slice or array layer |z| of a {{GPUTexture}} |texture| is
     determined by running the following steps:
 
-        1. Let |blockBytes| be the [=texel block copy footprint=] of |texture|.
+        1. Let |blockBytes| be the [=texel block copy footprint=] of |texture|.{{GPUTexture/format}}.
         1. Let |imageOffset| be (|z| &times; |dataLayout|.{{GPUImageDataLayout/rowsPerImage}} &times;
             |dataLayout|.{{GPUImageDataLayout/bytesPerRow}}) &plus; |dataLayout|.{{GPUImageDataLayout/offset}}.
         1. Let |rowOffset| be (|y| &times; |dataLayout|.{{GPUImageDataLayout/bytesPerRow}}) &plus; |imageOffset|.


### PR DESCRIPTION
Follow-up to #4672, reusing many of the patterns established there.

This PR completes the remaining texture copy algorithms: `copyBufferToTexture`, `copyTextureToBuffer`, and `writeTexture`. 

~~(Mermaid diagrams were updated during `make spec`. Looks like some minor formatting changes caused by the diagram software updating? Not entirely sure. I can remove them if needed.)~~ Update: Reverted mermaid diagram changes, may be causing a build failure?