### PR TITLE
Extensions editorial: linking and syncing

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1406,6 +1406,8 @@ path: syntax/enable_extension_name.syntax.bs.include
 The [=enable-extension=] names are:
 
 * <a for=extension lt=f16>`'f16'`</a>
+* <a for=extension lt=clip_distances>`'clip_distances'`</a>
+* <a for=extension lt=dual_source_blending>`'dual_source_blending'`</a>
 
 The valid [=language extension=] names are listed in [[#language-extensions-sec]] but in general have the same form as an [=identifier=]:
 
@@ -1752,15 +1754,15 @@ The valid [=enable-extensions=] are listed in the following table.
         <th>Description
   </thead>
   <tr><td><dfn noexport dfn-for="extension">`f16`</dfn>
-      <td>`"shader-f16"`
+      <td>[[WebGPU#shader-f16|"shader-f16"]]
       <td>The [=f16=] type is valid to use in the WGSL module. Otherwise, using [=f16=] (directly or indirectly) will result in a [=shader-creation error=].
   <tr><td><dfn noexport dfn-for="extension">`clip_distances`</dfn>
-      <td>`"clip_distances"`
+      <td>[[WebGPU#dom-gpufeaturename-clip-distances|"clip-distances"]]
       <td>The built-in variable [=built-in values/clip_distances=] is valid to use in the WGSL
           module. Otherwise, using [=built-in values/clip_distances=] will result in a
           [=shader-creation error=].
   <tr><td><dfn noexport dfn-for="extension">`dual_source_blending`</dfn>
-      <td>`"dual_source_blending"`
+      <td>[[WebGPU#dom-gpufeaturename-dual-source-blending|"dual-source-blending"]]
       <td>The attribute [=attribute/blend_src=] is valid to use in the WGSL module. Otherwise, using
           [=attribute/blend_src=] will result in a [=shader-creation error=].
 </table>


### PR DESCRIPTION
For some time, there was an editorial desire to link extensions to respective section in spec. In PR does that, and in addition, fixes feature names (their underscore versions were present in WGSL spec, does not match the API spec), and syncs the duplicate listing in names section (maybe this could really benefit from some sort of tooling). Thank you!