### PR TITLE
Improve render bundle steps

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10686,7 +10686,7 @@ dictionary GPUComputePassDescriptor
                             |this|.device.limits.{{supported limits/maxComputeWorkgroupsPerDimension}}.
                     </div>
 
-                1. Let |passState| be a snapshot of |this|'s current state.
+                1. Let |bindingState| be a snapshot of |this|'s current state.
                 1. [$Enqueue a command$] on |this| which issues the subsequent steps on the
                     [=Queue timeline=].
             </div>
@@ -10694,8 +10694,8 @@ dictionary GPUComputePassDescriptor
                 [=Queue timeline=] steps:
 
                 1. Execute a grid of workgroups with dimensions [|workgroupCountX|, |workgroupCountY|,
-                    |workgroupCountZ|] with |passState|.{{GPUComputePassEncoder/[[pipeline]]}} using
-                    |passState|.{{GPUBindingCommandsMixin/[[bind_groups]]}}.
+                    |workgroupCountZ|] with |bindingState|.{{GPUComputePassEncoder/[[pipeline]]}} using
+                    |bindingState|.{{GPUBindingCommandsMixin/[[bind_groups]]}}.
             </div>
         </div>
 
@@ -10752,7 +10752,7 @@ dictionary GPUComputePassDescriptor
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
 
-                1. Let |passState| be a snapshot of |this|'s current state.
+                1. Let |bindingState| be a snapshot of |this|'s current state.
                 1. [$Enqueue a command$] on |this| which issues the subsequent steps on the
                     [=Queue timeline=].
             </div>
@@ -10769,8 +10769,8 @@ dictionary GPUComputePassDescriptor
                     |this|.device.limits.{{supported limits/maxComputeWorkgroupsPerDimension}},
                     stop.
                 1. Execute a grid of workgroups with dimensions [|workgroupCountX|, |workgroupCountY|,
-                    |workgroupCountZ|] with |passState|.{{GPUComputePassEncoder/[[pipeline]]}} using
-                    |passState|.{{GPUBindingCommandsMixin/[[bind_groups]]}}.
+                    |workgroupCountZ|] with |bindingState|.{{GPUComputePassEncoder/[[pipeline]]}} using
+                    |bindingState|.{{GPUBindingCommandsMixin/[[bind_groups]]}}.
             </div>
         </div>
 </dl>
@@ -11777,7 +11777,7 @@ It must only be included by interfaces which also include those mixins.
                     </div>
                 1. Increment |this|.{{GPURenderCommandsMixin/[[drawCount]]}} by 1.
 
-                1. Let |passState| be a snapshot of |this|'s current state.
+                1. Let |bindingState| be a snapshot of |this|'s current state.
                 1. [$Enqueue a render command$] on |this| which issues the subsequent steps on the
                     [=Queue timeline=] with |renderState| when executed.
             </div>
@@ -11786,7 +11786,7 @@ It must only be included by interfaces which also include those mixins.
 
                 1. Draw |instanceCount| instances, starting with instance |firstInstance|, of
                     primitives consisting of |vertexCount| verticies, starting with vertex |firstVertex|,
-                    with the states from |passState| and |renderState|.
+                    with the states from |bindingState| and |renderState|.
             </div>
         </div>
 
@@ -11838,7 +11838,7 @@ It must only be included by interfaces which also include those mixins.
                     </div>
                 1. Increment |this|.{{GPURenderCommandsMixin/[[drawCount]]}} by 1.
 
-                1. Let |passState| be a snapshot of |this|'s current state.
+                1. Let |bindingState| be a snapshot of |this|'s current state.
                 1. [$Enqueue a render command$] on |this| which issues the subsequent steps on the
                     [=Queue timeline=] with |renderState| when executed.
             </div>
@@ -11848,7 +11848,7 @@ It must only be included by interfaces which also include those mixins.
                 1. Draw |instanceCount| instances, starting with instance |firstInstance|, of
                     primitives consisting of |indexCount| indexed verticies, starting with index
                     |firstIndex| from vertex |baseVertex|,
-                    with the states from |passState| and |renderState|.
+                    with the states from |bindingState| and |renderState|.
             </div>
 
             Note: a valid program should also never use vertex indices with
@@ -11914,7 +11914,7 @@ It must only be included by interfaces which also include those mixins.
                 1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Increment |this|.{{GPURenderCommandsMixin/[[drawCount]]}} by 1.
 
-                1. Let |passState| be a snapshot of |this|'s current state.
+                1. Let |bindingState| be a snapshot of |this|'s current state.
                 1. [$Enqueue a render command$] on |this| which issues the subsequent steps on the
                     [=Queue timeline=] with |renderState| when executed.
             </div>
@@ -11931,7 +11931,7 @@ It must only be included by interfaces which also include those mixins.
                     (|indirectOffset| + 12) bytes.
                 1. Draw |instanceCount| instances, starting with instance |firstInstance|, of
                     primitives consisting of |vertexCount| verticies, starting with vertex |firstVertex|,
-                    with the states from |passState| and |renderState|.
+                    with the states from |bindingState| and |renderState|.
             </div>
         </div>
 
@@ -11995,7 +11995,7 @@ It must only be included by interfaces which also include those mixins.
                 1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Increment |this|.{{GPURenderCommandsMixin/[[drawCount]]}} by 1.
 
-                1. Let |passState| be a snapshot of |this|'s current state.
+                1. Let |bindingState| be a snapshot of |this|'s current state.
                 1. [$Enqueue a render command$] on |this| which issues the subsequent steps on the
                     [=Queue timeline=] with |renderState| when executed.
             </div>
@@ -12015,7 +12015,7 @@ It must only be included by interfaces which also include those mixins.
                 1. Draw |instanceCount| instances, starting with instance |firstInstance|, of
                     primitives consisting of |indexCount| indexed verticies, starting with index
                     |firstIndex| from vertex |baseVertex|,
-                    with the states from |passState| and |renderState|.
+                    with the states from |bindingState| and |renderState|.
             </div>
         </div>
 </dl>
@@ -12384,9 +12384,6 @@ attachments used by this encoder.
 
                 1. For each |bundle| in |bundles|:
                     1. Increment |this|.{{GPURenderCommandsMixin/[[drawCount]]}} by |bundle|.{{GPURenderBundle/[[drawCount]]}}.
-
-                    1. [$Reset the render pass bindings$] of |this|.
-                    1. Let |passState| be a snapshot of |this|'s current state.
                     1. [$Enqueue a render command$] on |this| which issues the following steps on the
                         [=Queue timeline=] with |renderState| when executed:
 
@@ -12394,19 +12391,18 @@ attachments used by this encoder.
                             [=Queue timeline=] steps:
 
                             1. Execute each command in |bundle|.{{GPURenderBundle/[[command_list]]}}
-                                with |passState| and |renderState|.
+                                with |renderState|.
 
                                 Note: |renderState| cannot be changed by executing render bundles.
-                                Also note, no mutable |passState| state is visible to render bundles.
                         </div>
 
-                1. [$Reset the render pass bindings$] of |this|.
+                1. [$Reset the render pass binding state$] of |this|.
             </div>
         </div>
 </dl>
 
 <div algorithm data-timeline=device>
-    To <dfn abstract-op>Reset the render pass bindings</dfn> of {{GPURenderPassEncoder}} |encoder| run
+    To <dfn abstract-op>Reset the render pass binding state</dfn> of {{GPURenderPassEncoder}} |encoder| run
     the following [=device timeline=] steps:
 
         1. [=map/Clear=] |encoder|.{{GPUBindingCommandsMixin/[[bind_groups]]}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12385,28 +12385,35 @@ attachments used by this encoder.
                 1. For each |bundle| in |bundles|:
                     1. Increment |this|.{{GPURenderCommandsMixin/[[drawCount]]}} by |bundle|.{{GPURenderBundle/[[drawCount]]}}.
 
-                1. [=map/Clear=] |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}.
-                1. Set |this|.{{GPURenderCommandsMixin/[[pipeline]]}} to `null`.
-                1. Set |this|.{{GPURenderCommandsMixin/[[index_buffer]]}} to `null`.
-                1. [=map/Clear=] |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}.
+                    1. [$Reset the render pass bindings$] of |this|.
+                    1. Let |passState| be a snapshot of |this|'s current state.
+                    1. [$Enqueue a render command$] on |this| which issues the following steps on the
+                        [=Queue timeline=] with |renderState| when executed:
 
-                1. Let |passState| be a snapshot of |this|'s current state.
-                1. [$Enqueue a render command$] on |this| which issues the subsequent steps on the
-                    [=Queue timeline=] with |renderState| when executed.
+                        <div data-timeline=queue>
+                            [=Queue timeline=] steps:
+
+                            1. Execute each command in |bundle|.{{GPURenderBundle/[[command_list]]}}
+                                with |passState| and |renderState|.
+
+                                Note: |renderState| cannot be changed by executing render bundles.
+                                Also note, no mutable |passState| state is visible to render bundles.
+                        </div>
+
+                1. [$Reset the render pass bindings$] of |this|.
             </div>
-            <div data-timeline=queue>
-                [=Queue timeline=] steps:
-
-                1. For each |bundle| in |bundles|:
-                    1. Execute each command in |bundle|.{{GPURenderBundle/[[command_list]]}}
-                        with |passState| and |renderState|.
-
-                        Note: |renderState| cannot be changed by executing render bundles.
-                        Also note, no mutable |passState| state is visible to render bundles.
-            </div>
-
         </div>
 </dl>
+
+<div algorithm data-timeline=device>
+    To <dfn abstract-op>Reset the render pass bindings</dfn> of {{GPURenderPassEncoder}} |encoder| run
+    the following [=device timeline=] steps:
+
+        1. [=map/Clear=] |encoder|.{{GPUBindingCommandsMixin/[[bind_groups]]}}.
+        1. Set |encoder|.{{GPURenderCommandsMixin/[[pipeline]]}} to `null`.
+        1. Set |encoder|.{{GPURenderCommandsMixin/[[index_buffer]]}} to `null`.
+        1. [=map/Clear=] |encoder|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}.
+</div>
 
 # Bundles # {#bundles}
 
@@ -12523,8 +12530,6 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                 1. Set |e|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}.
                 1. Set |e|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
                 1. Set |e|.{{GPURenderCommandsMixin/[[drawCount]]}} to 0.
-
-                Issue: Describe the reset of the steps for {{GPUDevice/createRenderBundleEncoder()}}.
             </div>
         </div>
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12393,7 +12393,8 @@ attachments used by this encoder.
                             1. Execute each command in |bundle|.{{GPURenderBundle/[[command_list]]}}
                                 with |renderState|.
 
-                                Note: |renderState| cannot be changed by executing render bundles.
+                                Note: |renderState| cannot be changed by executing render bundles. Binding state was
+                                already captured at bundle encoding time, and so isn't used when executing bundles.
                         </div>
 
                 1. [$Reset the render pass binding state$] of |this|.


### PR DESCRIPTION
While reviewing the steps for render bundle creation/execution I realized that it omitted the step of clearing the render pass bindings after the bundles were executed. Also, the relationship between the queue timeline steps and the state they captured wasn't very clear. This change ensures the binding state is cleared before every bundle is executed, after all bundles are executed, and moves the queue steps into the loop through the bundles to ensure the captured state is clear.

I have also removed an inline issue in `createRenderBundleEncoder()` as I'm not aware of any additional steps that need to be detailed for that algorithm. 