### PR TITLE
Disable async operations after device destruction starts

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1246,6 +1246,8 @@ both an instance of compute/rendering functionality on the
 platform underlying a browser, and an instance of a browser's implementation of
 WebGPU on top of that functionality.
 
+[=Adapters=] are exposed via {{GPUAdapter}}.
+
 [=Adapters=] do not uniquely represent underlying implementations:
 calling {{GPU/requestAdapter()}} multiple times returns a different [=adapter=]
 object each time.
@@ -1299,8 +1301,6 @@ improved privacy. It is not required that a [=fallback adapter=] is available on
         </dl>
 </dl>
 
-[=Adapters=] are exposed via {{GPUAdapter}}.
-
 <div algorithm data-timeline=device>
     To <dfn abstract-op lt='expire|Expire|expires'>expire</dfn> a {{GPUAdapter}} |adapter|, run the
     following [=device timeline=] steps:
@@ -1317,6 +1317,8 @@ through which [=internal objects=] are created.
 <!-- POSTV1(multithreading) tentative text:
 It can be shared across multiple [=agents=] (e.g. dedicated workers).
 -->
+
+[=Devices=] are exposed via {{GPUDevice}}.
 
 A [=device=] is the exclusive owner of all [=internal objects=] created from it:
 when the [=device=] becomes [$invalid$]
@@ -1418,7 +1420,16 @@ no validation errors are raised, most promises resolve normally, etc.
     See [[#errors-and-debugging]].
 </div>
 
-[=Devices=] are exposed via {{GPUDevice}}.
+<div algorithm data-timeline=device>
+    To <dfn abstract-op lt="Listen for timeline event">listen for timeline event</dfn>
+    |event| on [=device=] |device|, handled by |steps| on timeline |timeline|:
+
+    - If or when the [=device timeline=] has been informed of the completion of |event|, or
+    - If |device|.{{device/[[destroy started]]}} is already `true`, or
+    - If |device| is [$invalid|lost$] already, or when it [=becomes lost=]:
+
+    Then issue |steps| on |timeline|.
+</div>
 
 ## Optional Capabilities ## {#optional-capabilities}
 
@@ -2896,13 +2907,11 @@ to.
                 1. Once:
                     - All <span data-timeline=queue>currently-enqueued operations on any queue on this device</span> have completed, and
                     - Any [=device timeline=] steps that were listening for completion of
-                        queue operations have completed,
+                        queue operations have completed
+                        ([=asserting=] that no new listeners were added after {{device/[[destroy started]]}} was set):
 
-                    issue the subsequent steps on the
+                    Then issue the subsequent steps on the
                     <span data-timeline=device>current timeline</span>.
-
-                    Note: No new listeners [=assert|will=] be added after {{device/[[destroy started]]}}
-                    has been set to `true`, so this only waits for listeners created before this point.
             </div>
             <div data-timeline=device>
                 1. [=Lose the device=](|this|.{{GPUObjectBase/[[device]]}},
@@ -6893,13 +6902,11 @@ Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
             <div data-timeline=device>
                 [=Device timeline=] |synchronization steps|:
 
-                1.
-                    - If or when the [=device timeline=] has been informed that [=shader module creation=] has
-                        completed for |this| (successfully or unsuccessfully), or
-                    - If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`, or
-                    - If |this|.{{GPUObjectBase/[[device]]}} is lost, or when it [=becomes lost=]:
-
-                    Then issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
+                1. Let |event| occur upon the (successful or unsuccessful) completion of
+                    [=shader module creation=] for |this|.
+                1. [$Listen for timeline event$] |event|
+                    on |this|.{{GPUObjectBase/[[device]]}}, handled by
+                    the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
             <div data-timeline=content>
                 [=Content timeline=] steps:
@@ -7804,14 +7811,11 @@ dictionary GPUComputePipelineDescriptor
                 1. Let |pipeline| be a new {{GPUComputePipeline}} created as if
                     |this|.{{GPUDevice/createComputePipeline()}} was called with |descriptor|,
                     except capturing any errors as |error|, rather than dispatching them to the device.
-
-                1.
-                    - If or when the [=device timeline=] has been informed that [=pipeline creation=] has
-                        completed for |pipeline| (successfully or unsuccessfully), or
-                    - If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`, or
-                    - If |this|.{{GPUObjectBase/[[device]]}} is lost, or when it [=becomes lost=]:
-
-                    Then issue the subsequent steps on the [=device timeline=] of |this|.
+                1. Let |event| occur upon the (successful or unsuccessful) completion of
+                    [=pipeline creation=] for |pipeline|.
+                1. [$Listen for timeline event$] |event|
+                    on |this|.{{GPUObjectBase/[[device]]}}, handled by
+                    the subsequent steps on the [=device timeline=] of |this|.
             </div>
             <div data-timeline=device>
                 [=Device timeline=] steps:
@@ -8083,14 +8087,11 @@ dictionary GPURenderPipelineDescriptor
                 1. Let |pipeline| be a new {{GPURenderPipeline}} created as if
                     |this|.{{GPUDevice/createRenderPipeline()}} was called with |descriptor|,
                     except capturing any errors as |error|, rather than dispatching them to the device.
-
-                1.
-                    - If or when the [=device timeline=] has been informed that [=pipeline creation=] has
-                        completed for |pipeline| (successfully or unsuccessfully), or
-                    - If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`, or
-                    - If |this|.{{GPUObjectBase/[[device]]}} is lost, or when it [=becomes lost=]:
-
-                    Then issue the subsequent steps on the [=device timeline=] of |this|.
+                1. Let |event| occur upon the (successful or unsuccessful) completion of
+                    [=pipeline creation=] for |pipeline|.
+                1. [$Listen for timeline event$] |event|
+                    on |this|.{{GPUObjectBase/[[device]]}}, handled by
+                    the subsequent steps on the [=device timeline=] of |this|.
             </div>
             <div data-timeline=device>
                 [=Device timeline=] steps:
@@ -13542,13 +13543,11 @@ GPUQueue includes GPUObjectBase;
             <div data-timeline=device>
                 [=Device timeline=] |synchronization steps|:
 
-                1.
-                    - If or when the [=device timeline=] has been informed of the completion of
-                        <span data-timeline=queue>all currently-enqueued operations</span>, or
-                    - If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`, or
-                    - If |this|.{{GPUObjectBase/[[device]]}} is lost, or when it [=becomes lost=]:
-
-                    Then issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
+                1. Let |event| occur upon the completion of
+                    <span data-timeline=queue>all currently-enqueued operations</span>.
+                1. [$Listen for timeline event$] |event|
+                    on |this|.{{GPUObjectBase/[[device]]}}, handled by
+                    the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
             <div data-timeline=content>
                 [=Content timeline=] steps:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2799,8 +2799,16 @@ Those not defined here are defined elsewhere in this document.
                 [=Device timeline=] steps:
 
                 1. Set |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} to `true`.
-                1. Once all <span data-timeline=queue>currently-enqueued operations on any queue on this device</span>
-                    are completed, issue the subsequent steps on the <span data-timeline=device>current timeline</span>.
+                1. Once:
+                    - All <span data-timeline=queue>currently-enqueued operations on any queue on this device</span> have completed, and
+                    - Any [=device timeline=] steps that were listening for completion of
+                        queue operations have completed,
+
+                    issue the subsequent steps on the
+                    <span data-timeline=device>current timeline</span>.
+
+                    Note: No new listeners [=assert|will=] be added after {{device/[[destroy started]]}}
+                    has been set to `true`, so this only waits for listeners created before this point.
             </div>
             <div data-timeline=device>
                 1. [=Lose the device=](|this|.{{GPUObjectBase/[[device]]}},

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3606,9 +3606,14 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                     Note: Since the buffer is mapped, its contents cannot change between this step and {{GPUBuffer/unmap()}}.
 
                 1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`:
+                    1. Return.
 
-                    1. Issue the <var data-timeline=content>map failure steps</var> on
-                        <var data-timeline=content>contentTimeline</var>.
+                    Note:
+                    The map promise will already have been aborted, because
+                    {{GPUDevice/destroy()|GPUDevice.destroy()}}
+                    aborts it, so there is no need to do so here.
+                    <!-- POSTV1(multithreading): this will no longer be true; instead,
+                    issue the map failure steps before returning -->
 
                 1. When either of the following events occur (whichever comes first),
                     or if either has already occurred:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6783,13 +6783,11 @@ Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
             <div data-timeline=device>
                 [=Device timeline=] |synchronization steps|:
 
-                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`,
-                    or when either of the following events occur (whichever comes first),
-                    or if either has already occurred:
-
-                    - The [=device timeline=] becomes informed that [=shader module creation=] has
-                        completed for |this| (successfully or unsuccessfully).
-                    - |this|.{{GPUObjectBase/[[device]]}} [=becomes lost=].
+                1.
+                    - If or when the [=device timeline=] has been informed that [=shader module creation=] has
+                        completed for |this| (successfully or unsuccessfully), or
+                    - If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`, or
+                    - If |this|.{{GPUObjectBase/[[device]]}} is lost, or when it [=becomes lost=]:
 
                     Then issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
@@ -7697,13 +7695,11 @@ dictionary GPUComputePipelineDescriptor
                     |this|.{{GPUDevice/createComputePipeline()}} was called with |descriptor|,
                     except capturing any errors as |error|, rather than dispatching them to the device.
 
-                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`,
-                    or when either of the following events occur (whichever comes first),
-                    or if either has already occurred:
-
-                    - The [=device timeline=] becomes informed that [=pipeline creation=] has
-                        completed for |pipeline| (successfully or unsuccessfully).
-                    - |this| [=becomes lost=].
+                1.
+                    - If or when the [=device timeline=] has been informed that [=pipeline creation=] has
+                        completed for |pipeline| (successfully or unsuccessfully), or
+                    - If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`, or
+                    - If |this|.{{GPUObjectBase/[[device]]}} is lost, or when it [=becomes lost=]:
 
                     Then issue the subsequent steps on the [=device timeline=] of |this|.
             </div>
@@ -7978,13 +7974,11 @@ dictionary GPURenderPipelineDescriptor
                     |this|.{{GPUDevice/createRenderPipeline()}} was called with |descriptor|,
                     except capturing any errors as |error|, rather than dispatching them to the device.
 
-                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`,
-                    or when either of the following events occur (whichever comes first),
-                    or if either has already occurred:
-
-                    - The [=device timeline=] becomes informed that [=pipeline creation=] has
-                        completed for |pipeline| (successfully or unsuccessfully).
-                    - |this| [=becomes lost=].
+                1.
+                    - If or when the [=device timeline=] has been informed that [=pipeline creation=] has
+                        completed for |pipeline| (successfully or unsuccessfully), or
+                    - If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`, or
+                    - If |this|.{{GPUObjectBase/[[device]]}} is lost, or when it [=becomes lost=]:
 
                     Then issue the subsequent steps on the [=device timeline=] of |this|.
             </div>
@@ -13415,13 +13409,11 @@ GPUQueue includes GPUObjectBase;
             <div data-timeline=device>
                 [=Device timeline=] |synchronization steps|:
 
-                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`,
-                    or when either of the following events occur (whichever comes first),
-                    or if either has already occurred:
-
-                    - The [=device timeline=] becomes informed of the completion of
-                        <span data-timeline=queue>all currently-enqueued operations</span>.
-                    - |this|.{{GPUObjectBase/[[device]]}} [=becomes lost=].
+                1.
+                    - If or when the [=device timeline=] has been informed of the completion of
+                        <span data-timeline=queue>all currently-enqueued operations</span>, or
+                    - If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`, or
+                    - If |this|.{{GPUObjectBase/[[device]]}} is lost, or when it [=becomes lost=]:
 
                     Then issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1248,7 +1248,7 @@ it and all objects created on it (directly, e.g.
 {{GPUDevice/createTexture()}}, or indirectly, e.g. {{GPUTexture/createView()}}) become
 implicitly [$valid to use with|unusable$].
 
-A [=device=] has the following [=immutable properties=]:
+[=device=] has the following [=immutable properties=]:
 
 <dl dfn-type=attribute dfn-for=device data-timeline=const>
     : <dfn>\[[adapter]]</dfn>, of type [=adapter=], readonly
@@ -1266,12 +1266,26 @@ A [=device=] has the following [=immutable properties=]:
         No [=limit/better=] limits can be used, even if the underlying [=adapter=] can support them.
 </dl>
 
-A [=device=] also has the following [=content timeline property=]:
+[=device=] has the following [=content timeline properties=]:
 
 <dl dfn-type=attribute dfn-for=device data-timeline=content>
     : <dfn>[[content device]]</dfn>, of type {{GPUDevice}}, readonly
     ::
         The [=Content timeline=] {{GPUDevice}} interface which this device is associated with.
+</dl>
+
+[=device=] has the following [=device timeline properties=]:
+
+<dl dfn-type=attribute dfn-for=device data-timeline=device>
+    : <dfn>[[destroy started]]</dfn>, of type `boolean`, initially `false`
+    ::
+        Becomes true when a {{GPUDevice/destroy()}} operation is started,
+        and remains true once it is finished.
+
+        Note:
+        Once destruction starts, ongoing operations can complete and send messages back to the
+        [=content timeline=], but no new operations can start which do so.
+        See also [[#errors-and-debugging]].
 </dl>
 
 <div algorithm data-timeline=device>
@@ -1321,7 +1335,8 @@ no validation errors are raised, most promises resolve normally, etc.
 
     1. Complete any outstanding steps that are waiting until |device| <dfn dfn>becomes lost</dfn>.
 
-    Note: No errors are generated after device loss. See [[#errors-and-debugging]].
+    Note: No errors are generated from a device which is lost or pending destruction.
+    See [[#errors-and-debugging]].
 </div>
 
 [=Devices=] are exposed via {{GPUDevice}}.
@@ -2783,6 +2798,7 @@ Those not defined here are defined elsewhere in this document.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
+                1. Set |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} to `true`.
                 1. Once all <span data-timeline=queue>currently-enqueued operations on any queue on this device</span>
                     are completed, issue the subsequent steps on the <span data-timeline=device>current timeline</span>.
             </div>
@@ -3465,6 +3481,11 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 1. Set |this|.{{GPUBuffer/[[internal state]]}} to "[=GPUBuffer/[[internal state]]/unavailable=]".
 
                     Note: Since the buffer is mapped, its contents cannot change between this step and {{GPUBuffer/unmap()}}.
+
+                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`:
+
+                    1. Issue the <var data-timeline=content>map failure steps</var> on
+                        <var data-timeline=content>contentTimeline</var>.
 
                 1. When either of the following events occur (whichever comes first),
                     or if either has already occurred:
@@ -6754,7 +6775,8 @@ Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
             <div data-timeline=device>
                 [=Device timeline=] |synchronization steps|:
 
-                1. When either of the following events occur (whichever comes first),
+                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`,
+                    or when either of the following events occur (whichever comes first),
                     or if either has already occurred:
 
                     - The [=device timeline=] becomes informed that [=shader module creation=] has
@@ -7667,7 +7689,8 @@ dictionary GPUComputePipelineDescriptor
                     |this|.{{GPUDevice/createComputePipeline()}} was called with |descriptor|,
                     except capturing any errors as |error|, rather than dispatching them to the device.
 
-                1. When either of the following events occur (whichever comes first),
+                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`,
+                    or when either of the following events occur (whichever comes first),
                     or if either has already occurred:
 
                     - The [=device timeline=] becomes informed that [=pipeline creation=] has
@@ -7679,16 +7702,22 @@ dictionary GPUComputePipelineDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. If |this| is [$invalid|lost$] or |pipeline| is [$valid$],
-                    issue the following steps on |contentTimeline|, and return.
+                1. If |pipeline| is [$valid$],
+                    |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`,
+                    or |this| is [$invalid|lost$]:
 
-                    <div data-timeline=content>
-                        [=Content timeline=] steps:
+                    1. Issue the following steps on |contentTimeline|:
 
-                        1. [=Resolve=] |promise| with |pipeline|.
-                    </div>
+                        <div data-timeline=content>
+                            [=Content timeline=] steps:
 
-                    Note: No errors are generated after device loss. See [[#errors-and-debugging]].
+                            1. [=Resolve=] |promise| with |pipeline|.
+                        </div>
+
+                    1. Return.
+
+                    Note: No errors are generated from a device which is lost or pending destruction.
+                    See [[#errors-and-debugging]].
 
                 1. If |pipeline| is [$invalid$] and |error| is an [$internal error$],
                     issue the following steps on |contentTimeline|, and return.
@@ -7941,7 +7970,8 @@ dictionary GPURenderPipelineDescriptor
                     |this|.{{GPUDevice/createRenderPipeline()}} was called with |descriptor|,
                     except capturing any errors as |error|, rather than dispatching them to the device.
 
-                1. When either of the following events occur (whichever comes first),
+                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`,
+                    or when either of the following events occur (whichever comes first),
                     or if either has already occurred:
 
                     - The [=device timeline=] becomes informed that [=pipeline creation=] has
@@ -7953,16 +7983,22 @@ dictionary GPURenderPipelineDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. If |this| is [$invalid|lost$] or |pipeline| is [$valid$],
-                    issue the following steps on |contentTimeline|, and return.
+                1. If |pipeline| is [$valid$],
+                    |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`,
+                    or |this| is [$invalid|lost$]:
 
-                    <div data-timeline=content>
-                        [=Content timeline=] steps:
+                    1. Issue the following steps on |contentTimeline|:
 
-                        1. [=Resolve=] |promise| with |pipeline|.
-                    </div>
+                        <div data-timeline=content>
+                            [=Content timeline=] steps:
 
-                    Note: No errors are generated after device loss. See [[#errors-and-debugging]].
+                            1. [=Resolve=] |promise| with |pipeline|.
+                        </div>
+
+                    1. Return.
+
+                    Note: No errors are generated from a device which is lost or pending destruction.
+                    See [[#errors-and-debugging]].
 
                 1. If |pipeline| is [$invalid$] and |error| is an [$internal error$],
                     issue the following steps on |contentTimeline|, and return.
@@ -13371,7 +13407,8 @@ GPUQueue includes GPUObjectBase;
             <div data-timeline=device>
                 [=Device timeline=] |synchronization steps|:
 
-                1. When either of the following events occur (whichever comes first),
+                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`,
+                    or when either of the following events occur (whichever comes first),
                     or if either has already occurred:
 
                     - The [=device timeline=] becomes informed of the completion of
@@ -14275,16 +14312,20 @@ is being composited into (e.g. an HTML page rendering, or a 2D canvas).
 
 During the normal course of operation of WebGPU, errors are raised via [$dispatch error$].
 
-After a device is [=lose the device|lost=] (described below), errors are no longer surfaced,
-where possible. ({{GPUBuffer/mapAsync()}} does produce an error, because it is impossible to
-provide the correct mapped data after the device has been lost.)
-
-At this point, implementations do not need to run validation or error tracking:
+After a device is {{device/[[destroy started]]}} or [=lose the device|lost=],
+errors are no longer surfaced, where possible.
+After this point, implementations do not need to run validation or error tracking:
 
 - The validity of objects on the device becomes unobservable.
 - {{GPUDevice/popErrorScope()}} and {{GPUDevice/uncapturederror}} stop reporting errors.
     (No errors are generated by the device loss itself.
     Instead, the {{GPUDevice}}.{{GPUDevice/lost}} promise resolves to indicate the device is lost.)
+- All operations which send a message back to the [=content timeline=] will skip their usual steps.
+    Most will appear to succeed, except for {{GPUBuffer/mapAsync()}}, which produces an error
+    because it is impossible to provide the correct mapped data after the device has been lost.
+
+    This makes it unobservable whether other types of operations (that don't send messages back)
+    actually execute or not.
 
 ## Fatal Errors ## {#fatal-errors}
 
@@ -14333,7 +14374,8 @@ and the {{GPUDevice/uncapturederror}} event.
 Errors must only be generated for operations that explicitly state the conditions one may
 be generated under in their respective algorithms, and the subtype of error that is generated.
 
-No errors are generated after device loss. See [[#errors-and-debugging]].
+No errors are generated from a device which is lost or pending destruction.
+See [[#errors-and-debugging]].
 
 Note: {{GPUError}} may gain new subtypes in future versions of this spec. Applications should handle
 this possibility, using only the error's {{GPUError/message}} when possible, and specializing using
@@ -14520,9 +14562,12 @@ partial interface GPUDevice {
     <div data-timeline=device>
         [=Device timeline=] steps:
 
-        1. If |device| is [$invalid|lost$], return.
+        Note: No errors are generated from a device which is lost or pending destruction.
+        If this algorithm is called while
+        |device|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`
+        or |device| is [$invalid|lost$], it will not be observable to the application.
+        See [[#errors-and-debugging]].
 
-            Note: No errors are generated after device loss. See [[#errors-and-debugging]].
         1. Let |scope| be the [$current error scope$] for |error| and |device|.
         1. If |scope| is not `undefined`:
             1. [=list/Append=] |error| to |scope|.{{GPU error scope/[[errors]]}}.
@@ -14603,17 +14648,22 @@ partial interface GPUDevice {
             <div data-timeline=device>
                 [=Device timeline=] |check steps|:
 
-                1. If |this| is [$invalid|lost$], issue the following steps on
-                    <var data-timeline=content>contentTimeline</var> and return:
+                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} or
+                    |this| is [$invalid|lost$]:
 
-                    <div data-timeline=content>
-                        [=Content timeline=] steps:
+                    1. Issue the following steps on
+                        <var data-timeline=content>contentTimeline</var>:
 
-                        1. [=Resolve=] |promise| with `null`.
-                    </div>
+                        <div data-timeline=content>
+                            [=Content timeline=] steps:
 
-                    Note: No errors are generated after device loss. See [[#errors-and-debugging]].
+                            1. [=Resolve=] |promise| with `null`.
+                        </div>
 
+                    1. Return.
+
+                    Note: No errors are generated from a device which is lost or pending destruction.
+                    See [[#errors-and-debugging]].
                 1. If any of the following requirements are unmet:
 
                     <div class=validusage>


### PR DESCRIPTION
**This should be `copyediting`, but may warrant attention from non-editors.**

Once the device is lost, no async stuff can happen anymore. However we "queue" device destruction so that the device loss doesn't happen instantaneously (async operations already enqueued can finish) (#2599).

The spec didn't actually do this correctly because it couldn't distinguish async operations enqueued before vs after the destroy started. So this PR adds an explicit state for that, and uses it to early-exit the few async operations that are round-trips (the rest of the operations can rely on non-observability).

Issue: #4294 - see there for more discussion.