### PR TITLE
Remove outdated inline issue

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7807,8 +7807,6 @@ dictionary GPURenderPipelineDescriptor
                             1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to true.
                 1. Set |pipeline|.{{GPUPipelineBase/[[layout]]}} to |layout|.
             </div>
-
-            Issue: need description of the render states.
         </div>
 
     : <dfn>createRenderPipelineAsync(descriptor)</dfn>


### PR DESCRIPTION
It appears that the inline issue ["need description of the render states."](https://gpuweb.github.io/gpuweb/#issue-22c6f42f) is resolved by the [definition of RenderState](http://localhost:8080/corp/gpuweb/spec/#renderstate). Removing the issue.