### PR TITLE
Update VideoFrames to use display size

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4957,7 +4957,8 @@ dictionary GPUExternalTextureDescriptor
 <dl dfn-type=dict-member dfn-for=GPUExternalTextureDescriptor>
     : <dfn>source</dfn>
     ::
-        The video source to import the external texture from.
+        The video source to import the external texture from. Source size is determined as described
+        by the [=external source dimensions=] table.
 
     : <dfn>colorSpace</dfn>
     ::

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -358,51 +358,8 @@ dictionary GPUImageCopyExternalImage {
     : <dfn>source</dfn>
     ::
         The source of the [=image copy=]. The copy source data is captured at the moment that
-        {{GPUQueue/copyExternalImageToTexture()}} is issued. Source size is defined by source
-        type, given by this table:
-
-        <table class=data>
-            <thead>
-                <tr>
-                    <th>Source type
-                    <th>Dimensions
-            </thead>
-            <tbody>
-                <tr>
-                    <td>{{ImageBitmap}}
-                    <td>{{ImageBitmap/width|ImageBitmap.width}},
-                        {{ImageBitmap/height|ImageBitmap.height}}
-                <tr>
-                    <td>{{HTMLImageElement}}
-                    <td>{{HTMLImageElement/naturalWidth|HTMLImageElement.naturalWidth}},
-                        {{HTMLImageElement/naturalHeight|HTMLImageElement.naturalHeight}}
-                <tr>
-                    <td>{{HTMLVideoElement}}
-                    <td>[=video/intrinsic width|intrinsic width of the frame=],
-                        [=video/intrinsic height|intrinsic height of the frame=]
-                <tr>
-                    <td>{{VideoFrame}}
-                    <td>{{VideoFrame/codedWidth|VideoFrame.codedWidth}},
-                        {{VideoFrame/codedHeight|VideoFrame.codedHeight}}
-                <tr>
-                    <td>{{ImageData}}
-                    <td>{{ImageData/width|ImageData.width}},
-                        {{ImageData/height|ImageData.height}}
-                <tr>
-                    <td>{{HTMLCanvasElement}} or {{OffscreenCanvas}} with {{CanvasRenderingContext2D}} or {{GPUCanvasContext}}
-                    <td>{{HTMLCanvasElement/width|HTMLCanvasElement.width}},
-                        {{HTMLCanvasElement/height|HTMLCanvasElement.height}}
-                <tr>
-                    <td>{{HTMLCanvasElement}} or {{OffscreenCanvas}} with {{WebGLRenderingContextBase}}
-                    <td>{{WebGLRenderingContextBase/drawingBufferWidth|WebGLRenderingContextBase.drawingBufferWidth}},
-                        {{WebGLRenderingContextBase/drawingBufferHeight|WebGLRenderingContextBase.drawingBufferHeight}}
-                <tr>
-                    <td>{{HTMLCanvasElement}} or {{OffscreenCanvas}} with {{ImageBitmapRenderingContext}}
-                    <td>{{ImageBitmapRenderingContext}}'s internal output bitmap
-                        {{ImageBitmap/width|ImageBitmap.width}},
-                        {{ImageBitmap/height|ImageBitmap.height}}
-            </tbody>
-        </table>
+        {{GPUQueue/copyExternalImageToTexture()}} is issued. Source size is determined as described
+        by the [=external source dimensions=] table.
 
     : <dfn>origin</dfn>
     ::
@@ -418,6 +375,52 @@ dictionary GPUImageCopyExternalImage {
         The {{GPUImageCopyExternalImage/origin}} option is still relative to the top-left corner
         of the source image, increasing downward.
 </dl>
+
+When external sources are used when creating or copying to textures, the <dfn dfn>external source dimensions</dfn>
+are defined by the source type, given by this table:
+
+<table class=data>
+    <thead>
+        <tr>
+            <th>External Source type
+            <th>Dimensions
+    </thead>
+    <tbody>
+        <tr>
+            <td>{{ImageBitmap}}
+            <td>{{ImageBitmap/width|ImageBitmap.width}},
+                {{ImageBitmap/height|ImageBitmap.height}}
+        <tr>
+            <td>{{HTMLImageElement}}
+            <td>{{HTMLImageElement/naturalWidth|HTMLImageElement.naturalWidth}},
+                {{HTMLImageElement/naturalHeight|HTMLImageElement.naturalHeight}}
+        <tr>
+            <td>{{HTMLVideoElement}}
+            <td>[=video/intrinsic width|intrinsic width of the frame=],
+                [=video/intrinsic height|intrinsic height of the frame=]
+        <tr>
+            <td>{{VideoFrame}}
+            <td>{{VideoFrame/displayWidth|VideoFrame.displayWidth}},
+                {{VideoFrame/displayHeight|VideoFrame.displayHeight}}
+        <tr>
+            <td>{{ImageData}}
+            <td>{{ImageData/width|ImageData.width}},
+                {{ImageData/height|ImageData.height}}
+        <tr>
+            <td>{{HTMLCanvasElement}} or {{OffscreenCanvas}} with {{CanvasRenderingContext2D}} or {{GPUCanvasContext}}
+            <td>{{HTMLCanvasElement/width|HTMLCanvasElement.width}},
+                {{HTMLCanvasElement/height|HTMLCanvasElement.height}}
+        <tr>
+            <td>{{HTMLCanvasElement}} or {{OffscreenCanvas}} with {{WebGLRenderingContextBase}}
+            <td>{{WebGLRenderingContextBase/drawingBufferWidth|WebGLRenderingContextBase.drawingBufferWidth}},
+                {{WebGLRenderingContextBase/drawingBufferHeight|WebGLRenderingContextBase.drawingBufferHeight}}
+        <tr>
+            <td>{{HTMLCanvasElement}} or {{OffscreenCanvas}} with {{ImageBitmapRenderingContext}}
+            <td>{{ImageBitmapRenderingContext}}'s internal output bitmap
+                {{ImageBitmap/width|ImageBitmap.width}},
+                {{ImageBitmap/height|ImageBitmap.height}}
+    </tbody>
+</table>
 
 ### Subroutines ### {#image-copies-subroutines}
 


### PR DESCRIPTION
Fixes #4525

Specifies that displayWidth and displayHeight are used when importing or copying VideoFrames. Also moves the table defining how external source dimensions are determined into a more generic place so it can be linked from GPUExternalTextureDescriptor as well.