### PR TITLE
Clarify inherited-from allows flushing

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12185,6 +12185,8 @@ possibilities:
     The given expression is only one valid implementation of the function.
     A WebGPU implementation may implement the operation differently, with better accuracy
     or with greater tolerance for extreme inputs.
+    Additionally, an implementation may treat intermediate results as subject to the rules for
+    floating-point evaluation (e.g. they may be rounded and/or [=flush to zero|flushed-to-zero=]).
 
 When the accuracy for an operation is specified over an input range,
 the accuracy is undefined for input values outside that range.


### PR DESCRIPTION
* Clarify that intermediate results in inherited-from formulae are treated as other floating-point calcuations and can be rounded or flushed-to-zero