### PR TITLE
Reject requestDevice() if the adapter has already been used

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1202,7 +1202,7 @@ improved privacy. It is not required that a [=fallback adapter=] is available on
 An [=adapter=] has the following internal slots:
 
 <dl dfn-type=attribute dfn-for=adapter>
-    : <dfn>\[[state]]</dfn>, of type boolean, initially {{adapter/[[state]]/"valid"}}
+    : <dfn>\[[state]]</dfn>, initially {{adapter/[[state]]/"valid"}}
     ::
         <dl dfn-type=enum-value dfn-for="adapter/[[state]]">
             : <dfn>"valid"</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1185,7 +1185,8 @@ calling {{GPU/requestAdapter()}} multiple times returns a different [=adapter=]
 object each time.
 
 Each [=adapter=] object can only be used to create one [=device=]:
-upon a successful {{GPUAdapter/requestDevice()}} call, the adapter [$expires$].
+upon a successful {{GPUAdapter/requestDevice()}} call, the adapter's {{adapter/[[state]]}}
+changes to {{adapter/[[state]]/"consumed"}}.
 Additionally, [=adapter=] objects may [$expire$] at any time.
 
 Note:
@@ -1201,9 +1202,16 @@ improved privacy. It is not required that a [=fallback adapter=] is available on
 An [=adapter=] has the following internal slots:
 
 <dl dfn-type=attribute dfn-for=adapter>
-    : <dfn>\[[expired]]</dfn>, of type boolean, initially `false`
+    : <dfn>\[[state]]</dfn>, of type boolean, initially {{adapter/[[state]]/"valid"}}
     ::
-        If set to `true` indicates that the adapter can no longer be used to create a [=device=].
+        <dl dfn-type=enum-value dfn-for="adapter/[[state]]">
+            : <dfn>"valid"</dfn>
+            :: The adapter can be used to create a device.
+            : <dfn>"consumed"</dfn>
+            :: The adapter has already been used to create a device, and cannot be used again.
+            : <dfn>"expired"</dfn>
+            :: The adapter has expired for some other reason.
+        </dl>
 
     : <dfn>\[[features]]</dfn>, of type [=ordered set=]&lt;{{GPUFeatureName}}&gt;, readonly
     ::
@@ -1224,15 +1232,11 @@ An [=adapter=] has the following internal slots:
 [=Adapters=] are exposed via {{GPUAdapter}}.
 
 <div algorithm data-timeline=device>
-    A given {{GPUAdapter}} |adapter| is <dfn abstract-op>expired</dfn> if
-    |adapter|.{{GPUAdapter/[[adapter]]}}.{{adapter/[[expired]]}} is `true`.
-</div>
-
-<div algorithm data-timeline=device>
     To <dfn abstract-op lt='expire|Expire|expires'>expire</dfn> a {{GPUAdapter}} |adapter|, run the
     following [=device timeline=] steps:
 
-    1. Set |adapter|.{{GPUAdapter/[[adapter]]}}.{{adapter/[[expired]]}} to `true`
+    1. Set |adapter|.{{GPUAdapter/[[adapter]]}}.{{adapter/[[state]]}} to
+        {{adapter/[[state]]/"expired"}}.
 </div>
 
 ### Devices ### {#devices}
@@ -2463,7 +2467,7 @@ interface GPUAdapter {
         Requests a [=device=] from the [=adapter=].
 
         This is a one-time action: if a device is returned successfully,
-        the adapter [$expires$].
+        the adapter becomes {{adapter/[[state]]/"consumed"}}.
 
         <div algorithm=GPUAdapter.requestDevice>
             <div data-timeline=content>
@@ -2512,9 +2516,9 @@ interface GPUAdapter {
                 1. If any of the following requirements are unmet:
 
                     <div class=validusage>
+                        - |adapter|.{{adapter/[[state]]}} must not be {{adapter/[[state]]/"consumed"}}.
                         - Each key in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}
                             must be the name of a member of [=supported limits=].
-
                         - For each limit name |key| in the keys of [=supported limits=]:
                             Let |value| be |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}[|key|].
                             - |value| must be no [=limit/better=] than the value of that limit in
@@ -2532,14 +2536,12 @@ interface GPUAdapter {
                         1. [=Reject=] |promise| with an {{OperationError}}.
                     </div>
 
-                1. If |adapter| is [$expired$],
+                1. If |adapter|.{{adapter/[[state]]}} is {{adapter/[[state]]/"expired"}}
                     or the user agent otherwise cannot fulfill the request:
 
                     1. Let |device| be a new [=device=].
                     1. [=Lose the device=](|device|, {{GPUDeviceLostReason/"unknown"}}).
-
-                        Note:
-                        This [$expires$] |adapter|, if it wasn't already expired.
+                    1. [=Assert=] |adapter|.{{adapter/[[state]]}} is {{adapter/[[state]]/"expired"}}.
 
                         Note:
                         User agents should consider issuing developer-visible warnings in
@@ -2549,7 +2551,7 @@ interface GPUAdapter {
                     Otherwise:
 
                     1. Let |device| be [=a new device=] with the capabilities described by |descriptor|.
-                    1. [$Expire$] |adapter|.
+                    1. Set |adapter|.{{adapter/[[state]]}} to {{adapter/[[state]]/"consumed"}}.
 
                 1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>


### PR DESCRIPTION
Separates the "expired" state from the "consumed" state so we can handle those cases differently.

Fixes #4352