### PR TITLE
Clarify blend factors must be validated against optional features

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8366,6 +8366,10 @@ the values are ignored.
             {{GPUBlendOperation/"min"}} or {{GPUBlendOperation/"max"}}:
             - |component|.{{GPUBlendComponent/srcFactor}} and
                 |component|.{{GPUBlendComponent/dstFactor}} must both be {{GPUBlendFactor/"one"}}.
+        - If |component|.{{GPUBlendComponent/srcFactor}} or
+            |component|.{{GPUBlendComponent/dstFactor}} requires a feature and
+            |device|.{{device/[[features]]}} does not [=list/contain=] the feature:
+            - Throw a {{TypeError}}.
     </div>
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4850,8 +4850,9 @@ the behavior the same as when the format is unknown to the implementation.
 See [[#texture-format-caps]] for information about which {{GPUTextureFormat}}s require features.
 
 <div algorithm class=validusage data-timeline=content>
-    To <dfn abstract-op>Validate texture format required features</dfn> of a {{GPUTextureFormat}} |format|<br/>
-    with logical [=device=] |device|, run the following [=content timeline=] steps:
+    {{GPUBlendComponent}} |component| is a <dfn>valid GPUBlendComponent</dfn> with logical
+    [=device=] |device| if it meets<br/>
+    the following requirements:
 
     1. If |format| requires a feature and |device|.{{device/[[features]]}} does not [=list/contain=]
         the feature:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4850,9 +4850,8 @@ the behavior the same as when the format is unknown to the implementation.
 See [[#texture-format-caps]] for information about which {{GPUTextureFormat}}s require features.
 
 <div algorithm class=validusage data-timeline=content>
-    {{GPUBlendComponent}} |component| is a <dfn>valid GPUBlendComponent</dfn> with logical
-    [=device=] |device| if it meets<br/>
-    the following requirements:
+    To <dfn abstract-op>Validate texture format required features</dfn> of a {{GPUTextureFormat}} |format|<br/>
+    with logical [=device=] |device|, run the following [=content timeline=] steps:
 
     1. If |format| requires a feature and |device|.{{device/[[features]]}} does not [=list/contain=]
         the feature:
@@ -8359,8 +8358,9 @@ The fragment shader may output more values than what the pipeline uses. If that 
 the values are ignored.
 
 <div algorithm data-timeline=device>
-    To validate if {{GPUBlendComponent}} |component| is a <dfn>valid GPUBlendComponent</dfn><br/>
-    with logical [=device=] |device|, run the following [=content timeline=] steps:
+    {{GPUBlendComponent}} |component| is a <dfn>valid GPUBlendComponent</dfn> with logical
+    [=device=] |device| if it meets<br/>
+    the following requirements:
 
     <div class=validusage>
         - If |component|.{{GPUBlendComponent/operation}} is

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8358,8 +8358,8 @@ The fragment shader may output more values than what the pipeline uses. If that 
 the values are ignored.
 
 <div algorithm data-timeline=device>
-    {{GPUBlendComponent}} |component| is a <dfn>valid GPUBlendComponent</dfn> if it meets<br/>
-    the following requirements:
+    To validate if {{GPUBlendComponent}} |component| is a <dfn>valid GPUBlendComponent</dfn><br/>
+    with logical [=device=] |device|, run the following [=content timeline=] steps:
 
     <div class=validusage>
         - If |component|.{{GPUBlendComponent/operation}} is

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8368,8 +8368,9 @@ the values are ignored.
             - |component|.{{GPUBlendComponent/srcFactor}} and
                 |component|.{{GPUBlendComponent/dstFactor}} must both be {{GPUBlendFactor/"one"}}.
         - If |component|.{{GPUBlendComponent/srcFactor}} or
-            |component|.{{GPUBlendComponent/dstFactor}} requires a feature and
-            |device|.{{device/[[features]]}} does not [=list/contain=] the feature:
+            |component|.{{GPUBlendComponent/dstFactor}} requires a feature according to the
+            {{GPUBlendFactor}} table and |device|.{{device/[[features]]}} does not [=list/contain=]
+            the feature:
             - Throw a {{TypeError}}.
     </div>
 </div>


### PR DESCRIPTION
This patch adds additional validations in `valid GPUBlendComponent` section that blend factors must be validated against the support of optional features (for example, `dual-source-blending`).