### PR TITLE
bgra8unorm-storage only enables write-only

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15881,20 +15881,21 @@ The [=texel block memory cost=] of each of these formats is the same as its
 <table class=data>
     <thead class=stickyheader>
         <tr>
-            <th>Format
-            <th>{{GPUTextureSampleType}}
-            <th><span class=vertical>{{GPUTextureUsage/RENDER_ATTACHMENT}}</span>
-            <th><span class=vertical>[=blendable=]</span>
-            <th><span class=vertical>multisampling</span>
-            <th><span class=vertical>resolve</span>
-            <th><span class=vertical>{{GPUStorageTextureAccess/"write-only"}} or {{GPUStorageTextureAccess/"read-only"}}<br>
-            {{GPUTextureUsage/STORAGE_BINDING}}</span>
-            <th><span class=vertical>{{GPUStorageTextureAccess/"read-write"}}<br>
-            {{GPUTextureUsage/STORAGE_BINDING}}</span>
-            <th>[=Texel block copy footprint=] (Bytes)
-            <th>[=Render target pixel byte cost=] (Bytes)
+            <th rowspan=2>Format
+            <th rowspan=2>{{GPUTextureSampleType}}
+            <th rowspan=2><span class=vertical>{{GPUTextureUsage/RENDER_ATTACHMENT}}</span>
+            <th rowspan=2><span class=vertical>[=blendable=]</span>
+            <th rowspan=2><span class=vertical>multisampling</span>
+            <th rowspan=2><span class=vertical>resolve</span>
+            <th colspan=3>{{GPUTextureUsage/STORAGE_BINDING}}
+            <th rowspan=2>[=Texel block copy footprint=] (Bytes)
+            <th rowspan=2>[=Render target pixel byte cost=] (Bytes)
+        <tr>
+            <th><span class=vertical>{{GPUStorageTextureAccess/"write-only"}}</span>
+            <th><span class=vertical>{{GPUStorageTextureAccess/"read-only"}}</span>
+            <th><span class=vertical>{{GPUStorageTextureAccess/"read-write"}}</span>
     </thead>
-    <tr><th colspan=10>8 bits per component (1-byte [=render target component alignment=])
+    <tr><th colspan=11>8 bits per component (1-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -15902,6 +15903,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
+        <td>
         <td>
         <td>
         <td colspan=2>1
@@ -15912,6 +15914,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
+        <td><!-- Vulkan -->
         <td><!-- Vulkan -->
         <td><!-- Vulkan -->
         <td>1
@@ -15925,6 +15928,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>
         <td>
+        <td>
         <td colspan=2>1
     <tr>
         <td>{{GPUTextureFormat/r8sint}}
@@ -15933,6 +15937,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td>&checkmark;
         <td><!-- Metal -->
+        <td>
         <td>
         <td>
         <td colspan=2>1
@@ -15945,6 +15950,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td><!-- Vulkan -->
         <td><!-- Vulkan -->
+        <td><!-- Vulkan -->
         <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/rg8snorm}}
@@ -15953,6 +15959,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
+        <td><!-- Vulkan -->
         <td><!-- Vulkan -->
         <td><!-- Vulkan -->
         <td>2
@@ -15966,6 +15973,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>
         <td>
+        <td>
         <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/rg8sint}}
@@ -15976,10 +15984,12 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>
         <td>
+        <td>
         <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
@@ -15997,6 +16007,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>
         <td>
+        <td>
         <td>4
         <td>8
     <tr>
@@ -16006,6 +16017,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
+        <td>&checkmark;
         <td>&checkmark;
         <td>
         <td>4
@@ -16018,6 +16030,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
+        <td>&checkmark;
         <td>
         <td colspan=2>4
     <tr>
@@ -16027,6 +16040,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td>&checkmark;
         <td><!-- Metal -->
+        <td>&checkmark;
         <td>&checkmark;
         <td>
         <td colspan=2>4
@@ -16039,6 +16053,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>If {{GPUFeatureName/"bgra8unorm-storage"}} is enabled
         <td>
+        <td>
         <td>4
         <td>8
     <tr>
@@ -16050,9 +16065,10 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>
         <td>
+        <td>
         <td>4
         <td>8
-    <tr><th colspan=10>16 bits per component (2-byte [=render target component alignment=])
+    <tr><th colspan=11>16 bits per component (2-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -16060,6 +16076,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td>&checkmark;
         <td><!-- Metal -->
+        <td>
         <td>
         <td>
         <td colspan=2>2
@@ -16072,6 +16089,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>
         <td>
+        <td>
         <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/r16float}}
@@ -16080,6 +16098,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
+        <td>
         <td>
         <td>
         <td colspan=2>2
@@ -16092,6 +16111,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>
         <td>
+        <td>
         <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/rg16sint}}
@@ -16100,6 +16120,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td>&checkmark;
         <td><!-- Metal -->
+        <td>
         <td>
         <td>
         <td colspan=2>4
@@ -16112,6 +16133,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td><!-- Vulkan -->
         <td><!-- Vulkan -->
+        <td><!-- Vulkan -->
         <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/rgba16uint}}
@@ -16120,6 +16142,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td>&checkmark;
         <td><!-- Metal -->
+        <td>&checkmark;
         <td>&checkmark;
         <td>
         <td colspan=2>8
@@ -16131,6 +16154,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
+        <td>&checkmark;
         <td>
         <td colspan=2>8
     <tr>
@@ -16141,9 +16165,10 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
+        <td>&checkmark;
         <td>
         <td colspan=2>8
-    <tr><th colspan=10>32 bits per component (4-byte [=render target component alignment=])
+    <tr><th colspan=11>32 bits per component (4-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -16151,6 +16176,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td><!-- Metal -->
         <td>
+        <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td colspan=2>4
@@ -16161,6 +16187,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td><!-- Metal -->
         <td>
+        <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td colspan=2>4
@@ -16175,6 +16202,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
+        <td>&checkmark;
         <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/rg32uint}}
@@ -16183,6 +16211,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td><!-- Metal -->
         <td>
+        <td>&checkmark;
         <td>&checkmark;
         <td>
         <td colspan=2>8
@@ -16193,6 +16222,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td><!-- Metal -->
         <td>
+        <td>&checkmark;
         <td>&checkmark;
         <td>
         <td colspan=2>8
@@ -16206,6 +16236,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
+        <td>&checkmark;
         <td>
         <td colspan=2>8
     <tr>
@@ -16216,6 +16247,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
+        <td>&checkmark;
         <td>
         <td colspan=2>16
     <tr>
@@ -16225,6 +16257,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td><!-- Metal -->
         <td>
+        <td>&checkmark;
         <td>&checkmark;
         <td>
         <td colspan=2>16
@@ -16238,15 +16271,17 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
+        <td>&checkmark;
         <td>
         <td colspan=2>16
-    <tr><th colspan=10>mixed component width, 32 bits per texel (4-byte [=render target component alignment=])
+    <tr><th colspan=11>mixed component width, 32 bits per texel (4-byte [=render target component alignment=])
     <tr>
         <td>{{GPUTextureFormat/rgb10a2uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
+        <td>
         <td>
         <td>
         <td>
@@ -16261,12 +16296,14 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>
         <td>
+        <td>
         <td>4
         <td>8
     <tr>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=4>If {{GPUFeatureName/"rg11b10ufloat-renderable"}} is enabled
+        <td><!-- Vulkan -->
         <td><!-- Vulkan -->
         <td><!-- Vulkan -->
         <td>4


### PR DESCRIPTION
Fixes #4377

Updates the plain color texture table to separate out read-only and write-only storage bindings. bgra8unorm is only given write-only access if the feature is enabled and never given read-only access. All other formats retain the same access as before.