### PR TITLE
Clarify that using the standard sample patterns is mandatory

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12728,7 +12728,7 @@ GPUQueue includes GPUObjectBase;
                 1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
                 1. [=?=] [$validate GPUExtent3D shape$](|size|).
                 1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
-                
+
                     Note: This is described as copying all of |data| to the device timeline,
                     but in practice |data| could be much larger than necessary.
                     Implementations should optimize by copying only the necessary bytes.
@@ -14706,6 +14706,9 @@ such that the pixel ranges from (0, 0) to (1, 1):
             Sample 2: (0.125, 0.625)<br>
             Sample 3: (0.625, 0.875)
 </table>
+
+Implementations must use the [=standard sample pattern=] for the given
+{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}} when performing rasterization.
 
 Let's define a <dfn dfn>FragmentDestination</dfn> to contain:
 <dl dfn-for=FragmentDestination>


### PR DESCRIPTION
Fixes #4005 for real this time.

This will cause me some heartache in #4633 because we'll want to move this out of the Detailed Operations doc to keep it normative, but I can deal with that when rebasing that PR.