### PR TITLE
Generate a validation error on mapAsync early-reject

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3424,12 +3424,20 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                 1. Let <var data-timeline=content>contentTimeline</var> be the current [=Content timeline=].
                 1. If |this|.{{GPUBuffer/[[pending_map]]}} is not `null`:
+                    1. Issue the |early-reject steps| on the [=Device timeline=] of
+                        |this|.{{GPUObjectBase/[[device]]}}.
                     1. Return [=a promise rejected with=] {{OperationError}}.
                 1. Let |p| be a new {{Promise}}.
                 1. Set |this|.{{GPUBuffer/[[pending_map]]}} to |p|.
                 1. Issue the |validation steps| on the [=Device timeline=] of
                     |this|.{{GPUObjectBase/[[device]]}}.
                 1. Return |p|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |early-reject steps|:
+
+                1. [$Generate a validation error$].
+                1. Return.
             </div>
             <div data-timeline=device>
                 [=Device timeline=] |validation steps|:


### PR DESCRIPTION
This is currently a **proposal**.

Fixes #4690