### PR TITLE
Clarify scope of pipeline creation

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -600,8 +600,8 @@ The events are:
     * Only the code forming the [=interface of a shader|shader interface=] of the specified
         [=entry point=] of the {{GPUProgrammableStage}} is considered during pipeline creation.
         That is, code unrelated to the entry point is effectively stripped before compilation.
-    * Note: Each [=shader stage=] is compiled separately and, thus, might include different
-        portions of the module.
+    * Note: Each [=shader stage=] is considered to be compiled separately and, thus, might
+        include different portions of the module.
 3. <dfn noexport>Shader execution start</dfn>
     * This occurs when a [=draw command|draw=] or [=dispatch command=] is issued to the GPU,
         begins executing the pipeline,

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -645,7 +645,7 @@ A processing error may occur during three phases in the shader lifecycle:
     and other information available to the particular pipeline creation API method.
     These errors are only triggered for code present in the
     [=interface of a shader|shader interface=] and [=statically accessed=]
-    [=address space/workgroup=] [=variables=] of the [=entry point=] being
+    [=address spaces/workgroup=] [=variables=] of the [=entry point=] being
     compiled for the {{GPUProgrammableStage}}.
 
 * A <dfn export>dynamic error</dfn> is an error occurring during shader execution.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -644,7 +644,8 @@ A processing error may occur during three phases in the shader lifecycle:
     Detection relies on the WGSL module source text
     and other information available to the particular pipeline creation API method.
     These errors are only triggered for code present in the
-    [=interface of a shader|shader interface=] of the [=entry point=] being
+    [=interface of a shader|shader interface=] and [=statically accessed=]
+    [=address space/workgroup=] [=variables=] of the [=entry point=] being
     compiled for the {{GPUProgrammableStage}}.
 
 * A <dfn export>dynamic error</dfn> is an error occurring during shader execution.
@@ -5246,11 +5247,12 @@ An expression is an override-expression if all its [=identifiers=] [=resolve=] t
 
 Note: All [=const-expressions=] are also override-expressions.
 
-Override-expressions are only evaluated after any API-provided values are
-substituted [=override-declarations=].
+Override-expressions are only validated or evaluated after any API-provided
+values are substituted for [=override-declarations=].
 If an [=override-declaration=] has its value substituted via the API, its
 initializer expression, if present, will not be evaluated.
-An override-expression |E| [=behavioral requirement|will=] be evaluated if and only if:
+Otherwise, an override-expression |E| [=behavioral requirement|will=] be
+evaluated if and only if:
 * |E| is [=top-level expression=] (after value substitution), or
 * |E| is a [=subexpression=] of an expression |OuterE|, and |OuterE|
     [=behavioral requirement|will=] be evaluated, and evaluation of |OuterE|
@@ -5287,7 +5289,7 @@ Example: `vec3(x,x,x)` is analyzed as follows:
   override b = 1 / a;
   override c = a / 0; // shader-creation error, regardless of attempting to override c
 
-  // b is a part of frag1's shader interface. When compiling frag1 into a pipeline
+  // b is a part of the frag1 shader. When compiling frag1 into a pipeline
   // the following cases may occur:
   // * if b is overridden, no error occurs.
   // * if a is overridden to a non-zero value, no error occurs.
@@ -5297,7 +5299,7 @@ Example: `vec3(x,x,x)` is analyzed as follows:
     _ = b;
   }
 
-  // b is not part of frag2's shader interface. When compiling frag2 into a pipeline
+  // b is not part of the frag2 shader. When compiling frag2 into a pipeline
   // no errors occur even if b is not overridden and the value of a is 0.
   @fragment
   fn frag2() {

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -643,7 +643,7 @@ A processing error may occur during three phases in the shader lifecycle:
     is an error detectable at [=pipeline creation=] time.
     Detection relies on the WGSL module source text
     and other information available to the particular pipeline creation API method.
-    These errors are only triggered for code present in
+    These errors are only triggered for code present in the
     [=interface of a shader|shader interface=] of the [=entry point=] being
     compiled for the {{GPUProgrammableStage}}.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5281,11 +5281,18 @@ Example: `vec3(x,x,x)` is analyzed as follows:
 * The type of the expression is a [=vector=] of 3 components
     of [=i32=] (`vec3<i32>`).
 
+<div class='example override-expression errors' heading='Shader-creation errors from override-expressions'>
+  <xmp highlight=wgsl>
+  override a : i32 = 0;
+  override b = a / 0; // shader-creation error,
+                      // regardless of attempting to override c
+  </xmp>
+</div>
+
 <div class='example override-expression errors' heading='Pipeline-creation errors from override-expressions'>
   <xmp highlight=wgsl>
   override a : i32 = 0;
   override b = 1 / a;
-  override c = a / 0; // shader-creation error, regardless of attempting to override c
 
   // b is a part of the frag1 shader. When compiling frag1 into a pipeline
   // the following cases may occur:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -597,6 +597,11 @@ The events are:
         is invoked.
         These methods use one or more previously created shader modules, together with other
         configuration information.
+    * Only the code forming the [=interface of a shader|shader interface=] of the specified
+        [=entry point=] of the {{GPUProgrammableStage}} is considered during pipeline creation.
+        That is, code unrelated to the entry point is effectively stripped before compilation.
+    * Note: Each [=shader stage=] is compiled separately and, thus, might include different
+        portions of the module.
 3. <dfn noexport>Shader execution start</dfn>
     * This occurs when a [=draw command|draw=] or [=dispatch command=] is issued to the GPU,
         begins executing the pipeline,
@@ -638,6 +643,9 @@ A processing error may occur during three phases in the shader lifecycle:
     is an error detectable at [=pipeline creation=] time.
     Detection relies on the WGSL module source text
     and other information available to the particular pipeline creation API method.
+    These errors are only triggered for code present in
+    [=interface of a shader|shader interface=] of the [=entry point=] being
+    compiled for the {{GPUProgrammableStage}}.
 
 * A <dfn export>dynamic error</dfn> is an error occurring during shader execution.
     These errors may or may not be detectable.
@@ -5238,8 +5246,12 @@ An expression is an override-expression if all its [=identifiers=] [=resolve=] t
 
 Note: All [=const-expressions=] are also override-expressions.
 
+Override-expressions are only evaluated after any API-provided values are
+substituted [=override-declarations=].
+If an [=override-declaration=] has its value substituted via the API, its
+initializer expression, if present, will not be evaluated.
 An override-expression |E| [=behavioral requirement|will=] be evaluated if and only if:
-* |E| is [=top-level expression=], or
+* |E| is [=top-level expression=] (after value substitution), or
 * |E| is a [=subexpression=] of an expression |OuterE|, and |OuterE|
     [=behavioral requirement|will=] be evaluated, and evaluation of |OuterE|
     requires |E| to be evaluated.
@@ -5268,6 +5280,30 @@ Example: `vec3(x,x,x)` is analyzed as follows:
     [=resolve=] to override-declarations.
 * The type of the expression is a [=vector=] of 3 components
     of [=i32=] (`vec3<i32>`).
+
+<div class='example override-expression errors' heading='Pipeline-creation errors from override-expressions'>
+  <xmp highlight=wgsl>
+  override a : i32 = 0;
+  override b = 1 / a;
+  override c = a / 0; // shader-creation error, regardless of attempting to override c
+
+  // b is a part of frag1's shader interface. When compiling frag1 into a pipeline
+  // the following cases may occur:
+  // * if b is overridden, no error occurs.
+  // * if a is overridden to a non-zero value, no error occurs.
+  // * if a is 0 and b is not overridden, a pipeline-creation error occurs.
+  @fragment
+  fn frag1() {
+    _ = b;
+  }
+
+  // b is not part of frag2's shader interface. When compiling frag2 into a pipeline
+  // no errors occur even if b is not overridden and the value of a is 0.
+  @fragment
+  fn frag2() {
+  }
+  </xmp>
+</div>
 
 ## Indeterminate values ## {#indeterminate-values}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -597,8 +597,8 @@ The events are:
         is invoked.
         These methods use one or more previously created shader modules, together with other
         configuration information.
-    * Only the code forming the [=interface of a shader|shader interface=] of the specified
-        [=entry point=] of the {{GPUProgrammableStage}} is considered during pipeline creation.
+    * Only the code forming the [=shader=] of the specified [=entry point=] of the
+        {{GPUProgrammableStage}} is considered during pipeline creation.
         That is, code unrelated to the entry point is effectively stripped before compilation.
     * Note: Each [=shader stage=] is considered to be compiled separately and, thus, might
         include different portions of the module.
@@ -643,10 +643,8 @@ A processing error may occur during three phases in the shader lifecycle:
     is an error detectable at [=pipeline creation=] time.
     Detection relies on the WGSL module source text
     and other information available to the particular pipeline creation API method.
-    These errors are only triggered for code present in the
-    [=interface of a shader|shader interface=] and [=statically accessed=]
-    [=address spaces/workgroup=] [=variables=] of the [=entry point=] being
-    compiled for the {{GPUProgrammableStage}}.
+    These errors are only triggered for code present in the [=shader=] of the
+    [=entry point=] being compiled for the {{GPUProgrammableStage}}.
 
 * A <dfn export>dynamic error</dfn> is an error occurring during shader execution.
     These errors may or may not be detectable.


### PR DESCRIPTION
Fixes #4648

* Clarify that pipeline-creation only includes the code encompassed by the shader interface of the entry point being compiled
* Clarify that value substitution occurs before override-expression evaluation
  * Add examples of potential errors
* Clarify pipeline-creation errors only occur for the portion of the module being compiled