### PR TITLE
wgsl: Fix range of atan: starts at -pi/2, not pi/2

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -13830,7 +13830,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
   <tr>
     <td>Description
     <td>Returns the principal value, in radians, of the inverse tangent (tan<sup>-1</sup>) of `e`.<br>
-    That is, approximates `x` with &pi;/2 &le; `x` &le; &pi;/2, such that `tan`(`x`) = `e`.
+    That is, approximates `x` with &minus; &pi;/2 &le; `x` &le; &pi;/2, such that `tan`(`x`) = `e`.
 
     [=Component-wise=] when `T` is a vector.
 </table>


### PR DESCRIPTION
Fixed: #4376