### PR TITLE
Note that leading zeros are forbidden because no octals.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1072,6 +1072,9 @@ An <dfn>integer literal</dfn> is:
     * `0x` or `0X` followed by a sequence of hexadecimal digits.
 * Then an optional `i` or `u` suffix.
 
+Note: A leading zero on a non-zero number literal (e.g. 012) is forbidden,
+so as to avoid confusion with other languages' leading-zero-means-octal notation.
+
 <pre class=include>
 path: syntax/int_literal.syntax.bs.include
 </pre>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1072,7 +1072,7 @@ An <dfn>integer literal</dfn> is:
     * `0x` or `0X` followed by a sequence of hexadecimal digits.
 * Then an optional `i` or `u` suffix.
 
-Note: A leading zero on a non-zero number literal (e.g. 012) is forbidden,
+Note: A leading zero on a non-zero integer literal (e.g. 012) is forbidden,
 so as to avoid confusion with other languages' leading-zero-means-octal notation.
 
 <pre class=include>


### PR DESCRIPTION
Fixes #2075.