### PR TITLE
Fixed baseVertex type for drawIndexedIndirect

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11930,15 +11930,19 @@ It must only be included by interfaces which also include those mixins.
         See [[#rendering-operations]] for the detailed specification.
 
         The <dfn dfn for="">indirect drawIndexed parameters</dfn> encoded in the buffer must be a
-        tightly packed block of **five 32-bit unsigned integer values (20 bytes total)**, given in
-        the same order as the arguments for {{GPURenderCommandsMixin/drawIndexed()}}. For example:
+        tightly packed block of **five 32-bit values (20 bytes total)**, given in the same order as
+        the arguments for {{GPURenderCommandsMixin/drawIndexed()}}. The value corresponding to
+        `baseVertex` is a signed 32-bit integer, and all others are unsigned 32-bit integers.
+        For example:
 
         <pre highlight=js>
             let drawIndexedIndirectParameters = new Uint32Array(5);
+            let drawIndexedIndirectParametersSigned = new Int32Array(drawIndexedIndirectParameters.buffer);
             drawIndexedIndirectParameters[0] = indexCount;
             drawIndexedIndirectParameters[1] = instanceCount;
             drawIndexedIndirectParameters[2] = firstIndex;
-            drawIndexedIndirectParameters[3] = baseVertex;
+            // baseVertex is a signed value.
+            drawIndexedIndirectParametersSigned[3] = baseVertex;
             drawIndexedIndirectParameters[4] = firstInstance;
         </pre>
 
@@ -11993,7 +11997,7 @@ It must only be included by interfaces which also include those mixins.
                     (|indirectOffset| + 4) bytes.
                 1. Let |firstIndex| be an unsigned 32-bit integer read from |indirectBuffer| at
                     (|indirectOffset| + 8) bytes.
-                1. Let |baseVertex| be an unsigned 32-bit integer read from |indirectBuffer| at
+                1. Let |baseVertex| be a signed 32-bit integer read from |indirectBuffer| at
                     (|indirectOffset| + 12) bytes.
                 1. Let |firstInstance| be an unsigned 32-bit integer read from |indirectBuffer| at
                     (|indirectOffset| + 16) bytes.
@@ -12728,7 +12732,7 @@ GPUQueue includes GPUObjectBase;
                 1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
                 1. [=?=] [$validate GPUExtent3D shape$](|size|).
                 1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
-                
+
                     Note: This is described as copying all of |data| to the device timeline,
                     but in practice |data| could be much larger than necessary.
                     Implementations should optimize by copying only the necessary bytes.


### PR DESCRIPTION
Fixes #4674

They type of the `baseVertex` in the indirect args buffer is signed in Vulkan, D3D12, and Metal, as well as the `drawIndexed()` method. This updates our description of the indirect buffer args to match.