### PR TITLE
Add extra example for operations involving abstract numerics

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2556,13 +2556,13 @@ Example:  `1u + 2.5` results in a [=shader-creation error=]:
     * No type rule matches *e*`+`*f* with *e* in an [=integer scalar=] type, and *f* in a floating point type.
 
 Example:  `-1 * i32(-2147483648)` does not result in a [=shader-creation error=]:
-* The `-1` term is an expression of type [=AbstractInt=]
-* The `i32(-2147483648)` term is an expression of type [=i32=]
-* There is no overload of the multiply operator for these two types and the [=i32=] term cannot be up-converted to [=AbstractInt=]
+* The `-1` term is an expression of type [=AbstractInt=].
+* The `i32(-2147483648)` term is an expression of type [=i32=].
+* There is no overload of the multiply operator for these two types and the [=i32=] term cannot be up-converted to [=AbstractInt=].
 * The only feasible automatic conversion is converting the [=AbstractInt=] to [=i32=] so:
-    * The resulting computation is a multiplication operation between [=i32=]
-    * [=i32=] operations use two's complement arithmetic and have defined overflow behavior
-    * Wrapping occurs
+    * The resulting computation is a multiplication operation between [=i32=].
+    * [=i32=] operations use two's complement arithmetic and have defined overflow behavior.
+    * Wrapping occurs.
 
 <div class='example literals' heading="Type inference for literals">
   <xmp highlight=wgsl>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2555,6 +2555,15 @@ Example:  `1u + 2.5` results in a [=shader-creation error=]:
     * There is no feasible automatic conversion from a GPU-materialized [=integer scalar=] type to a floating point type.
     * No type rule matches *e*`+`*f* with *e* in an [=integer scalar=] type, and *f* in a floating point type.
 
+Example:  `-1 * i32(-2147483648)` does not result in a [=shader-creation error=]:
+* The `-1` term is an expression of type [=AbstractInt=]
+* The `i32(-2147483648)` term is an expression of type [=i32=]
+* There is no overload of the multiply operator for these two types and the [=i32=] term cannot be up-converted to [=AbstractInt=]
+* The only feasible automatic conversion is converting the [=AbstractInt=] to [=i32=] so:
+    * The resulting computation is a multiplication operation between [=i32=]
+    * [=i32=] operations use two's complement arithmetic and have defined overflow behavior
+    * Wrapping occurs
+
 <div class='example literals' heading="Type inference for literals">
   <xmp highlight=wgsl>
     // Explicitly-typed unsigned integer literal.


### PR DESCRIPTION
Hi! I came across some WGSL behavior related to operations involving abstract numerics that I and a couple others got confused about, even after reading the spec. I thought it might be helpful to other developers to maybe update the spec with an extra example related to an operation between an abstract numeric and a non-abstract numeric. 

```wgsl
// This isn't an error 
const num : i32 = -1 * i32(-2147483648)

// This is an error:
const num : i32 = -1 * -2147483648
```

I know that the spec already contains an example of an operation involving an abstract numeric and a u32 that results in a `shader-creation error`, but perhaps it would also be useful to include an example where it succeeds (i.e., the expression doesn't produce an overflow or infinite or NaN value because of automatic conversion to a type with defined overflow behavior)? 

I added in an extra example with an explanation that was very kindly provided by Alan and David. 

But I'm not sure if this example might be a bit too niche/contrived. Looking forward to hear your thoughts. Thanks!

