### PR TITLE
Move overflow rules for concrete integers

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2677,6 +2677,8 @@ The <dfn noexport>u32</dfn> type is the set of 32-bit unsigned integers.
 The <dfn noexport>i32</dfn> type is the set of 32-bit signed integers.
 It uses a two's complementation representation, with the sign bit in the most significant bit position.
 
+[[#arithmetic-expr|Expressions]] on [=type/concrete=] integer types that overflow produce a result that is modulo 2<sup><i>bitwidth</i></sup>
+
 <table class='data'>
   <caption>Extreme values for integer types</caption>
   <thead>
@@ -5955,19 +5957,16 @@ See [[#sync-builtin-functions]].
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `+` |e2| : |T|
     <td>Addition. [=Component-wise=] when |T| is a vector.
-    If |T| is a [=type/concrete=] [=integer scalar=] type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="subtraction">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `-` |e2| : |T|
     <td>Subtraction [=Component-wise=] when |T| is a vector.
-    If |T| is a [=type/concrete=] [=integer scalar=] type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="multiplication">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `*` |e2| : |T|
     <td>Multiplication. [=Component-wise=] when |T| is a vector.
-    If |T| is a [=type/concrete=] [=integer scalar=] type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="division">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]


### PR DESCRIPTION
Fixes #3132

* Pulled the concrete integer overflow descriptions out of arithmetic expressions and moved them in general form into integer types to be consistent with abstract types