### PR TITLE
Add note that enabling features can have performance impact

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1353,6 +1353,11 @@ For privacy considerations, see [[#privacy-machine-limits]].
 A <dfn dfn>feature</dfn> is a set of optional WebGPU functionality that is not supported
 on all implementations, typically due to hardware or system software constraints.
 
+Note:
+Enabling features may not necessarily be desirable, as doing so may have a performance impact.
+Because of this, and to improve portability across devices and implementations,
+applications should generally only request features that they may actually require.
+
 Functionality that is part of a feature may only be used if the feature was requested at device
 creation (in {{GPUDeviceDescriptor/requiredFeatures}}).
 Otherwise, using existing API surfaces in a new way **typically** results in a [$validation error$],
@@ -1375,6 +1380,11 @@ See the [[#feature-index|Feature Index]] for a description of the functionality 
 ### Limits ### {#limits}
 
 Each <dfn dfn>limit</dfn> is a numeric limit on the usage of WebGPU on a device.
+
+Note:
+Setting "better" limits may not necessarily be desirable, as doing so may have a performance impact.
+Because of this, and to improve portability across devices and implementations, applications should
+generally only request better limits if they may actually require them.
 
 Each limit has a <dfn dfn for=limit>default</dfn> value.
 Every [=adapter=] is guaranteed to support the default value or [=limit/better=].
@@ -1407,12 +1417,6 @@ Different limits have different <dfn dfn lt="limit class">limit classes</dfn>:
         Values which are not powers of 2 are invalid.
         Higher powers of 2 are clamped to the [=limit/default=].
 </dl>
-
-Note:
-Setting "better" limits may not necessarily be desirable, as they may have a performance impact.
-Because of this, and to improve portability across devices and implementations,
-applications should generally request the "worst" limits that work for their content
-(ideally, the default values).
 
 A <dfn dfn>supported limits</dfn> object has a value for every limit defined by WebGPU:
 


### PR DESCRIPTION
We had this note feature for limits, but not features.

The particular thing that inspired this note is the fact that Metal requires setting a render pass flag to use indirect command buffers: https://developer.apple.com/documentation/metal/mtlrenderpipelinestate/2966639-supportindirectcommandbuffers?language=objc