### PR TITLE
Add inverse channel transfer function

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4151,8 +4151,10 @@ with the same name.
 Only certain texel formats are used in WGSL source code.
 The channel formats used to define those texel formats are listed in the
 <dfn dfn>Channel Formats</dfn> table.
-The last column specifies the conversion from the stored channel bits to the value used in the shader.
+The second last column specifies the conversion from the stored channel bits to the value used in the shader.
 This is also known as the <dfn noexport>channel transfer function</dfn>, or CTF.
+The last column specifies the conversion from the shader value to the stored channel bits.
+This is also known as the <dfn noexport>inverse channel transfer function</dfn>, or ICTF.
 
 Note: The channel transfer function for 8unorm maps {0,...,255} to the floating point interval [0.0, 1.0].
 
@@ -4164,19 +4166,20 @@ Note: The channel transfer function for 8snorm maps {-128,...,127} to the floati
     <tr><th>Channel format
         <th>Number of stored bits
         <th>Interpretation of stored bits
-        <th>Shader type<td style="width:25%">Shader value
-(Channel Transfer Function)
+        <th>Shader type
+        <th style="width:15%">Shader value (Channel Transfer Function)
+        <th style="width:30%">Write value `T` (Inverse Channel Transfer Function)
   </thead>
-  <tr><td>8unorm<td>8<td>unsigned integer |v| &isinv; {0,...,255}<td>f32<td> |v| &div; 255
-  <tr><td>8snorm<td>8<td>signed integer |v| &isinv; {-128,...,127}<td>f32<td> max(-1, |v| &div; 127)
-  <tr><td>8uint<td>8<td>unsigned integer |v| &isinv; {0,...,255}<td>u32<td> |v|
-  <tr><td>8sint<td>8<td>signed integer |v| &isinv; {-128,...,127}<td>i32<td> |v|
-  <tr><td>16uint<td>16<td>unsigned integer |v| &isinv; {0,...,65535}<td>u32<td> |v|
-  <tr><td>16sint<td>16<td>signed integer |v| &isinv; {-32768,...,32767}<td>i32<td> |v|
-  <tr><td>16float<td>16<td>[[!IEEE-754|IEEE-754]] binary16 16-bit floating point value |v|, with 1 sign bit, 5 exponent bits, 10 mantissa bits<td>f32<td>|v|
-  <tr><td>32uint<td>32<td>32-bit unsigned integer value |v|<td>u32<td>|v|
-  <tr><td>32sint<td>32<td>32-bit signed integer value |v|<td>i32<td>|v|
-  <tr><td>32float<td>32<td>[[!IEEE-754|IEEE-754]] binary32 32-bit floating point value |v|<td>f32<td>|v|
+  <tr><td>8unorm<td>8<td>unsigned integer |v| &isinv; {0,...,255}<td>f32<td> |v| &div; 255<td> max(0, min(1, `T`))
+  <tr><td>8snorm<td>8<td>signed integer |v| &isinv; {-128,...,127}<td>f32<td> |v| &div; 127<td> max(-1, min(1, `T`))
+  <tr><td>8uint<td>8<td>unsigned integer |v| &isinv; {0,...,255}<td>u32<td> |v|<td> min(255, `T`)
+  <tr><td>8sint<td>8<td>signed integer |v| &isinv; {-128,...,127}<td>i32<td> |v|<td> max(-128, min(127, `T`))
+  <tr><td>16uint<td>16<td>unsigned integer |v| &isinv; {0,...,65535}<td>u32<td> |v|<td> min(65535, `T`)
+  <tr><td>16sint<td>16<td>signed integer |v| &isinv; {-32768,...,32767}<td>i32<td> |v|<td> max(-32768, min(32767, `T`))
+  <tr><td>16float<td>16<td>[[!IEEE-754|IEEE-754]] binary16 16-bit floating point value |v|, with 1 sign bit, 5 exponent bits, 10 mantissa bits<td>f32<td>|v|<td>`quantizeToF16(T)`
+  <tr><td>32uint<td>32<td>32-bit unsigned integer value |v|<td>u32<td>|v|<td>`T`
+  <tr><td>32sint<td>32<td>32-bit signed integer value |v|<td>i32<td>|v|<td>`T`
+  <tr><td>32float<td>32<td>[[!IEEE-754|IEEE-754]] binary32 32-bit floating point value |v|<td>f32<td>|v|<td>`T`
 </table>
 
 The texel formats listed in the
@@ -4188,11 +4191,12 @@ in [[#texture-storage]].
 
 When the texel format does not have all four channels, then:
 
-* When reading the texel:
+* When reading the texel, the [=channel transfer function=] is applied [=component-wise=]:
     * If the texel format has no green channel, then the second component of the shader value is 0.
     * If the texel format has no blue channel, then the third component of the shader value is 0.
     * If the texel format has no alpha channel, then the fourth component of the shader value is 1.
-* When writing the texel, shader value components for missing channels are ignored.
+* When writing the texel, the [=inverse channel transfer function=] is applied [=component-wise=]
+    and shader value components for missing channels are ignored.
 
 The last column in the table below uses the format-specific
 [=channel transfer function=] from the [=channel formats=] table.
@@ -17425,7 +17429,8 @@ Writes a single texel to a texture.
   <tr><td>`array_index`<td>
   The 0-based texture array index.
   <tr><td>`value`<td>
-  The new texel value.<br>
+  The new texel value.
+  `value` is converted using the [=inverse channel transfer function=].
 </table>
 
 **Note:**


### PR DESCRIPTION
* Define the inverse channel transfer functions and use it in textureStore
* This clarifies that shader values are clamped