### PR TITLE
Clarify textureSampleBias bias param

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -16751,7 +16751,6 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
   The 0-based texture array index to sample.
   <tr><td>`bias`<td>
   The bias to apply to the mip level before sampling.
-  `bias` [=shader-creation error|must=] be between `-16.0` and `15.99`.
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
@@ -16765,7 +16764,8 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
 
 The sampled value.
 
-An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
+An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=]
+or `bias` is outside the range [`-16.0`, `15.99`].
 
 ### `textureSampleCompare` ### {#texturesamplecompare}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -16750,7 +16750,8 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
   <tr><td>`array_index`<td>
   The 0-based texture array index to sample.
   <tr><td>`bias`<td>
-  The bias to apply to the mip level before sampling.
+  The bias to apply to the mip level before sampling.<br>
+  This value [=behavioral requirement|will=] be clamped in the range `[-16.0, 15.99]`.
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
@@ -16763,9 +16764,6 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
 **Returns:**
 
 The sampled value.
-
-An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=]
-or `bias` is outside the range [`-16.0`, `15.99`].
 
 ### `textureSampleCompare` ### {#texturesamplecompare}
 


### PR DESCRIPTION
* Range restriction is not a shader-creation error
* Instead an indeterminate value results if bias is out of range