### PR TITLE
Uncapturederror and preventDefault

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14758,8 +14758,8 @@ partial interface GPUDevice {
 
         Note: After dispatching the event, user agents **should** surface uncaptured errors to
         developers, for example as warnings in the browser's developer console, unless event's
-        {{Event/defaultPrevented}} is true. In other words, if {{Event/preventDefault}} has been
-        called on the event don't surface the error.
+        {{Event/defaultPrevented}} is true. In other words, calling {{Event/preventDefault()}}
+        on the event should silence the console warning.
     </div>
 
     Note: The user agent may choose to throttle or limit the number of {{GPUUncapturedErrorEvent}}s

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14756,9 +14756,10 @@ partial interface GPUDevice {
                     |device|, with an {{GPUUncapturedErrorEvent/error}} of |error|.
             </div>
 
-        Note: If (and only if) there are no {{GPUDevice/uncapturederror}} handlers are
-        registered, user agents **should** surface uncaptured errors to developers,
-        for example as warnings in the browser's developer console.
+        Note: After dispatching the event, user agents **should** surface uncaptured errors to
+        developers, for example as warnings in the browser's developer console, unless event's
+        {{Event/defaultPrevented}} is true. In other words, if {{Event/preventDefault}} has been
+        called on the event don't surface the error.
     </div>
 
     Note: The user agent may choose to throttle or limit the number of {{GPUUncapturedErrorEvent}}s

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14757,7 +14757,7 @@ partial interface GPUDevice {
             </div>
 
         Note: After dispatching the event, user agents **should** surface uncaptured errors to
-        developers, for example as warnings in the browser's developer console, unless event's
+        developers, for example as warnings in the browser's developer console, unless the event's
         {{Event/defaultPrevented}} is true. In other words, calling {{Event/preventDefault()}}
         on the event should silence the console warning.
     </div>


### PR DESCRIPTION
Like JavaScript error events, If a listener added to uncapturederror calls `preventDefault` on the event the user agent should not log the error to the console.

---

Note: under `createShaderModule` there is this wording

> As shader compilation errors should be rare in production applications, user agents
> could choose to surface them *to developers* regardless of error handling ([=GPU error scopes=] or
> {{GPUDevice/uncapturederror}} event handlers), e.g. as an expandable warning.

I think that should be changed. If the application is capturing errors (uncaptured, and pushErrorScope/popErrorScope), IMO WebGPU should not be logging to the console. I know it says "could" so the UA is free to ignore the advice above but I believe (1) it shouldn't have this advice and (2) it should arguably not log anything if the app captures the error.

I've pointed out one example elsewhere. For example, if the user is using a preprocessor, they may want to wrap `createShaderModule` and/or `getCompilationInfo` such that the data returned to user and the messages displayed are in terms of the pre-processed language. If WebGPU logs errors against the user's wishes then suddenly there are confusing error messages. One generated by WebGPU and other generated by the wrapping library. Other examples include interactive editors (shadertoy, compute.toys) that want the ability to keep console messages to things that are bugs in their app and not related to the user editing shaders which they already surface in their UI.

Note that `eval` and `Function` follow this behavior. If you try/catch their evaluation then messages about Syntax errors, etc, do not get logged to the console. I think WebGPU should do the same.