### PR TITLE
Fix some language which ignores that limits get clamped to defaults

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1248,12 +1248,12 @@ A [=device=] has the following [=immutable properties=]:
 
     : <dfn>\[[features]]</dfn>, of type [=ordered set=]&lt;{{GPUFeatureName}}&gt;, readonly
     ::
-        The [=features=] which can be used on this device.
+        The [=features=] which can be used on this device, as computed [=a new device|at creation=].
         No additional features can be used, even if the underlying [=adapter=] can support them.
 
     : <dfn>\[[limits]]</dfn>, of type [=supported limits=], readonly
     ::
-        The limits which can be used on this device.
+        The limits which can be used on this device, as computed [=a new device|at creation=].
         No [=limit/better=] limits can be used, even if the underlying [=adapter=] can support them.
 </dl>
 
@@ -1331,9 +1331,10 @@ The capabilities of an [=adapter=] must conform to [[#adapter-capability-guarant
 Only supported capabilities may be requested in {{GPUAdapter/requestDevice()}};
 requesting unsupported capabilities results in failure.
 
-The capabilities of a [=device=] are exactly the ones which were requested in
-{{GPUAdapter/requestDevice()}}. These capabilities are enforced regardless of the
-capabilities of the [=adapter=].
+The capabilities of a [=device=] are determined in "[=a new device=]" by starting with the adapter's
+defaults (no features and the default [=supported limits=])
+and adding capabilities as requested in {{GPUAdapter/requestDevice()}}.
+These capabilities are enforced regardless of the capabilities of the [=adapter=].
 
 <p tracking-vector>
 For privacy considerations, see [[#privacy-machine-limits]].
@@ -2159,7 +2160,7 @@ interface GPU {
                 [=Device timeline=] |initialization steps|:
 
                 1. Let |adapter| be `null`.
-                1. If the user agent chooses to return an adapter, it should:
+                1. If the user agent chooses to return an adapter:
                     1. Set |adapter| to an [=adapter=] chosen according to
                         the rules in [[#adapter-selection]] and the criteria in |options|,
                         adhering to [[#adapter-capability-guarantees]].
@@ -2727,12 +2728,11 @@ GPUDevice includes GPUObjectBase;
     : <dfn>features</dfn>
     ::
         A set containing the {{GPUFeatureName}} values of the features
-        supported by the device (i.e. the ones with which it was created).
+        supported by the device ({{GPUObjectBase/[[device]]}}.{{device/[[features]]}}).
 
     : <dfn>limits</dfn>
     ::
-        Exposes the limits supported by the device
-        (which are exactly the ones with which it was created).
+        The limits supported by the device ({{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}).
 
     : <dfn>queue</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -417,8 +417,8 @@ table.data th {
     border-left: 1px solid rgb(186 186 186 / 30%);
 }
 
-table.data.no-colspan-center td[colspan],
-table.data.no-colspan-center th[colspan] {
+table.data tr.row-continuation td[colspan],
+table.data tr.row-continuation th[colspan] {
     text-align: unset;
 }
 
@@ -428,9 +428,12 @@ table.data tr.row-continuation th {
 }
 
 /*
- * Vertical class for table columns. (Can't use th.vertical because of a Safari bug.)
+ * Vertical class for table columns. (Can't use th.vertical directly because of a Safari bug.)
  */
-span.vertical {
+th.vertical {
+    vertical-align: top;
+}
+th.vertical span {
     writing-mode: vertical-rl;
     white-space: nowrap;
 }
@@ -1407,7 +1410,7 @@ applications should generally request the "worst" limits that work for their con
 
 A <dfn dfn>supported limits</dfn> object has a value for every limit defined by WebGPU:
 
-<table class="data no-colspan-center" dfn-type=attribute dfn-for="supported limits">
+<table class=data dfn-type=attribute dfn-for="supported limits">
     <thead>
         <tr><th>Limit name <th>Type <th>[=Limit class=] <th>[=limit/Default=]
     </thead>
@@ -15908,17 +15911,17 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <tr>
             <th rowspan=2>Format
             <th rowspan=2>{{GPUTextureSampleType}}
-            <th rowspan=2><span class=vertical>{{GPUTextureUsage/RENDER_ATTACHMENT}}</span>
-            <th rowspan=2><span class=vertical>[=blendable=]</span>
-            <th rowspan=2><span class=vertical>multisampling</span>
-            <th rowspan=2><span class=vertical>resolve</span>
+            <th rowspan=2 class=vertical><span>{{GPUTextureUsage/RENDER_ATTACHMENT}}</span>
+            <th rowspan=2 class=vertical><span>[=blendable=]</span>
+            <th rowspan=2 class=vertical><span>multisampling</span>
+            <th rowspan=2 class=vertical><span>resolve</span>
             <th colspan=3>{{GPUTextureUsage/STORAGE_BINDING}}
             <th rowspan=2>[=Texel block copy footprint=] (Bytes)
             <th rowspan=2>[=Render target pixel byte cost=] (Bytes)
         <tr>
-            <th><span class=vertical>{{GPUStorageTextureAccess/"write-only"}}</span>
-            <th><span class=vertical>{{GPUStorageTextureAccess/"read-only"}}</span>
-            <th><span class=vertical>{{GPUStorageTextureAccess/"read-write"}}</span>
+            <th class=vertical><span>{{GPUStorageTextureAccess/"write-only"}}</span>
+            <th class=vertical><span>{{GPUStorageTextureAccess/"read-only"}}</span>
+            <th class=vertical><span>{{GPUStorageTextureAccess/"read-write"}}</span>
     </thead>
     <tr><th colspan=11>8 bits per component (1-byte [=render target component alignment=])
     <tr>


### PR DESCRIPTION
Additionally, some small table formatting tweaks:

- Top-align vertical table headers
- Use .row-continuation to determine whether to un-center colspan cells