### PR TITLE
More rigorously define the relationship between device/GPUDevice

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1222,6 +1222,14 @@ A [=device=] has the following [=immutable properties=]:
         No [=limit/better=] limits can be used, even if the underlying [=adapter=] can support them.
 </dl>
 
+A [=device=] also has the following [=content timeline property=]:
+
+<dl dfn-type=attribute dfn-for=device data-timeline=content>
+    : <dfn>[[content device]]</dfn>, of type {{GPUDevice}}, readonly
+    ::
+        The [=Content timeline=] {{GPUDevice}} interface which this device is associated with.
+</dl>
+
 <div algorithm data-timeline=device>
     When <dfn dfn>a new device</dfn> |device| is created from [=adapter=] |adapter|
     with {{GPUDeviceDescriptor}} |descriptor|, run the following [=device timeline=] steps:
@@ -1257,10 +1265,7 @@ no validation errors are raised, most promises resolve normally, etc.
     To <dfn dfn>lose the device</dfn>(|device|, |reason|) run the following [=device timeline=] steps:
 
     1. [$Invalidate$] |device|.
-    1. Let |gpuDevice| be the [=content timeline=] {{GPUDevice}} corresponding to |device|.
-
-        Issue: Define this more rigorously.
-    1. Issue the following steps on the [=content timeline=] of |gpuDevice|:
+    1. Issue the following steps on the [=content timeline=] of |device|.{{device/[[content device]]}}:
         <div data-timeline=content>
             1. Resolve |device|.{{GPUDevice/lost}} with a new {{GPUDeviceLostInfo}} with
                 {{GPUDeviceLostInfo/reason}} set to |reason| and
@@ -2506,7 +2511,14 @@ interface GPUAdapter {
             <div data-timeline=content>
                 [=Content timeline=] steps:
 
-                1. [=Resolve=] |promise| with a new {{GPUDevice}} object |device|.
+                <!--This is a variant of [$create a new WebGPU object$] that accounts for the fact
+                    that the device has no parent.-->
+                1. Let |gpuDevice| be a new {{GPUDevice}} instance.
+                1. Set |gpuDevice|.{{GPUObjectBase/[[device]]}} to |device|.
+                1. Set |device|.{{device/[[content device]]}} to |gpuDevice|.
+                1. Set |gpuDevice|.{{GPUObjectBase/label}} to |descriptor|.{{GPUObjectDescriptorBase/label}}.
+
+                1. [=Resolve=] |promise| with |gpuDevice|.
 
                     Note:
                     If the device is already lost because the adapter could not fulfill the request,
@@ -12729,7 +12741,7 @@ GPUQueue includes GPUObjectBase;
                 1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
                 1. [=?=] [$validate GPUExtent3D shape$](|size|).
                 1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
-                
+
                     Note: This is described as copying all of |data| to the device timeline,
                     but in practice |data| could be much larger than necessary.
                     Implementations should optimize by copying only the necessary bytes.


### PR DESCRIPTION
Resolves another inline issue.

This change makes the `GPUDevice` associated with a given `device` more formal, as both now have references to one another for the purposes of invoking steps on the appropriate timeline.