### PR TITLE
Add missing "valid to use with" checks to `GPURenderPassDescriptor` Valid Usage

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11195,10 +11195,16 @@ dictionary GPURenderPassDescriptor
 
     1. For each non-`null` |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:
 
+        1. |colorAttachment|.{{GPURenderPassColorAttachment/view}} must be [$valid to use with$] |device|.
+        1. If |colorAttachment|.{{GPURenderPassColorAttachment/resolveTarget}} is [=map/exist|provided=]:
+
+            1. |colorAttachment|.{{GPURenderPassColorAttachment/resolveTarget}} must be [$valid to use with$] |device|.
+
         1. |colorAttachment| must meet the [$GPURenderPassColorAttachment/GPURenderPassColorAttachment Valid Usage$] rules.
 
     1. If |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} is [=map/exist|provided=]:
 
+        1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}} must be [$valid to use with$] |device|.
         1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must meet the [$GPURenderPassDepthStencilAttachment/GPURenderPassDepthStencilAttachment Valid Usage$] rules.
 
     1. There must exist at least one attachment, either:
@@ -11217,6 +11223,7 @@ dictionary GPURenderPassDescriptor
 
     1. If |this|.{{GPURenderPassDescriptor/occlusionQuerySet}} is not `null`:
 
+        1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}} must be [$valid to use with$] |device|.
         1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/type}}
             must be {{GPUQueryType/occlusion}}.
 


### PR DESCRIPTION
The CTS already has those https://github.com/gpuweb/cts/blob/20425f60bb00676af386b5c31e7748c0e2cb1702/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts.