### PR TITLE
Define canvas image contents when unconfigured

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13772,6 +13772,13 @@ interface GPUCanvasContext {
 
     [=Content timeline=] steps:
 
+    1. If |context|.{{GPUCanvasContext/[[configuration]]}} is `null`:
+        1. Return a transparent black image of the same size as |context|.{{GPUCanvasContext/canvas}}.
+
+        Note: The {{GPUCanvasContext/[[configuration]]}} will be `null` if the context has not been
+        configured or has been {{GPUCanvasContext/unconfigure()|unconfigured}}. This is identical to
+        the behavior when the canvas has no context.
+
     1. Ensure that all submitted work items (e.g. queue submissions) have
         completed writing to the image (via |context|.{{GPUCanvasContext/[[currentTexture]]}}).
     1. Let |snapshot| be a copy of |context|.{{GPUCanvasContext/[[drawingBuffer]]}}.


### PR DESCRIPTION
Fixes #4606

Handle the case when canvas image contents are copied but the context hasn't been configured (or has been explicitly unconfigured). The behavior is identical to if the canvas has no context.