### PR TITLE
Clarify the use of `@blend_src` in certain shader stages

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8439,7 +8439,9 @@ path: syntax/blend_src_attr.syntax.bs.include
     [=attribute/location=] attribute.
     [=shader-creation error|Must=] only be applied to declarations of objects with [=numeric scalar=]
     or [=numeric vector=] type.
-    [=shader-creation error|Must=] only be used as an output of the [=fragment=] shader stage.
+    [=shader-creation error|Must=] only be used in [=fragment=] shader stage.
+    [=shader-creation error|Must not=] be used as a part of the user-defined input of [=fragment=]
+    shader stage.
 
   <tr>
     <td>Parameters


### PR DESCRIPTION
It is not suitable to say `blend_src` "must only be used as an output of the fragment shader stage" because apparently we need to use the struct variables with `blend_src` in many other places.

For example, we can first declare a struct variable with `blend_src` and assign values into the struct before using the struct in the
return expression of the entry point.