### PR TITLE
Resolve read-only depth/stencil inline issue

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9724,6 +9724,13 @@ dictionary GPUCommandEncoderDescriptor
                 1. If |depthStencilAttachment| is not `null`:
                     1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} is:
                         <dl class=switch>
+                            : Not [=map/exist|provided=]
+                            ::
+                                [=Assert=] that |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}}
+                                is `true` and ensure the contents of the [=aspect/depth=] [=GPUTextureView/subresource=]
+                                of |depthStencilView| are loaded into the [=framebuffer memory=] associated with
+                                |depthStencilView|.
+
                             : {{GPULoadOp/"load"}}
                             ::
                                 Ensure the contents of the [=aspect/depth=] [=GPUTextureView/subresource=] of
@@ -9739,6 +9746,13 @@ dictionary GPUCommandEncoderDescriptor
 
                     1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilLoadOp}} is:
                         <dl class=switch>
+                            : Not [=map/exist|provided=]
+                            ::
+                                [=Assert=] that |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
+                                is `true` and ensure the contents of the [=aspect/stencil=] [=GPUTextureView/subresource=]
+                                of |depthStencilView| are loaded into the [=framebuffer memory=] associated with
+                                |depthStencilView|.
+
                             : {{GPULoadOp/"load"}}
                             ::
                                 Ensure the contents of the [=aspect/stencil=] [=GPUTextureView/subresource=] of
@@ -9752,7 +9766,9 @@ dictionary GPUCommandEncoderDescriptor
                                 |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilClearValue}}.
                         </dl>
 
-                Issue: specify the behavior of read-only depth/stencil
+                Note: Read-only depth/stencil attachments are implicitly treated as though the {{GPULoadOp/"load"}}
+                operation was used. Validation that requires the load op to not be provided for read-only attachments
+                is done in [$GPURenderPassDepthStencilAttachment/GPURenderPassDepthStencilAttachment Valid Usage$].
             </div>
         </div>
 
@@ -11670,6 +11686,12 @@ called the render pass encoder can no longer be used.
                 1. If |depthStencilAttachment| is not `null`:
                     1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} is:
                         <dl class=switch>
+                            : Not [=map/exist|provided=]
+                            ::
+                                [=Assert=] that |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}}
+                                is `true` and leave the [=aspect/depth=] [=GPUTextureView/subresource=] of |depthStencilView|
+                                unchanged.
+
                             : {{GPUStoreOp/"store"}}
                             ::
                                 Ensure the contents of the [=framebuffer memory=] associated with the [=aspect/depth=]
@@ -11683,6 +11705,12 @@ called the render pass encoder can no longer be used.
 
                     1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilLoadOp}} is:
                         <dl class=switch>
+                            : Not [=map/exist|provided=]
+                            ::
+                                [=Assert=] that |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
+                                is `true` and leave the [=aspect/stencil=] [=GPUTextureView/subresource=] of |depthStencilView|
+                                unchanged.
+
                             : {{GPUStoreOp/"store"}}
                             ::
                                 Ensure the contents of the [=framebuffer memory=] associated with the [=aspect/stencil=]
@@ -11699,6 +11727,11 @@ called the render pass encoder can no longer be used.
                 Note: Discarded attachments behave as if they are cleared to zero, but implementations are not required
                 to perform a clear at the end of the render pass. See the note on {{GPUStoreOp/"discard"}} for
                 additional details.
+
+                Note: Read-only depth/stencil attachments can be thought of as implicitly using the {{GPUStoreOp/"store"}}
+                operation, but since their content is unchanged during the render pass implementations don't need to
+                update the attachment. Validation that requires the store op to not be provided for read-only attachments
+                is done in [$GPURenderPassDepthStencilAttachment/GPURenderPassDepthStencilAttachment Valid Usage$].
             </div>
             </div>
         </div>
@@ -14056,7 +14089,7 @@ This enum specifies how color values are displayed to the screen.
     ::
         Color values in the extended dynamic range of the screen are unchanged, and all
         other color values are projected to the extended dynamic range of the screen.
-        
+
         Note:
         This projection is often accomplished by clamping color values in the color space of
         the screen to the interval of values that the screen is capable of displaying,


### PR DESCRIPTION
Updates the load/store algorithms to take into account that read-only depth/stencil attachments require the load/store op to not be provided.