### PR TITLE
Clarify array layer OOB for texture sampling

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -16047,6 +16047,10 @@ https://github.com/gpuweb/gpuweb/issues/2343
 
 A four component vector with components extracted from the specified channel from the selected texels, as described above.
 
+If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
+* The data for some texel within bounds of the texture
+* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type
+
 <div class='example wgsl global-scope' heading="Gather components from texels in 2D texture">
   <xmp highlight=wgsl>
     @group(0) @binding(0) var t: texture_2d<f32>;
@@ -16187,6 +16191,10 @@ texture and collects the results into a single vector, as follows:
 **Returns:**
 
 A four component vector with comparison result for the selected texels, as described above.
+
+If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
+* The data for some texel within bounds of the texture
+* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type
 
 <div class='example wgsl global-scope' heading="Gather depth comparison">
   <xmp highlight=wgsl>
@@ -16663,6 +16671,11 @@ The sampled value.
 
 An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
 
+If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
+* The data for some texel within bounds of the texture
+* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
+* 0.0 for depth textures
+
 ### `textureSampleBias` ### {#texturesamplebias}
 
 Samples a texture with a bias to the mip level.
@@ -16783,6 +16796,11 @@ The sampled value.
 
 An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
 
+If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
+* The data for some texel within bounds of the texture
+* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
+* 0.0 for depth textures
+
 ### `textureSampleCompare` ### {#texturesamplecompare}
 
 Samples a [=type/depth texture=] and compares the sampled depth values against a reference value.
@@ -16899,6 +16917,10 @@ single texel is returned.
 
 An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
 
+If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
+* The data for some texel within bounds of the texture
+* 0.0
+
 ### `textureSampleCompareLevel` ### {#texturesamplecomparelevel}
 
 Samples a [=type/depth texture=] and compares the sampled depth values against a reference value.
@@ -16999,6 +17021,10 @@ Samples a [=type/depth texture=] and compares the sampled depth values against a
 **Returns:**
 
 A value in the range `[0.0..1.0]`.
+
+If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
+* The data for some texel within bounds of the texture
+* 0.0
 
 The `textureSampleCompareLevel` function is the same as `textureSampleCompare`, except that:
 
@@ -17128,6 +17154,10 @@ Samples a texture using explicit gradients.
 
 The sampled value.
 
+If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
+* The data for some texel within bounds of the texture
+* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
+* 0.0 for depth textures
 
 ### `textureSampleLevel` ### {#texturesamplelevel}
 
@@ -17312,6 +17342,11 @@ Samples a texture using an explicit mip level.
 
 The sampled value.
 
+If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
+* The data for some texel within bounds of the texture
+* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
+* 0.0 for depth textures
+
 ### `textureSampleBaseClampToEdge` ### {#textureSampleBaseClampToEdge}
 
 Samples a texture view at its base level,
@@ -17361,6 +17396,10 @@ with texture coordinates clamped to the edge as described below.
 **Returns:**
 
 The sampled value.
+
+If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
+* The data for some texel within bounds of the texture
+* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type
 
 ### `textureStore` ### {#texturestore}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -16033,7 +16033,8 @@ https://github.com/gpuweb/gpuweb/issues/2343
   <tr><td>`coords`<td>
   The texture coordinates.
   <tr><td>`array_index`<td>
-  The 0-based texture array index.
+  The 0-based texture array index.<br>
+  This value [=behavioral requirement|will=] be clamped to the range `[0, textureNumLayers(t) - 1]`.
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
@@ -16046,10 +16047,6 @@ https://github.com/gpuweb/gpuweb/issues/2343
 **Returns:**
 
 A four component vector with components extracted from the specified channel from the selected texels, as described above.
-
-If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
-* The data for some texel within bounds of the texture
-* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type
 
 <div class='example wgsl global-scope' heading="Gather components from texels in 2D texture">
   <xmp highlight=wgsl>
@@ -16176,7 +16173,8 @@ texture and collects the results into a single vector, as follows:
   <tr><td>`coords`<td>
   The texture coordinates.
   <tr><td>`array_index`<td>
-  The 0-based texture array index.
+  The 0-based texture array index.<br>
+  This value [=behavioral requirement|will=] be clamped to the range `[0, textureNumLayers(t) - 1]`.
   <tr><td>`depth_ref`<td>
   The reference value to compare the sampled depth value against.
   <tr><td>`offset`<td>
@@ -16191,10 +16189,6 @@ texture and collects the results into a single vector, as follows:
 **Returns:**
 
 A four component vector with comparison result for the selected texels, as described above.
-
-If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
-* The data for some texel within bounds of the texture
-* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type
 
 <div class='example wgsl global-scope' heading="Gather depth comparison">
   <xmp highlight=wgsl>
@@ -16655,7 +16649,8 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
   <tr><td>`array_index`<td>
-  The 0-based texture array index to sample.
+  The 0-based texture array index to sample.<br>
+  This value [=behavioral requirement|will=] be clamped to the range `[0, textureNumLayers(t) - 1]`.
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
@@ -16670,11 +16665,6 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
 The sampled value.
 
 An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
-
-If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
-* The data for some texel within bounds of the texture
-* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
-* 0.0 for depth textures
 
 ### `textureSampleBias` ### {#texturesamplebias}
 
@@ -16777,7 +16767,8 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
   <tr><td>`array_index`<td>
-  The 0-based texture array index to sample.
+  The 0-based texture array index to sample.<br>
+  This value [=behavioral requirement|will=] be clamped to the range `[0, textureNumLayers(t) - 1]`.
   <tr><td>`bias`<td>
   The bias to apply to the mip level before sampling.
   `bias` [=shader-creation error|must=] be between `-16.0` and `15.99`.
@@ -16795,11 +16786,6 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
 The sampled value.
 
 An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
-
-If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
-* The data for some texel within bounds of the texture
-* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
-* 0.0 for depth textures
 
 ### `textureSampleCompare` ### {#texturesamplecompare}
 
@@ -16891,7 +16877,8 @@ then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
   <tr><td>`array_index`<td>
-  The 0-based texture array index to sample.
+  The 0-based texture array index to sample.<br>
+  This value [=behavioral requirement|will=] be clamped to the range `[0, textureNumLayers(t) - 1]`.
   <tr><td>`depth_ref`<td>
   The reference value to compare the sampled depth value against.
   <tr><td>`offset`<td>
@@ -16916,10 +16903,6 @@ the filtered average of these values, otherwise the comparison result of a
 single texel is returned.
 
 An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
-
-If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
-* The data for some texel within bounds of the texture
-* 0.0
 
 ### `textureSampleCompareLevel` ### {#texturesamplecomparelevel}
 
@@ -17006,7 +16989,8 @@ Samples a [=type/depth texture=] and compares the sampled depth values against a
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
   <tr><td>`array_index`<td>
-  The 0-based texture array index to sample.
+  The 0-based texture array index to sample.<br>
+  This value [=behavioral requirement|will=] be clamped to the range `[0, textureNumLayers(t) - 1]`.
   <tr><td>`depth_ref`<td>
   The reference value to compare the sampled depth value against.
   <tr><td>`offset`<td>
@@ -17021,10 +17005,6 @@ Samples a [=type/depth texture=] and compares the sampled depth values against a
 **Returns:**
 
 A value in the range `[0.0..1.0]`.
-
-If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
-* The data for some texel within bounds of the texture
-* 0.0
 
 The `textureSampleCompareLevel` function is the same as `textureSampleCompare`, except that:
 
@@ -17136,7 +17116,8 @@ Samples a texture using explicit gradients.
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
   <tr><td>`array_index`<td>
-  The 0-based texture array index to sample.
+  The 0-based texture array index to sample.<br>
+  This value [=behavioral requirement|will=] be clamped to the range `[0, textureNumLayers(t) - 1]`.
   <tr><td>`ddx`<td>
   The x direction derivative vector used to compute the sampling locations.
   <tr><td>`ddy`<td>
@@ -17153,11 +17134,6 @@ Samples a texture using explicit gradients.
 **Returns:**
 
 The sampled value.
-
-If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
-* The data for some texel within bounds of the texture
-* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
-* 0.0 for depth textures
 
 ### `textureSampleLevel` ### {#texturesamplelevel}
 
@@ -17323,7 +17299,8 @@ Samples a texture using an explicit mip level.
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
   <tr><td>`array_index`<td>
-  The 0-based texture array index to sample.
+  The 0-based texture array index to sample.<br>
+  This value [=behavioral requirement|will=] be clamped to the range `[0, textureNumLayers(t) - 1]`.
   <tr><td>`level`<td>
   The mip level, with level 0 containing a full size version of the texture.
   For the functions where `level` is a `f32`, fractional values may interpolate
@@ -17341,11 +17318,6 @@ Samples a texture using an explicit mip level.
 **Returns:**
 
 The sampled value.
-
-If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
-* The data for some texel within bounds of the texture
-* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
-* 0.0 for depth textures
 
 ### `textureSampleBaseClampToEdge` ### {#textureSampleBaseClampToEdge}
 
@@ -17396,10 +17368,6 @@ with texture coordinates clamped to the edge as described below.
 **Returns:**
 
 The sampled value.
-
-If `array_index` is outside the range `[0, textureNumLayers(t))`, the return value is one of:
-* The data for some texel within bounds of the texture
-* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type
 
 ### `textureStore` ### {#texturestore}
 


### PR DESCRIPTION
Fixes #4782

* Add array_index OOB behavior for sampled texture built-in functions similar to textureLoad