### PR TITLE
`mix` inherits accuracy from either `x * (1.0 - z) + y * z` or `x + (y - x) * z`.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12305,7 +12305,7 @@ the rules in [[#floating-point-overflow]] apply.
   <p>If both `x` and `y` are denormalized, the result may be either input.
   <tr><td>`min(x, y)`<td colspan=2 style="text-align:left;">Correctly rounded.
   <p>If both `x` and `y` are denormalized, the result may be either input.
-  <tr><td>`mix(x, y, z)`<td colspan=2 style="text-align:left;">Inherited from `x * (1.0 - z) + y * z`
+  <tr><td>`mix(x, y, z)`<td colspan=2 style="text-align:left;">Inherited from either `x * (1.0 - z) + y * z` or `x + (y - x) * z`.
   <tr><td>`modf(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`normalize(x)`<td colspan=2 style="text-align:left;">Inherited from `x / length(x)`
 


### PR DESCRIPTION
Fixes #3260.