### PR TITLE
Point and line primitives must not have depth bias

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7932,7 +7932,8 @@ dictionary GPURenderPipelineDescriptor
                         must have a [=aspect/depth=] aspect.
             - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|) succeeds.
             - If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is [=map/exist|provided=]:
-                - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
+                - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}},
+                    |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}}) succeeds.
             - [$validating GPUMultisampleState$](|descriptor|.{{GPURenderPipelineDescriptor/multisample}}) succeeds.
             - If |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}}
                 is true:
@@ -8677,16 +8678,21 @@ will affect a render pass's {{GPURenderPassDescriptor/depthStencilAttachment}}:
 
     : <dfn>depthBias</dfn>
     ::
-        Constant depth bias added to each fragment. See [$biased fragment depth$] for details.
+        Constant depth bias added to each triangle fragment. See [$biased fragment depth$] for details.
 
     : <dfn>depthBiasSlopeScale</dfn>
     ::
-        Depth bias that scales with the fragment’s slope. See [$biased fragment depth$] for details.
+        Depth bias that scales with the triangle fragment’s slope. See [$biased fragment depth$] for details.
 
     : <dfn>depthBiasClamp</dfn>
     ::
-        The maximum depth bias of a fragment. See [$biased fragment depth$] for details.
+        The maximum depth bias of a triangle fragment. See [$biased fragment depth$] for details.
 </dl>
+
+Note: {{GPUDepthStencilState/depthBias}}, {{GPUDepthStencilState/depthBiasSlopeScale}}, and
+{{GPUDepthStencilState/depthBiasClamp}} have no effect on {{GPUPrimitiveTopology/"point-list"}},
+{{GPUPrimitiveTopology/"line-list"}}, and {{GPUPrimitiveTopology/"line-strip"}} primitives, and
+must be 0.
 
 <div algorithm data-timeline=queue>
     The <dfn abstract-op>biased fragment depth</dfn> for a fragment being written to
@@ -8709,11 +8715,12 @@ will affect a render pass's {{GPURenderPassDescriptor/depthStencilAttachment}}:
 </div>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>validating GPUDepthStencilState</dfn>(|descriptor|)
+    <dfn abstract-op>validating GPUDepthStencilState</dfn>(|descriptor|, |topology|)
 
     **Arguments:**
 
     - {{GPUDepthStencilState}} |descriptor|
+    - {{GPUPrimitiveTopology}} |topology|
 
     [=Device timeline=] steps:
 
@@ -8736,6 +8743,11 @@ will affect a render pass's {{GPURenderPassDescriptor/depthStencilAttachment}}:
                         is not {{GPUStencilOperation/"keep"}}, or
                     - |descriptor|.{{GPUDepthStencilState/stencilBack}}.{{GPUStencilFaceState/depthFailOp}}
                         is not {{GPUStencilOperation/"keep"}}.
+            - If |topology| is {{GPUPrimitiveTopology/"point-list"}}, {{GPUPrimitiveTopology/"line-list"}}, or
+                {{GPUPrimitiveTopology/"line-strip"}}:
+                - |descriptor|.{{GPUDepthStencilState/depthBias}} must be 0.
+                - |descriptor|.{{GPUDepthStencilState/depthBiasSlopeScale}} must be 0.
+                - |descriptor|.{{GPUDepthStencilState/depthBiasClamp}} must be 0.
         </div>
 
 </div>


### PR DESCRIPTION
Fixes #4729

Adds a note that depth bias doesn't affect line and point primitives, and validate that they are zero during pipeline creation to ensure that is the case universally.