### PR TITLE
[push-constants] remove per-stage immediates open question

### DIFF
--- a/proposals/push-constants.md
+++ b/proposals/push-constants.md
@@ -116,9 +116,6 @@ NOTE: dataOffset: Offset in into data to begin writing from. Given in elements i
 
 # Open Questions:
 
-- Should immediates be defined per-stage?
-  - wgpu currently has per-stage immediates (@teoxoy?) and we weren't sure if that is a feasible alternative.
-
 - Should pipelineLayout defines immediate range compatible?
   - Implementation internal immediate data usage could easily break compatibility. Implementation needs extra
     effort to ensure such compatibility.


### PR DESCRIPTION
I checked our implementation and we pass the stage property to Vulkan's `VkPipelineLayoutCreateInfo.pPushConstantRanges` & `vkCmdPushConstants`.

I thought you could create 2 ranges (one for the vertex and one for the fragment stage) that you could then populate individually but the following VUID prevents that.

> VUID-vkCmdPushConstants-offset-01796
> For each byte in the range specified by offset and size and for each push constant range that overlaps that byte, stageFlags must include all stages in that push constant range’s VkPushConstantRange::stageFlags