### PR TITLE
[editorial] Link to a definition for [=implementation-defined=]

### DIFF
--- a/explainer/index.bs
+++ b/explainer/index.bs
@@ -194,7 +194,7 @@ options which may influence what adapter is chosen, like a
 `requestAdapter()` never rejects, but may resolve to null if an adapter can't be returned with
 the specified options.
 
-A returned adapter exposes a `name` (implementation-defined), a boolean `isSoftware` so
+A returned adapter exposes a `name` ([=implementation-defined=]), a boolean `isSoftware` so
 applications with fallback paths (like WebGL or 2D canvas) can avoid slow software implementations,
 and the [[#optional-capabilities]] available on the adapter.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -640,7 +640,7 @@ interface mixin GPUObjectBase {
 <dl dfn-type=attribute dfn-for=GPUObjectBase data-timeline=content>
     : <dfn>label</dfn>
     ::
-        A developer-provided label which is used in an implementation-defined way.
+        A developer-provided label which is used in an [=implementation-defined=] way.
         It can be used by the browser, OS, or other tools to help
         identify the underlying [=internal object=] to the developer.
         Examples include displaying the label in {{GPUError}} messages, console warnings,
@@ -670,7 +670,7 @@ interface mixin GPUObjectBase {
 
             This means one underlying object could be associated with multiple labels.
             This specification does not define how the label is propagated to the [=device timeline=].
-            How labels are used is completely implementation-defined: error messages could
+            How labels are used is completely [=implementation-defined=]: error messages could
             show the most recently set label, all known labels, or no labels at all.
 
             It is defined as a {{USVString}} because some user agents may
@@ -1313,7 +1313,7 @@ no validation errors are raised, most promises resolve normally, etc.
         <div data-timeline=content>
             1. Resolve |device|.{{GPUDevice/lost}} with a new {{GPUDeviceLostInfo}} with
                 {{GPUDeviceLostInfo/reason}} set to |reason| and
-                {{GPUDeviceLostInfo/message}} set to an implementation-defined value.
+                {{GPUDeviceLostInfo/message}} set to an [=implementation-defined=] value.
 
                 Note: {{GPUDeviceLostInfo/message}} should not disclose unnecessary user/system
                 information and should never be parsed by applications.
@@ -2092,7 +2092,7 @@ them to WGSL values (`bool`, `i32`, `u32`, `f32`, `f16`).
         step, and return the result.
 
         Note:
-        For non-integer types, the exact choice of value is implementation-defined.
+        For non-integer types, the exact choice of value is [=implementation-defined=].
         For normalized types, the value is clamped to the range of the type.
 
     Note:
@@ -4895,7 +4895,7 @@ External textures use several binding slots: see [=Exceeds the binding slot limi
 
 <div class=note heading>
     External textures *can* be implemented without creating a copy of the imported source,
-    but this depends implementation-defined factors.
+    but this depends [=implementation-defined=] factors.
     Ownership of the underlying representation may either be exclusive or shared with other
     owners (such as a video decoder), but this is not visible to the application.
 
@@ -6735,7 +6735,7 @@ Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
     ::
         Returns any messages generated during the {{GPUShaderModule}}'s compilation.
 
-        The locations, order, and contents of messages are implementation-defined.
+        The locations, order, and contents of messages are [=implementation-defined=]
         In particular, messages may not be ordered by {{GPUCompilationMessage/lineNum}}.
 
         <div algorithm=GPUShaderModule.getCompilationInfo>
@@ -10843,7 +10843,7 @@ dictionary GPUComputePassTimestampWrites {
 </dl>
 
 Note: Timestamp query values are written in nanoseconds, but how the value is determined is
-implementation-defined and may not increase monotonically. See [[#timestamp]] for details.
+[=implementation-defined=] and may not increase monotonically. See [[#timestamp]] for details.
 
 <script type=idl>
 dictionary GPUComputePassDescriptor
@@ -11217,7 +11217,7 @@ dictionary GPURenderPassTimestampWrites {
 </dl>
 
 Note: Timestamp query values are written in nanoseconds, but how the value is determined is
-implementation-defined and may not increase monotonically. See [[#timestamp]] for details.
+[=implementation-defined=] and may not increase monotonically. See [[#timestamp]] for details.
 
 <script type=idl>
 dictionary GPURenderPassDescriptor
@@ -13569,7 +13569,7 @@ Timestamp queries allow applications to write timestamps to a {{GPUQuerySet}}, u
 and then resolve timestamp values (in nanoseconds as a [=64-bit unsigned integer=]) into
 a {{GPUBuffer}}, using {{GPUCommandEncoder}}.{{GPUCommandEncoder/resolveQuerySet()}}.
 
-Timestamp values are implementation defined and may not increase monotonically. The physical device
+Timestamp values are [=implementation-defined=] and may not increase monotonically. The physical device
 may reset the timestamp counter occasionally, which can result in unexpected values such as negative
 deltas between timestamps that logically should be monotonically increasing. These instances should
 be rare and can safely be ignored. Applications should not be written in such a way that unexpected
@@ -13583,8 +13583,9 @@ To mitigate security and privacy concerns, their precision must be reduced:
     To get the <dfn abstract-op>current queue timestamp</dfn>, run the following [=queue timeline=] steps:
 
     - Let |fineTimestamp| be the current timestamp value of the current [=queue timeline=],
-        in nanoseconds, relative to an implementation-defined point in the past.
-    - Return the result of calling [=coarsen time=] on |fineTimestamp|.
+        in nanoseconds, relative to an [=implementation-defined=] point in the past.
+    - Return the result of calling [=coarsen time=] on |fineTimestamp|
+        with `crossOriginIsolatedCapability` set to `false`.
 
     Note: Since cross-origin isolation may not apply to the [=device timeline=] or
     [=queue timeline=], `crossOriginIsolatedCapability` is never set to `true`.
@@ -15016,7 +15017,7 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
 
                 If this results in an out-of-bounds access, the resulting value is determined
                 according to WGSL's [=invalid memory reference=] behavior.
-            1. **Optionally (implementation-defined):**
+            1. **Optionally ([=implementation-defined=]):**
                 If |attributeOffset| + sizeof(|attributeDesc|.{{GPUVertexAttribute/format}}) &gt;
                 |vertexBufferOffset| + |vertexBufferBindingSize|,
                 [=list/empty=] |vertexIndexList| and stop, cancelling the draw call.
@@ -15424,7 +15425,7 @@ Otherwise, the polygon is <dfn dfn>back-facing</dfn>.
 
             : enabled
             :: Each pixel is associated with |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}
-                locations, which are implementation-defined.
+                locations, which are [=implementation-defined=].
                 The locations are ordered, and the list is the same for each pixel of the [=framebuffer=].
                 Each location corresponds to one fragment in the multisampled [=framebuffer=].
 
@@ -16532,7 +16533,7 @@ must be {{GPUTextureSampleType/"uint"}}.
 
 Reading or sampling the depth or stencil aspect of a texture behaves as if the texture contains
 the values `(V, X, X, X)`, where V is the actual depth or stencil value,
-and each X is an implementation-defined unspecified value.
+and each X is an [=implementation-defined=] unspecified value.
 
 For depth-aspect bindings, the unspecified values are not visible through bindings with
 `texture_depth_*` types.


### PR DESCRIPTION
I found out there's a common definition of "implementation-defined", so link to it.
https://infra.spec.whatwg.org/#implementation-defined

Also explicitly set the optional `crossOriginIsolatedCapability` option of the `coarsen time` algorithm for a tiny bit of extra clarity.