### PR TITLE
Change mapAsync to reject with AbortError on device loss

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3542,6 +3542,9 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                     1. [=Reject=] |p| with an {{AbortError}}.
 
+                        Note: This is the same error type produced by cancelling the map using
+                        {{GPUBuffer/unmap()}}.
+
                     Otherwise:
 
                     1. [=Reject=] |p| with an {{OperationError}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3483,7 +3483,9 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. If |this|.{{GPUObjectBase/[[device]]}} is [$invalid|lost$]:
+                1. Set |deviceLost| to `true` if |this|.{{GPUObjectBase/[[device]]}} is [$invalid|lost$],
+                    and `false` otherwise.
+                1. If |deviceLost|:
 
                     1. Issue the <var data-timeline=content>map failure steps</var> on
                         <var data-timeline=content>contentTimeline</var>.
@@ -3535,8 +3537,14 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                     1. [=Assert=] |p| is already rejected.
                     1. Return.
                 1. [=Assert=] |p| is still pending.
-                1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`,
-                    and [=reject=] |p| with an {{OperationError}}.
+                1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`.
+                1. If |deviceLost|:
+
+                    1. [=Reject=] |p| with an {{AbortError}}.
+
+                    Otherwise:
+
+                    1. [=Reject=] |p| with an {{OperationError}}.
             </div>
         </div>
 


### PR DESCRIPTION
Fixes #4774

This can't be tested without #4177 but adding `needs-cts-issue` anyway.