### PR TITLE
If any vertex is OOB, the whole draw call may behave as OOB

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15025,6 +15025,10 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
                 1. Load the attribute |data| according to WGSL's [=invalid memory reference=]
                     behavior, from |vertexBuffer|.
 
+                    Note: [=Invalid memory reference=] allows several behaviors, including actually
+                    loading the "correct" result for an attribute that is in-bounds, even when
+                    the draw-call-wide |drawCallOutOfBounds| is true.
+
                 Otherwise:
 
                 1. Let |attributeOffset| be |vertexBufferOffset| +

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15006,23 +15006,34 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
                 : {{GPUVertexStepMode/"instance"}}
                 :: |instanceIndex|
             </dl>
+        1. Let |drawCallOutOfBounds| be `false`.
         1. For each |attributeDesc| in |vertexBufferLayout|.{{GPUVertexBufferLayout/attributes}}:
             1. Let |attributeOffset| be |vertexBufferOffset| +
                 |vertexElementIndex| * |vertexBufferLayout|.{{GPUVertexBufferLayout/arrayStride}} +
                 |attributeDesc|.{{GPUVertexAttribute/offset}}.
-            1. Load the attribute |data| of format |attributeDesc|.{{GPUVertexAttribute/format}}
-                from |vertexBuffer| starting at offset |attributeOffset|.
-                The components are loaded in the order `x`, `y`, `z`, `w` from buffer memory.
+            1. If |attributeOffset| + sizeof(|attributeDesc|.{{GPUVertexAttribute/format}}) &gt;
+                |vertexBufferOffset| + |vertexBufferBindingSize|:
+                1. Set |drawCallOutOfBounds| to `true`.
+                1. **Optionally (implementation-defined)**,
+                    [=list/empty=] |vertexIndexList| and stop, cancelling the draw call.
 
-                If this results in an out-of-bounds access, the resulting value is determined
-                according to WGSL's [=invalid memory reference=] behavior.
-            1. **Optionally (implementation-defined):**
-                If |attributeOffset| + sizeof(|attributeDesc|.{{GPUVertexAttribute/format}}) &gt;
-                |vertexBufferOffset| + |vertexBufferBindingSize|,
-                [=list/empty=] |vertexIndexList| and stop, cancelling the draw call.
+                    Note: This allows implementations to detect out-of-bounds values in the index buffer
+                    before issuing a draw call, instead of using [=invalid memory reference=] behavior.
+        1. For each |attributeDesc| in |vertexBufferLayout|.{{GPUVertexBufferLayout/attributes}}:
+            1. If |drawCallOutOfBounds| is `true`:
 
-                Note: This allows implementations to detect out-of-bounds values in the index buffer
-                before issuing a draw call, instead of using [=invalid memory reference=] behavior.
+                1. Load the attribute |data| according to WGSL's [=invalid memory reference=]
+                    behavior, from |vertexBuffer|.
+
+                Otherwise:
+
+                1. Let |attributeOffset| be |vertexBufferOffset| +
+                    |vertexElementIndex| * |vertexBufferLayout|.{{GPUVertexBufferLayout/arrayStride}} +
+                    |attributeDesc|.{{GPUVertexAttribute/offset}}.
+                1. Load the attribute |data| of format |attributeDesc|.{{GPUVertexAttribute/format}}
+                    from |vertexBuffer| starting at offset |attributeOffset|.
+                    The components are loaded in the order `x`, `y`, `z`, `w` from buffer memory.
+
             1. Convert the |data| into a shader-visible format, according to [=channel formats=] rules.
 
                 <div class=example>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15021,13 +15021,12 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
                     before issuing a draw call, instead of using [=invalid memory reference=] behavior.
         1. For each |attributeDesc| in |vertexBufferLayout|.{{GPUVertexBufferLayout/attributes}}:
             1. If |drawCallOutOfBounds| is `true`:
-
                 1. Load the attribute |data| according to WGSL's [=invalid memory reference=]
                     behavior, from |vertexBuffer|.
 
                     Note: [=Invalid memory reference=] allows several behaviors, including actually
                     loading the "correct" result for an attribute that is in-bounds, even when
-                    the draw-call-wide |drawCallOutOfBounds| is true.
+                    the draw-call-wide |drawCallOutOfBounds| is `true`.
 
                 Otherwise:
 
@@ -15037,7 +15036,6 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
                 1. Load the attribute |data| of format |attributeDesc|.{{GPUVertexAttribute/format}}
                     from |vertexBuffer| starting at offset |attributeOffset|.
                     The components are loaded in the order `x`, `y`, `z`, `w` from buffer memory.
-
             1. Convert the |data| into a shader-visible format, according to [=channel formats=] rules.
 
                 <div class=example>


### PR DESCRIPTION
Fixes #4668