### PR TITLE
Clarify stage restrictions for IO attributes

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8482,7 +8482,9 @@ path: syntax/blend_src_attr.syntax.bs.include
     [=attribute/location=] attribute.
     [=shader-creation error|Must=] only be applied to declarations of objects with [=numeric scalar=]
     or [=numeric vector=] type.
-    [=shader-creation error|Must=] only be used as an output of the [=fragment=] shader stage.
+    [=shader-creation error|Must not=] be included in a [=shader stage input=].
+    [=shader-creation error|Must not=] be included in a [=shader stage output=],
+    except for the [=fragment=] shader stage.
 
   <tr>
     <td>Parameters
@@ -8685,7 +8687,7 @@ path: syntax/location_attr.syntax.bs.include
     return type, or member of a [=structure=] type.
     [=shader-creation error|Must=] only be applied to declarations of objects with [=numeric scalar=]
     or [=numeric vector=] type.
-    [=shader-creation error|Must not=] be used with the [=compute=] shader stage.
+    [=shader-creation error|Must not=] be included in [=compute=] [=shader stage inputs=].
 
   <tr>
     <td>Parameters


### PR DESCRIPTION
Fixes #4748

* Stage restrictions only apply when the attribute is used as an IO attribute
* Rephrased restrictions on blend_src and location to restrict stages specifically related to IO