### PR TITLE
Allow unknown limits to be requested with value `undefined`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1329,7 +1329,7 @@ A [=device=] also has the following [=content timeline property=]:
         |descriptor|.{{GPUDeviceDescriptor/requiredFeatures}}.
     1. Let |limits| be a [=supported limits=] object with all values set to their defaults.
     1. For each (|key|, |value|) pair in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}:
-        1. If |value| is [=limit/better=] than |limits|[|key|]:
+        1. If |value| is not `undefined` and |value| is [=limit/better=] than |limits|[|key|]:
             1. Set |limits|[|key|] to |value|.
     1. Let |device| be a [=device=] object.
     1. Set |device|.{{device/[[adapter]]}} to |adapter|.
@@ -2573,7 +2573,8 @@ interface GPUAdapter {
 
                     <div class=validusage>
                         1. |adapter|.{{adapter/[[state]]}} must not be {{adapter/[[state]]/"consumed"}}.
-                        1. For each [|key|, |value|] in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}:
+                        1. For each [|key|, |value|] in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}
+                            for which |value| is not `undefined`:
                             1. |key| |must| be the name of a member of [=supported limits=].
                             1. |value| |must| be no [=limit/better=] than |adapter|.{{adapter/[[limits]]}}[|key|].
                             1. If |key|'s [=limit class|class=] is [=limit class/alignment=],
@@ -2646,7 +2647,7 @@ interface GPUAdapter {
 dictionary GPUDeviceDescriptor
          : GPUObjectDescriptorBase {
     sequence<GPUFeatureName> requiredFeatures = [];
-    record<DOMString, GPUSize64> requiredLimits = {};
+    record<DOMString, (GPUSize64 or undefined)> requiredLimits = {};
     GPUQueueDescriptor defaultQueue = {};
 };
 </script>
@@ -2667,7 +2668,7 @@ dictionary GPUDeviceDescriptor
         Specifies the [=limits=] that are required by the device request.
         The request will fail if the adapter cannot provide these limits.
 
-        Each key must be the name of a member of [=supported limits=].
+        Each key with a non-`undefined` value must be the name of a member of [=supported limits=].
 
         API calls on the resulting device perform validation according to the exact limits of the
         device (not the adapter; see [[#limits]]).

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2579,6 +2579,10 @@ interface GPUAdapter {
                             1. |value| |must| be no [=limit/better=] than |adapter|.{{adapter/[[limits]]}}[|key|].
                             1. If |key|'s [=limit class|class=] is [=limit class/alignment=],
                                 |value| |must| be a power of 2 less than 2<sup>32</sup>.
+
+                            Note:
+                            User agents should consider issuing developer-visible warnings when
+                            |key| is not recognized, even when |value| is `undefined`.
                     </div>
 
                     If any are unmet, issue the following steps on <var data-timeline=content>contentTimeline</var>


### PR DESCRIPTION
**Proposal.**

This is useful for application code like this:

`{ requiredLimits: { someLimit: adapter.limits.someLimit } }`

when `adapter.limits.someLimit` is `undefined` due to situations such as:

- A limit was removed (#4688/#4783)
- A limit exists in one browser, but another browser doesn't know about it
  (though it provides very limited protection against this)
- Possibly, depending on future designs:
  a limit is part of a feature, and the feature isn't available (#4613)