### PR TITLE
Change mapAsync to also early-reject if already mapped

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3521,7 +3521,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 [=Content timeline=] steps:
 
                 1. Let <var data-timeline=content>contentTimeline</var> be the current [=Content timeline=].
-                1. If |this|.{{GPUBuffer/[[pending_map]]}} is not `null`:
+                1. If |this|.{{GPUBuffer/mapState}} is not {{GPUBufferMapState/"unmapped"}}:
                     1. Issue the |early-reject steps| on the [=Device timeline=] of
                         |this|.{{GPUObjectBase/[[device]]}}.
                     1. Return [=a promise rejected with=] {{OperationError}}.


### PR DESCRIPTION
Not just if already _pending_ mapping. This makes the two cases more consistent with their timing which is probably good for application robustness.

~**PR is dependent on #4786.**~ Rebased!

~This is currently a **proposal**.~ Approved!

Related to #4690.
