### PR TITLE
Clarify workgroupSize calculation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14559,8 +14559,8 @@ The main compute algorithm:
 
     1. Let |computeInvocations| be an [=list/empty=] [=list=].
     1. Let |computeStage| be |descriptor|.{{GPUComputePipelineDescriptor/compute}}.
-    1. Let |workgroupSize| be the `@workgroup_size` declared for |computeStage|.{{GPUProgrammableStage/entryPoint}}
-        of |computeStage|.{{GPUProgrammableStage/module}}
+    1. Let |workgroupSize| be the computed workgroup size for |computeStage|.{{GPUProgrammableStage/entryPoint}} after
+        applying |computeStage|.{{GPUProgrammableStage/constants}} to |computeStage|.{{GPUProgrammableStage/module}}.
     1. For |workgroupX| in range <code>[0, |dispatchCall|.`workgroupCountX`]</code>:
         1. For |workgroupY| in range <code>[0, |dispatchCall|.`workgroupCountY`]</code>:
             1. For |workgroupZ| in range <code>[0, |dispatchCall|.`workgroupCountZ`]</code>:


### PR DESCRIPTION
Suggested by @alan-baker, who was concerned that the current text didn't capture the possibility of overrides affecting the value or defaults.