### PR TITLE
Add queue steps for copyExternalImageToTexture

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12915,7 +12915,7 @@ GPUQueue includes GPUObjectBase;
                     1. For each |x| in the range [0, |copySize|.[=GPUExtent3D/width=] &minus; 1]:
                         1. Set [=texel block=]
                             (|dstOrigin|.[=GPUOrigin3D/x=] &plus; |x|, |dstOrigin|.[=GPUOrigin3D/y=] &plus; |y|) of
-                            |dstSubregion| to be the value of the pixel at
+                            |dstSubregion| to be an [=equivalent texel representation=] of the pixel at
                             (|srcOrigin|.[=GPUOrigin2D/x=] &plus; |x|, |srcOrigin|.[=GPUOrigin2D/y=] &plus; |srcY|) of
                             |source|.{{GPUImageCopyExternalImage/source}} after applying any
                             [[#color-space-conversions|color encoding]] required by

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12919,8 +12919,8 @@ GPUQueue includes GPUObjectBase;
                             (|srcOrigin|.[=GPUOrigin2D/x=] &plus; |x|, |srcOrigin|.[=GPUOrigin2D/y=] &plus; |srcY|) of
                             |source|.{{GPUImageCopyExternalImage/source}} after applying any
                             [[#color-space-conversions|color encoding]] required by
-                            |source|.{{GPUImageCopyTextureTagged/colorSpace}} and
-                            |source|.{{GPUImageCopyTextureTagged/premultipliedAlpha}}.
+                            |destination|.{{GPUImageCopyTextureTagged/colorSpace}} and
+                            |destination|.{{GPUImageCopyTextureTagged/premultipliedAlpha}}.
             </div>
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12894,7 +12894,30 @@ GPUQueue includes GPUObjectBase;
                             - {{GPUTextureFormat/"rgba16float"}}
                             - {{GPUTextureFormat/"rgba32float"}}
                     </div>
-                1. Issue: Do the actual copy.
+
+                1. If |copySize|.[=GPUExtent3D/depthOrArrayLayers=] is &gt; 0, issue the subsequent
+                    steps on the [=Queue timeline=] of |this|.
+            </div>
+            <div data-timeline=queue>
+                [=Queue timeline=] steps:
+
+                1. [=Assert=] that the [=texel block width=] of |destination|.{{GPUImageCopyTexture/texture}} is 1,
+                    the [=texel block height=] of |destination|.{{GPUImageCopyTexture/texture}} is 1, and that
+                    |copySize|.[=GPUExtent3D/depthOrArrayLayers=] is 1.
+
+                1. Let |srcOrigin| be |source|.{{GPUImageCopyExternalImage/origin}};
+                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}};
+                1. Let |dstSubregion| be [$texture copy sub-region$] (|dstOrigin|.[=GPUOrigin3D/z=]) of |destination|.
+
+                1. For each |y| in the range [0, |copySize|.[=GPUExtent3D/height=] &minus; 1]:
+                    1. Let |srcY| be |y| if |source|.{{GPUImageCopyExternalImage/flipY}} is `false` and
+                        (|copySize|.[=GPUExtent3D/height=] &minus; 1 &minus; |y|) otherwise.
+                    1. For each |x| in the range [0, |copySize|.[=GPUExtent3D/width=] &minus; 1]:
+                        1. Set [=texel block=]
+                            (|dstOrigin|.[=GPUOrigin3D/x=] &plus; |x|, |dstOrigin|.[=GPUOrigin3D/y=] &plus; |y|) of
+                            |dstSubregion| to be an [=equivalent texel representation=] of the pixel at
+                            (|srcOrigin|.[=GPUOrigin2D/x=] &plus; |x|, |srcOrigin|.[=GPUOrigin2D/y=] &plus; |srcY|) of
+                            |source|.{{GPUImageCopyExternalImage/source}}.
             </div>
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12905,8 +12905,8 @@ GPUQueue includes GPUObjectBase;
                     the [=texel block height=] of |destination|.{{GPUImageCopyTexture/texture}} is 1, and that
                     |copySize|.[=GPUExtent3D/depthOrArrayLayers=] is 1.
 
-                1. Let |srcOrigin| be |source|.{{GPUImageCopyExternalImage/origin}};
-                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}};
+                1. Let |srcOrigin| be |source|.{{GPUImageCopyExternalImage/origin}}.
+                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}}.
                 1. Let |dstSubregion| be [$texture copy sub-region$] (|dstOrigin|.[=GPUOrigin3D/z=]) of |destination|.
 
                 1. For each |y| in the range [0, |copySize|.[=GPUExtent3D/height=] &minus; 1]:
@@ -12915,9 +12915,12 @@ GPUQueue includes GPUObjectBase;
                     1. For each |x| in the range [0, |copySize|.[=GPUExtent3D/width=] &minus; 1]:
                         1. Set [=texel block=]
                             (|dstOrigin|.[=GPUOrigin3D/x=] &plus; |x|, |dstOrigin|.[=GPUOrigin3D/y=] &plus; |y|) of
-                            |dstSubregion| to be an [=equivalent texel representation=] of the pixel at
+                            |dstSubregion| to be the value of the pixel at
                             (|srcOrigin|.[=GPUOrigin2D/x=] &plus; |x|, |srcOrigin|.[=GPUOrigin2D/y=] &plus; |srcY|) of
-                            |source|.{{GPUImageCopyExternalImage/source}}.
+                            |source|.{{GPUImageCopyExternalImage/source}} after applying any
+                            [[#color-space-conversions|color encoding]] required by
+                            |source|.{{GPUImageCopyTextureTagged/colorSpace}} and
+                            |source|.{{GPUImageCopyTextureTagged/premultipliedAlpha}}.
             </div>
         </div>
 


### PR DESCRIPTION
Roughly follows the pattern set by `copyTextureToTexture` and friends, but simplified because we can be sure that we're only copying one slice/layer and we know the block size is 1.

Not sure if anything more needs to be said to clarify the pixel -> texel transition, which this PR kind of handwaves with `equivalent texel representation`.