### PR TITLE
Add usage to GPUTextureViewDescriptor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4342,10 +4342,8 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
             - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
                 |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
                 [=texture view format compatible=].
-                <div class=note heading>
-                    Implementations may consider issuing a warning if |viewFormat| is not compatible with any of the
-                    given {{GPUTextureDescriptor/usage}} bits, as that |viewFormat| will be unusable.
-                </div>
+
+                <!-- TODO(#4852): Either validate or encourage a warning here if there is no valid viewFormat/usage combination -->
         </div>
 </div>
 
@@ -9016,8 +9014,8 @@ operations are performed:
 <dl dfn-type=dict-member dfn-for=GPUStencilFaceState>
     : <dfn>compare</dfn>
     ::
-        The {{GPUCompareFunction}} used when testing fragments against
-        {{GPURenderPassDescriptor/depthStencilAttachment}} stencil values.
+        The {{GPUCompareFunction}} used when testing the {{RenderState/[[stencilReference]]}} value
+        against the fragment's {{GPURenderPassDescriptor/depthStencilAttachment}} stencil value.
 
     : <dfn>failOp</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4343,7 +4343,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                 |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
                 [=texture view format compatible=].
 
-                <!-- TODO(#4852): Either validate or encourage a warning here if there is no valid viewFormat/usage combination -->
+                Issue(#4852): Either validate or encourage a warning here if there is no valid viewFormat/usage combination.
         </div>
 </div>
 
@@ -4751,7 +4751,7 @@ enum GPUTextureAspect {
                 1. Let |view| be a new {{GPUTextureView}} object.
                 1. Set |view|.{{GPUTextureView/[[texture]]}} to |this|.
                 1. Set |view|.{{GPUTextureView/[[descriptor]]}} to |descriptor|.
-                1. If |this|.{{GPUTexture/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
+                1. If |descriptor|.{{GPUTextureViewDescriptor/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
                     1. Let |renderExtent| be [$compute render extent$]([|this|.{{GPUTexture/width}}, |this|.{{GPUTexture/height}}, |this|.{{GPUTexture/depthOrArrayLayers}}], |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
                     1. Set |view|.{{GPUTextureView/[[renderExtent]]}} to |renderExtent|.
             </div>
@@ -9014,8 +9014,8 @@ operations are performed:
 <dl dfn-type=dict-member dfn-for=GPUStencilFaceState>
     : <dfn>compare</dfn>
     ::
-        The {{GPUCompareFunction}} used when testing the {{RenderState/[[stencilReference]]}} value
-        against the fragment's {{GPURenderPassDescriptor/depthStencilAttachment}} stencil value.
+        The {{GPUCompareFunction}} used when testing testing fragments against
+        {{GPURenderPassDescriptor/depthStencilAttachment}} stencil value.
 
     : <dfn>failOp</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4453,6 +4453,7 @@ dictionary GPUTextureViewDescriptor
          : GPUObjectDescriptorBase {
     GPUTextureFormat format;
     GPUTextureViewDimension dimension;
+    GPUTextureUsageFlags usage;
     GPUTextureAspect aspect = "all";
     GPUIntegerCoordinate baseMipLevel = 0;
     GPUIntegerCoordinate mipLevelCount;
@@ -4472,6 +4473,12 @@ dictionary GPUTextureViewDescriptor
     : <dfn>dimension</dfn>
     ::
         The dimension to view the texture as.
+
+    : <dfn>usage</dfn>
+    ::
+        The allowed {{GPUTextureUsage|usage(s)}} for the texture view. Must be a subset of the
+        {{GPUTexture/usage}} flags of the texture. Defaults to the full set of {{GPUTexture/usage}}
+        flags of the texture.
 
     : <dfn>aspect</dfn>
     ::
@@ -4682,6 +4689,10 @@ enum GPUTextureAspect {
                                 |this|.{{GPUTexture/format}},
                                 |descriptor|.{{GPUTextureViewDescriptor/aspect}}).
 
+                        - |descriptor|.{{GPUTextureViewDescriptor/usage}} must be a subset of |this|.{{GPUTexture/usage}}.
+                        - If |descriptor|.{{GPUTextureViewDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit:
+                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must be listed in [[#plain-color-formats]] table
+                                with {{GPUTextureUsage/STORAGE_BINDING}} capability for the appropriate access mode.
                         - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &gt; 0.
                         - |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}} +
                             |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &le;
@@ -4792,6 +4803,8 @@ enum GPUTextureAspect {
             :: Set |resolved|.{{GPUTextureViewDescriptor/arrayLayerCount}} to the [$array layer count$] of |texture|
                 &minus; |resolved|.{{GPUTextureViewDescriptor/baseArrayLayer}}.
         </dl>
+    1. If |resolved|.{{GPUTextureViewDescriptor/usage}} is not [=map/exist|provided=]:
+        set |resolved|.{{GPUTextureViewDescriptor/usage}} to |texture|.{{GPUTexture/usage}}.
 
     1. Return |resolved|.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6333,7 +6333,8 @@ following members:
                                         - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}
                                             is [[#texture-format-caps|compatible]] with
                                             |resource|'s {{GPUTextureViewDescriptor/format}}.
-                                        - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/TEXTURE_BINDING}}.
+                                        - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
+                                            includes {{GPUTextureUsage/TEXTURE_BINDING}}.
                                         - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/multisampled}}
                                             is `true`, |texture|'s {{GPUTextureDescriptor/sampleCount}}
                                             &gt; `1`, Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
@@ -6347,7 +6348,8 @@ following members:
                                             is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
                                         - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
                                             is equal to |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
-                                        - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/STORAGE_BINDING}}.
+                                        - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
+                                            includes {{GPUTextureUsage/STORAGE_BINDING}}.
                                         - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
 
                                     :  {{GPUBindGroupLayoutEntry/buffer}}
@@ -11613,7 +11615,7 @@ dictionary GPURenderPassColorAttachment {
 
     <div class=validusage>
         1. Let |descriptor| be |view|.{{GPUTextureView/[[descriptor]]}}.
-        1. |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/usage}}
+        1. |descriptor|.{{GPUTextureViewDescriptor/usage}}
             must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
         1. |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be {{GPUTextureViewDimension/"2d"}}
             or {{GPUTextureViewDimension/"2d-array"}} or {{GPUTextureViewDimension/"3d"}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4342,6 +4342,10 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
             - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
                 |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
                 [=texture view format compatible=].
+                <div class=note heading>
+                    Implementations may consider issuing a warning if |viewFormat| is not compatible with any of the
+                    given {{GPUTextureDescriptor/usage}} bits, as that |viewFormat| will be unusable.
+                </div>
         </div>
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4480,6 +4480,10 @@ dictionary GPUTextureViewDescriptor
         {{GPUTexture/usage}} flags of the texture. Defaults to the full set of {{GPUTexture/usage}}
         flags of the texture.
 
+        Note: If the view's {{GPUTextureViewDescriptor/format}} doesn't support all of the
+        texture's {{GPUTextureDescriptor/usage}}s, the default will fail,
+        and the view's {{GPUTextureViewDescriptor/usage}} must be specified explicitly.
+
     : <dfn>aspect</dfn>
     ::
         Which {{GPUTextureAspect|aspect(s)}} of the texture are accessible to the texture view.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4338,7 +4338,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                 - |descriptor|.{{GPUTextureDescriptor/dimension}} must be either {{GPUTextureDimension/"2d"}} or {{GPUTextureDimension/"3d"}}.
             - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit:
                 - |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
-                    with {{GPUTextureUsage/STORAGE_BINDING}} capability for the appropriate access mode.
+                    with {{GPUTextureUsage/STORAGE_BINDING}} capability for at least one access mode.
             - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
                 |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
                 [=texture view format compatible=].
@@ -4694,9 +4694,11 @@ enum GPUTextureAspect {
                                 |descriptor|.{{GPUTextureViewDescriptor/aspect}}).
 
                         - |descriptor|.{{GPUTextureViewDescriptor/usage}} must be a subset of |this|.{{GPUTexture/usage}}.
+                        - If |descriptor|.{{GPUTextureViewDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
+                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must be a [=renderable format=].
                         - If |descriptor|.{{GPUTextureViewDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit:
                             - |descriptor|.{{GPUTextureViewDescriptor/format}} must be listed in [[#plain-color-formats]] table
-                                with {{GPUTextureUsage/STORAGE_BINDING}} capability for the appropriate access mode.
+                                with {{GPUTextureUsage/STORAGE_BINDING}} capability for at least one access mode.
                         - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &gt; 0.
                         - |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}} +
                             |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &le;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4457,7 +4457,7 @@ dictionary GPUTextureViewDescriptor
          : GPUObjectDescriptorBase {
     GPUTextureFormat format;
     GPUTextureViewDimension dimension;
-    GPUTextureUsageFlags usage;
+    GPUTextureUsageFlags usage = 0;
     GPUTextureAspect aspect = "all";
     GPUIntegerCoordinate baseMipLevel = 0;
     GPUIntegerCoordinate mipLevelCount;
@@ -4481,8 +4481,8 @@ dictionary GPUTextureViewDescriptor
     : <dfn>usage</dfn>
     ::
         The allowed {{GPUTextureUsage|usage(s)}} for the texture view. Must be a subset of the
-        {{GPUTexture/usage}} flags of the texture. Defaults to the full set of {{GPUTexture/usage}}
-        flags of the texture.
+        {{GPUTexture/usage}} flags of the texture. If 0, defaults to the full set of
+        {{GPUTexture/usage}} flags of the texture.
 
         Note: If the view's {{GPUTextureViewDescriptor/format}} doesn't support all of the
         texture's {{GPUTextureDescriptor/usage}}s, the default will fail,
@@ -4813,7 +4813,7 @@ enum GPUTextureAspect {
             :: Set |resolved|.{{GPUTextureViewDescriptor/arrayLayerCount}} to the [$array layer count$] of |texture|
                 &minus; |resolved|.{{GPUTextureViewDescriptor/baseArrayLayer}}.
         </dl>
-    1. If |resolved|.{{GPUTextureViewDescriptor/usage}} is not [=map/exist|provided=]:
+    1. If |resolved|.{{GPUTextureViewDescriptor/usage}} is `0`:
         set |resolved|.{{GPUTextureViewDescriptor/usage}} to |texture|.{{GPUTexture/usage}}.
 
     1. Return |resolved|.


### PR DESCRIPTION
Fixes #4426

Adds usage to texture views, defaulting them to the full set of usages from the texture. Validates that they must be a subset of the texture usage and validates that the view format is storage compatible if the `STORAGE_BINDING` usage is specified.

CC @teoxoy and @austinEng