### PR TITLE
Require `module` to be "valid to use with" `device`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7279,18 +7279,19 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
 </div>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>validating GPUProgrammableStage</dfn>(|stage|, |descriptor|, |layout|)
+    <dfn abstract-op>validating GPUProgrammableStage</dfn>(|stage|, |descriptor|, |layout|, |device|)
 
     **Arguments:**
 
     - {{GPUShaderStage}} |stage|
     - {{GPUProgrammableStage}} |descriptor|
     - {{GPUPipelineLayout}} |layout|
+    - {{GPUDevice}} |device|
 
     All of the requirements in the following steps |must| be met.
     If any are unmet, return `false`; otherwise, return `true`.
 
-    1. |descriptor|.{{GPUProgrammableStage/module}} |must| be [$valid$].
+    1. |descriptor|.{{GPUProgrammableStage/module}} |must| be [$valid to use with$] |device|.
     1. Let |entryPoint| be [$get the entry point$](|stage|, |descriptor|).
     1. |entryPoint| |must| not be `null`.
     1. For each |binding| that is [=statically used=] by |entryPoint|:
@@ -7572,7 +7573,7 @@ dictionary GPUComputePipelineDescriptor
                     <div class=validusage>
                         1. |layout| |must| be [$valid to use with$] |this|.
                         1. [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
-                            |descriptor|.{{GPUComputePipelineDescriptor/compute}}, |layout|) |must| succeed.
+                            |descriptor|.{{GPUComputePipelineDescriptor/compute}}, |layout|, |this|) |must| succeed.
                         1. Let |entryPoint| be [$get the entry point$]({{GPUShaderStage/COMPUTE}}, |descriptor|.{{GPUComputePipelineDescriptor/compute}}).
 
                             [=Assert=] |entryPoint| is not `null`.
@@ -8280,7 +8281,7 @@ dictionary GPUFragmentState
     1. Return `true` if all of the following requirements are met:
 
         <div class=validusage>
-            - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}}, |descriptor|, |layout|) succeeds.
+            - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}}, |descriptor|, |layout|, |device|) succeeds.
             - |descriptor|.{{GPUFragmentState/targets}}.length must be &le;
                 |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
             - Let |entryPoint| be [$get the entry point$]({{GPUShaderStage/FRAGMENT}}, |descriptor|).
@@ -9364,7 +9365,7 @@ dictionary GPUVertexAttribute {
     1. Return `true`, if and only if, all of the following conditions are satisfied:
 
         <div class=validusage>
-            - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}}, |descriptor|, |layout|) succeeds.
+            - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}}, |descriptor|, |layout|, |device|) succeeds.
             - |descriptor|.{{GPUVertexState/buffers}}.length is &le;
                 |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
             - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}


### PR DESCRIPTION
The CTS already checks this https://github.com/gpuweb/cts/blob/fb57fd8509dcf1a5acbaa4cf3c6ac8a02547cd34/src/webgpu/api/validation/compute_pipeline.spec.ts#L91