### PR TITLE
Add `texture-compression-bc-sliced-3d`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2254,10 +2254,12 @@ handling should allow it to recover.
 Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the following guarantees:
 
 - At least one of the following must be true:
-- At least one of the following must be true:
     - {{GPUFeatureName/"texture-compression-bc"}} is supported.
     - Both {{GPUFeatureName/"texture-compression-etc2"}} and
         {{GPUFeatureName/"texture-compression-astc"}} are supported.
+- If either {{GPUFeatureName/"texture-compression-bc"}} or
+    {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
+    is supported, both must be supported.
 - All supported limits must be either the [=limit/default=] value or [=limit/better=].
 - All [=limit class/alignment|alignment-class=] limits must be powers of 2.
 - {{supported limits/maxBindingsPerBindGroup}} must be must be &ge;
@@ -15844,15 +15846,11 @@ This feature adds the following [=optional API surfaces=]:
 
 Allows the {{GPUTextureDimension/3d}} dimension for textures with BC compressed formats.
 
-Note:
-This feature does not enable the BC formats, so in order to take advantage of it,
-enable the {{GPUFeatureName/"texture-compression-bc"}} feature as well.
-
 Note: Adapters which support either {{GPUFeatureName/"texture-compression-bc"}}
 or {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
 always support both, even though they are separate features.
 To use {{GPUFeatureName/"texture-compression-bc-sliced-3d"}},
-both must be enabled explicitly.
+both must be enabled explicitly as this feature does not enable the BC formats.
 
 This feature adds no [=optional API surfaces=].
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15815,8 +15815,10 @@ This feature adds the following [=optional API surfaces=]:
 
 Allows for explicit creation of textures of BC compressed formats. Only supports 2D textures.
 
-Note: This feature implies the availability of
-the {{GPUFeatureName/"texture-compression-bc-sliced-3d"}} feature.
+Note: Adapters which support either {{GPUFeatureName/"texture-compression-bc"}}
+or {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
+always support both, even though they are separate features.
+They still must be enabled separately.
 
 This feature adds the following [=optional API surfaces=]:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15986,7 +15986,9 @@ This feature adds the following [=optional API surfaces=]:
 
 Allows the {{GPUTextureDimension/3d}} dimension for textures with BC compressed formats.
 
-This feature requires the {{GPUFeatureName/"texture-compression-bc"}} feature to be enabled.
+Note:
+This feature does not enable the BC formats, so in order to take advantage of it,
+enable the {{GPUFeatureName/"texture-compression-bc"}} feature as well.
 
 Note: Adapters which support either {{GPUFeatureName/"texture-compression-bc"}}
 or {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2254,8 +2254,8 @@ handling should allow it to recover.
 Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the following guarantees:
 
 - At least one of the following must be true:
-    - Both {{GPUFeatureName/"texture-compression-bc"}} and
-        {{GPUFeatureName/"texture-compression-bc-sliced-3d"}} are supported.
+- At least one of the following must be true:
+    - {{GPUFeatureName/"texture-compression-bc"}} is supported.
     - Both {{GPUFeatureName/"texture-compression-etc2"}} and
         {{GPUFeatureName/"texture-compression-astc"}} are supported.
 - All supported limits must be either the [=limit/default=] value or [=limit/better=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15818,7 +15818,7 @@ Allows for explicit creation of textures of BC compressed formats. Only supports
 Note: Adapters which support either {{GPUFeatureName/"texture-compression-bc"}}
 or {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
 always support both, even though they are separate features.
-They still must be enabled separately.
+To use {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}, enable it separately.
 
 This feature adds the following [=optional API surfaces=]:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2675,6 +2675,7 @@ enum GPUFeatureName {
     "depth-clip-control",
     "depth32float-stencil8",
     "texture-compression-bc",
+    "texture-compression-bc-sliced-3d",
     "texture-compression-etc2",
     "texture-compression-astc",
     "timestamp-query",
@@ -2685,7 +2686,6 @@ enum GPUFeatureName {
     "float32-filterable",
     "clip-distances",
     "dual-source-blending",
-    "texture-compression-bc-sliced-3d",
 };
 </script>
 
@@ -15838,6 +15838,24 @@ This feature adds the following [=optional API surfaces=]:
     - {{GPUTextureFormat/"bc7-rgba-unorm"}}
     - {{GPUTextureFormat/"bc7-rgba-unorm-srgb"}}
 
+<h3 id=texture-compression-bc-sliced-3d data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-bc-sliced-3d"`
+<span id=dom-gpufeaturename-texture-compression-bc-sliced-3d></span>
+</h3>
+
+Allows the {{GPUTextureDimension/3d}} dimension for textures with BC compressed formats.
+
+Note:
+This feature does not enable the BC formats, so in order to take advantage of it,
+enable the {{GPUFeatureName/"texture-compression-bc"}} feature as well.
+
+Note: Adapters which support either {{GPUFeatureName/"texture-compression-bc"}}
+or {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
+always support both, even though they are separate features.
+To use {{GPUFeatureName/"texture-compression-bc-sliced-3d"}},
+both must be enabled explicitly.
+
+This feature adds no [=optional API surfaces=].
+
 <h3 id=texture-compression-etc2 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-etc2"`
 <span id=texture-compression-etc></span>
 <span id=dom-gpufeaturename-texture-compression-etc2></span>
@@ -15979,24 +15997,6 @@ This feature adds the following [=optional API surfaces=]:
 
 - New WGSL extensions:
     - [=extension/dual_source_blending=]
-
-<h3 id=texture-compression-bc-sliced-3d data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-bc-sliced-3d"`
-<span id=dom-gpufeaturename-texture-compression-bc-sliced-3d></span>
-</h3>
-
-Allows the {{GPUTextureDimension/3d}} dimension for textures with BC compressed formats.
-
-Note:
-This feature does not enable the BC formats, so in order to take advantage of it,
-enable the {{GPUFeatureName/"texture-compression-bc"}} feature as well.
-
-Note: Adapters which support either {{GPUFeatureName/"texture-compression-bc"}}
-or {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
-always support both, even though they are separate features.
-To use {{GPUFeatureName/"texture-compression-bc-sliced-3d"}},
-both must be enabled explicitly.
-
-This feature adds no [=optional API surfaces=].
 
 # Appendices # {#appendices}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2684,6 +2684,7 @@ enum GPUFeatureName {
     "float32-filterable",
     "clip-distances",
     "dual-source-blending",
+    "texture-compression-bc-sliced-3d",
 };
 </script>
 
@@ -15811,7 +15812,7 @@ This feature adds the following [=optional API surfaces=]:
 <span id=dom-gpufeaturename-texture-compression-bc></span>
 </h3>
 
-Allows for explicit creation of textures of BC compressed formats. Supports both 2D and 3D textures.
+Allows for explicit creation of textures of BC compressed formats. Only supports 2D textures.
 
 This feature adds the following [=optional API surfaces=]:
 
@@ -15972,6 +15973,16 @@ This feature adds the following [=optional API surfaces=]:
 
 - New WGSL extensions:
     - [=extension/dual_source_blending=]
+
+<h3 id=texture-compression-bc-sliced-3d data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-bc-sliced-3d"`
+<span id=dom-gpufeaturename-texture-compression-bc-sliced-3d></span>
+</h3>
+
+Allows the {{GPUTextureDimension/3d}} dimension for textures with BC compressed formats.
+
+This feature requires the {{GPUFeatureName/"texture-compression-bc"}} feature to be enabled.
+
+This feature adds no [=optional API surfaces=].
 
 # Appendices # {#appendices}
 
@@ -16610,7 +16621,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td rowspan=2>8
         <td rowspan=14>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td rowspan=14>4 &times; 4
-        <td rowspan=14>&check;
+        <td rowspan=14>If {{GPUFeatureName/"texture-compression-bc-sliced-3d"}} is enabled
         <td rowspan=14>{{GPUFeatureName/texture-compression-bc}}
     <tr>
         <td>{{GPUTextureFormat/bc1-rgba-unorm-srgb}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2254,7 +2254,8 @@ handling should allow it to recover.
 Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the following guarantees:
 
 - At least one of the following must be true:
-    - {{GPUFeatureName/"texture-compression-bc"}} is supported.
+    - Both {{GPUFeatureName/"texture-compression-bc"}} and
+        {{GPUFeatureName/"texture-compression-bc-sliced-3d"}} are supported.
     - Both {{GPUFeatureName/"texture-compression-etc2"}} and
         {{GPUFeatureName/"texture-compression-astc"}} are supported.
 - All supported limits must be either the [=limit/default=] value or [=limit/better=].
@@ -15814,6 +15815,9 @@ This feature adds the following [=optional API surfaces=]:
 
 Allows for explicit creation of textures of BC compressed formats. Only supports 2D textures.
 
+Note: This feature implies the availability of
+the {{GPUFeatureName/"texture-compression-bc-sliced-3d"}} feature.
+
 This feature adds the following [=optional API surfaces=]:
 
 - New {{GPUTextureFormat}} enum values:
@@ -15981,6 +15985,9 @@ This feature adds the following [=optional API surfaces=]:
 Allows the {{GPUTextureDimension/3d}} dimension for textures with BC compressed formats.
 
 This feature requires the {{GPUFeatureName/"texture-compression-bc"}} feature to be enabled.
+
+Note: This feature is always available in conjunction with
+the {{GPUFeatureName/"texture-compression-bc"}} feature.
 
 This feature adds no [=optional API surfaces=].
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15991,7 +15991,8 @@ This feature requires the {{GPUFeatureName/"texture-compression-bc"}} feature to
 Note: Adapters which support either {{GPUFeatureName/"texture-compression-bc"}}
 or {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
 always support both, even though they are separate features.
-They still must be enabled separately.
+To use {{GPUFeatureName/"texture-compression-bc-sliced-3d"}},
+both must be enabled explicitly.
 
 This feature adds no [=optional API surfaces=].
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15986,8 +15986,10 @@ Allows the {{GPUTextureDimension/3d}} dimension for textures with BC compressed 
 
 This feature requires the {{GPUFeatureName/"texture-compression-bc"}} feature to be enabled.
 
-Note: This feature is always available in conjunction with
-the {{GPUFeatureName/"texture-compression-bc"}} feature.
+Note: Adapters which support either {{GPUFeatureName/"texture-compression-bc"}}
+or {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
+always support both, even though they are separate features.
+They still must be enabled separately.
 
 This feature adds no [=optional API surfaces=].
 


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/issues/4705

This PR makes base BCn extension 2D only, and requires the bc-sliced-3d extension to allow 3D dimension for BCn textures as sliced 3D.

This extension requires base bc extension, so I tried to phrase it in a succinct way. Please let me know if that would benefit from any improvement.

TYVM!