### PR TITLE
Fix rules about dual source blending in `validating GPUFragmentState`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8410,12 +8410,9 @@ dictionary GPUFragmentState
                     - |entryPoint| must have a [=shader stage output=] with [=location=] equal to |index|
                          and [=blend_src=] omitted or equal to 0.
             - If |usesDualSourceBlending| is `true`:
-                - All the [=shader stage output=] values of |entryPoint| must have a [=blend_src=] attribute.
                 - |descriptor|.{{GPUFragmentState/targets}}.length must be 1.
-                - Let |colorState| be |descriptor|.{{GPUFragmentState/targets}}[0].
-                - If |colorState|.{{GPUColorTargetState/writeMask}} is not 0:
-                    - |entryPoint| must have a [=shader stage output=] with [=location=] equal to 0
-                        and [=blend_src=] equal to 1.
+                - |entryPoint| must have a [=shader stage output=] with [=location=] equal to 0
+                    and [=blend_src=] equal to 1.
             - [$Validating GPUFragmentState's color attachment bytes per sample$](|device|, |descriptor|.{{GPUFragmentState/targets}}) succeeds.
         </div>
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -112,6 +112,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: interpolation-sampling; url: interpolation-sampling
         text: textureSampleLevel; url: texturesamplelevel
         text: interpolation type; url: interpolation-type
+        text: use dual source blending; url: use-dual-source-blending
         for: interpolation type
             text: flat; url: interpolation-type-flat
             text: linear; url: interpolation-type-linear
@@ -8411,8 +8412,7 @@ dictionary GPUFragmentState
                          and [=blend_src=] omitted or equal to 0.
             - If |usesDualSourceBlending| is `true`:
                 - |descriptor|.{{GPUFragmentState/targets}}.length must be 1.
-                - |entryPoint| must have a [=shader stage output=] with [=location=] equal to 0
-                    and [=blend_src=] equal to 1.
+                - |entryPoint| must [=use dual source blending=].
             - [$Validating GPUFragmentState's color attachment bytes per sample$](|device|, |descriptor|.{{GPUFragmentState/targets}}) succeeds.
         </div>
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8481,7 +8481,8 @@ dictionary GPUFragmentState
                          and [=blend_src=] omitted or equal to 0.
             - If |usesDualSourceBlending| is `true`:
                 - |descriptor|.{{GPUFragmentState/targets}}.length must be 1.
-                - |entryPoint| must [=use dual source blending=].
+                - All the [=shader stage outputs=] with [=location=] in |entryPoint| must be in one
+                    struct and [=use dual source blending=].
             - [$Validating GPUFragmentState's color attachment bytes per sample$](|device|, |descriptor|.{{GPUFragmentState/targets}}) succeeds.
         </div>
 </div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9533,7 +9533,8 @@ Each structure member in the entry point IO [=shader-creation error|must=] be on
 <div algorithm="locations in structs">
     For each structure type |S| defined in a WGSL module (not just those used in shader stage inputs or outputs),
     let |members| be the set of members of |S| that have [=attribute/location=] attributes.
-    - If any entry in |members| specifies a [=attribute/blend_src=] attribute:
+    - If any entry in |members| specifies a [=attribute/blend_src=] attribute, it must <dfn>use
+        dual source blending</dfn>, which means:
         - |members| [=shader-creation error|must=] contain exactly `2` entries,
             one with `@location(0) @blend_src(0)` and one with `@location(0) @blend_src(1)`.
         - All the |members| [=shader-creation error|must=] have same data type.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9533,8 +9533,8 @@ Each structure member in the entry point IO [=shader-creation error|must=] be on
 <div algorithm="locations in structs">
     For each structure type |S| defined in a WGSL module (not just those used in shader stage inputs or outputs),
     let |members| be the set of members of |S| that have [=attribute/location=] attributes.
-    - If any entry in |members| specifies a [=attribute/blend_src=] attribute, it must <dfn>use
-        dual source blending</dfn>, which means:
+    - If any entry in |members| specifies a [=attribute/blend_src=] attribute, it must <dfn export>
+        use dual source blending</dfn>, which means:
         - |members| [=shader-creation error|must=] contain exactly `2` entries,
             one with `@location(0) @blend_src(0)` and one with `@location(0) @blend_src(1)`.
         - All the |members| [=shader-creation error|must=] have same data type.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9533,7 +9533,7 @@ Each structure member in the entry point IO [=shader-creation error|must=] be on
 <div algorithm="locations in structs">
     For each structure type |S| defined in a WGSL module (not just those used in shader stage inputs or outputs),
     let |members| be the set of members of |S| that have [=attribute/location=] attributes.
-    - If any entry in |members| specifies a [=attribute/blend_src=] attribute, it must <dfn export>
+    - If any entry in |members| specifies a [=attribute/blend_src=] attribute, |members| must <dfn export>
         use dual source blending</dfn>, which means:
         - |members| [=shader-creation error|must=] contain exactly `2` entries,
             one with `@location(0) @blend_src(0)` and one with `@location(0) @blend_src(1)`.


### PR DESCRIPTION
This patch fixes several rules about dual source blending in the algorithm `validating GPUFragmentState`
(1) When `Src1` is used, the fragment output at location 0 must have
    `@blend_src(1)` whether the colorWriteMask is 0 or not, which is
    required by Metal validation layer.
(2) The first validation rule is not needed any more because:
    - According to the second rule (required by D3D12) we must
      have exactly one color target
    - According to (1), the fragment output at location 0 must have
      `blend_src(1)`.

Issue: #4283