### PR TITLE
Add algorithm for linear interpolation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -107,6 +107,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: line break; url: line-break
         text: 64-bit unsigned integer; url: 64-bit-integer
         text: Synchronization Built-in Functions; url: sync-builtin-functions
+        text: interpolation-sampling; url: interpolation-sampling
         for: interpolation type
             text: flat; url: interpolation-type-flat
             text: linear; url: interpolation-type-linear
@@ -14994,23 +14995,19 @@ The clipped shader output |c|.v is produced based on the interpolation qualifier
 <dl class=switch>
     : [=interpolation type/flat=]
     ::
-        Flat interpolation is unaffected, and is based on <dfn dfn>provoking vertex</dfn>,
-        which is the first vertex in the primitive. The output value is the same
-        for the whole primitive, and matches the vertex output of the [=provoking vertex=]:
-        |c|.v = [=provoking vertex=].v
+        Flat interpolation is unaffected, and is based on the <dfn dfn>provoking vertex</dfn>,
+        which is determined by the [=interpolation sampling=] mode declared in the shader. The
+        output value is the same for the whole primitive, and matches the vertex output of the
+        [=provoking vertex=].
 
     : [=interpolation type/linear=]
     ::
         The interpolation ratio gets adjusted against the perspective coordinates of the
         [=clip position=]s, so that the result of interpolation is linear in screen space.
 
-        |c|.v = ((|t| &times; |a|.v) &div; |a|.p.w &plus; (1 &minus; |t|) &times; |b|.v &div; |b|.p.w) &div; (|t| &div; |a|.p.w &plus; (1 &minus; |t|) &div; |b|.p.w)
-
     : [=interpolation type/perspective=]
     ::
-        The value is linearly interpolated in clip space, producing perspective-correct values:
-
-        |c|.v = |t| &times; |a|.v &plus; (1 &minus; |t|) &times; |b|.v
+        The value is linearly interpolated in clip space, producing perspective-correct values.
 </dl>
 
 The result of primitive clipping is a new set of primitives, which are contained

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15004,7 +15004,7 @@ The clipped shader output |c|.v is produced based on the interpolation qualifier
         The interpolation ratio gets adjusted against the perspective coordinates of the
         [=clip position=]s, so that the result of interpolation is linear in screen space.
 
-        <p class="note editorial"><span class=marker>Editorial note:</span> provide more specifics here, if possible
+        |c|.v = ((|t| &times; |a|.v) &div; |a|.p.w &plus; (1 &minus; |t|) &times; |b|.v &div; |b|.p.w) &div; (|t| &div; |a|.p.w &plus; (1 &minus; |t|) &div; |b|.p.w)
 
     : [=interpolation type/perspective=]
     ::


### PR DESCRIPTION
I think this algorithm is right (pulling from https://registry.khronos.org/vulkan/specs/1.3/html/chap25.html#primsrast-lines-basic) but I'm still not completely convinced we've got the right algorithms paired with the linear/perspective modes. That said, the description of the linear mode DOES seem to match what the algorithm is doing, so I'm putting it there for now.

Renders as:

c.v = ((t × a.v) ÷ a.p.w + (1 − t) × b.v ÷ b.p.w) ÷ (t ÷ a.p.w + (1 − t) ÷ b.p.w)