### PR TITLE
[editorial] Add timelines to all attributes/slots, assorted editing

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -606,6 +606,13 @@ The following special property types can be defined on [=WebGPU objects=]:
 
     [=Device timeline properties=] are named `[[with brackets]]`, and are internal slots.
 
+: <dfn dfn data-timeline=queue>queue timeline property</dfn>
+::
+    A property which tracks state of the [=internal object=] and is only accessible from the
+    [=queue timeline=] where the object was created. [=queue timeline properties=] may be mutable.
+
+    [=Queue timeline properties=] are named `[[with brackets]]`, and are internal slots.
+
 <script type=idl>
 interface mixin GPUObjectBase {
     attribute USVString label;
@@ -681,7 +688,7 @@ interface mixin GPUObjectBase {
 {{GPUObjectBase}} has the following [=device timeline properties=]:
 
 <dl dfn-type=attribute dfn-for=GPUObjectBase data-timeline=device>
-    : <dfn>\[[valid]]</dfn>, of type boolean, initially `true`.
+    : <dfn>\[[valid]]</dfn>, of type {{boolean}}, initially `true`.
     ::
         If `true`, indicates that the [=internal object=] is valid to use.
 </dl>
@@ -1198,13 +1205,9 @@ An [=adapter=] may be considered a <dfn>fallback adapter</dfn> if it has signifi
 caveats in exchange for some combination of wider compatibility, more predictable behavior, or
 improved privacy. It is not required that a [=fallback adapter=] is available on every system.
 
-An [=adapter=] has the following internal slots:
+[=adapter=] has the following [=immutable properties=]:
 
-<dl dfn-type=attribute dfn-for=adapter>
-    : <dfn>\[[expired]]</dfn>, of type boolean, initially `false`
-    ::
-        If set to `true` indicates that the adapter can no longer be used to create a [=device=].
-
+<dl dfn-type=attribute dfn-for=adapter data-timeline=device>
     : <dfn>\[[features]]</dfn>, of type [=ordered set=]&lt;{{GPUFeatureName}}&gt;, readonly
     ::
         The [=features=] which can be used to create devices on this adapter.
@@ -1216,9 +1219,17 @@ An [=adapter=] has the following internal slots:
         Each adapter limit must be the same or [=limit/better=] than its default value
         in [=supported limits=].
 
-    : <dfn>\[[fallback]]</dfn>, of type boolean
+    : <dfn>\[[fallback]]</dfn>, of type {{boolean}}, readonly
     ::
         If set to `true` indicates that the adapter is a [=fallback adapter=].
+</dl>
+
+[=adapter=] has the following [=device timeline properties=]:
+
+<dl dfn-type=attribute dfn-for=adapter data-timeline=device>
+    : <dfn>\[[expired]]</dfn>, of type {{boolean}}, initially `false`
+    ::
+        If set to `true` indicates that the adapter can no longer be used to create a [=device=].
 </dl>
 
 [=Adapters=] are exposed via {{GPUAdapter}}.
@@ -1248,7 +1259,7 @@ it and all objects created on it (directly, e.g.
 {{GPUDevice/createTexture()}}, or indirectly, e.g. {{GPUTexture/createView()}}) become
 implicitly [$valid to use with|unusable$].
 
-A [=device=] has the following [=immutable properties=]:
+[=device=] has the following [=immutable properties=]:
 
 <dl dfn-type=attribute dfn-for=device data-timeline=const>
     : <dfn>\[[adapter]]</dfn>, of type [=adapter=], readonly
@@ -1266,7 +1277,7 @@ A [=device=] has the following [=immutable properties=]:
         No [=limit/better=] limits can be used, even if the underlying [=adapter=] can support them.
 </dl>
 
-A [=device=] also has the following [=content timeline property=]:
+[=device=] has the following [=content timeline property=]:
 
 <dl dfn-type=attribute dfn-for=device data-timeline=content>
     : <dfn>[[content device]]</dfn>, of type {{GPUDevice}}, readonly
@@ -1787,7 +1798,7 @@ interface GPUAdapterInfo {
 
 {{GPUAdapterInfo}} has the following attributes:
 
-<dl dfn-type=attribute dfn-for=GPUAdapterInfo>
+<dl dfn-type=attribute dfn-for=GPUAdapterInfo data-timeline=content>
     : <dfn>vendor</dfn>
     ::
         The name of the vendor of the [=adapter=], if available. Empty string otherwise.
@@ -2118,7 +2129,7 @@ WorkerNavigator includes NavigatorGPU;
 
 {{NavigatorGPU}} has the following attributes:
 
-<dl dfn-type=attribute dfn-for=NavigatorGPU>
+<dl dfn-type=attribute dfn-for=NavigatorGPU data-timeline=content>
     : <dfn>gpu</dfn>
     ::
         A global singleton providing top-level entry points like {{GPU/requestAdapter()}}.
@@ -2137,7 +2148,7 @@ interface GPU {
 };
 </script>
 
-{{GPU}} has the following methods and attributes:
+{{GPU}} has the following methods:
 
 <dl dfn-type=method dfn-for=GPU>
     : <dfn>requestAdapter(options)</dfn>
@@ -2219,8 +2230,12 @@ interface GPU {
                     {{GPUTextureFormat/"bgra8unorm"}}, depending on which format is optimal for
                     displaying WebGPU canvases on this system.
         </div>
+</dl>
 
-    : <dfn dfn-type=attribute>wgslLanguageFeatures</dfn>
+{{GPU}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for=GPU data-timeline=content>
+    : <dfn>wgslLanguageFeatures</dfn>
     ::
         The names of supported WGSL [=language extensions=].
         Supported language extensions are automatically enabled.
@@ -2414,9 +2429,9 @@ interface GPUAdapter {
 };
 </script>
 
-{{GPUAdapter}} has the following attributes:
+{{GPUAdapter}} has the following [=immutable properties=]
 
-<dl dfn-type=attribute dfn-for=GPUAdapter>
+<dl dfn-type=attribute dfn-for=GPUAdapter data-timeline=const>
     : <dfn>features</dfn>
     ::
         The set of values in `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[features]]}}.
@@ -2448,11 +2463,7 @@ interface GPUAdapter {
     : <dfn>isFallbackAdapter</dfn>
     ::
         Returns the value of {{GPUAdapter/[[adapter]]}}.{{adapter/[[fallback]]}}.
-</dl>
 
-{{GPUAdapter}} has the following internal slots:
-
-<dl dfn-type=attribute dfn-for=GPUAdapter>
     : <dfn>\[[adapter]]</dfn>, of type [=adapter=], readonly
     ::
         The [=adapter=] to which this {{GPUAdapter}} refers.
@@ -2735,9 +2746,9 @@ interface GPUDevice : EventTarget {
 GPUDevice includes GPUObjectBase;
 </script>
 
-{{GPUDevice}} has the following attributes:
+{{GPUDevice}} has the following [=immutable properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUDevice>
+<dl dfn-type=attribute dfn-for=GPUDevice data-timeline=const>
     : <dfn>features</dfn>
     ::
         A set containing the {{GPUFeatureName}} values of the features
@@ -2755,8 +2766,7 @@ GPUDevice includes GPUObjectBase;
 The {{GPUObjectBase/[[device]]}} for a {{GPUDevice}} is the [=device=] that the {{GPUDevice}} refers
 to.
 
-{{GPUDevice}} has the methods listed in its WebIDL definition above.
-Those not defined here are defined elsewhere in this document.
+{{GPUDevice}} has the following methods:
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>destroy()</dfn>
@@ -3295,6 +3305,8 @@ unmaps it, freeing any memory allocated for the mapping.
 Note: This allows the user agent to reclaim the GPU memory associated with the {{GPUBuffer}}
 once all previously submitted operations using it are complete.
 
+{{GPUBuffer}} has the following methods:
+
 <dl dfn-type=method dfn-for=GPUBuffer>
     : <dfn>destroy()</dfn>
     ::
@@ -3392,6 +3404,8 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
         produced by the GPU, and the returned {{ArrayBuffer}} will only ever contain the default
         initialized data (zeros) or data written by the webpage during a previous mapping.
 </dl>
+
+{{GPUBuffer}} has the following methods:
 
 <dl dfn-type=method dfn-for=GPUBuffer>
     : <dfn>mapAsync(mode, offset, size)</dfn>
@@ -3738,9 +3752,9 @@ interface GPUTexture {
 GPUTexture includes GPUObjectBase;
 </script>
 
-{{GPUTexture}} has the following attributes:
+{{GPUTexture}} has the following [=immutable properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUTexture>
+<dl dfn-type=attribute dfn-for=GPUTexture data-timeline=const>
     : <dfn>width</dfn>
     ::
         The width of this {{GPUTexture}}.
@@ -3772,22 +3786,17 @@ GPUTexture includes GPUObjectBase;
     : <dfn>usage</dfn>
     ::
         The allowed usages for this {{GPUTexture}}.
-</dl>
-
-{{GPUTexture}} has the following internal slots:
-
-<dl dfn-type=attribute dfn-for=GPUTexture>
-    : <dfn>\[[size]]</dfn>, of type {{GPUExtent3D}}
-    ::
-        The size of the texture (same as the {{GPUTexture/width}}, {{GPUTexture/height}}, and
-        {{GPUTexture/depthOrArrayLayers}} attributes).
 
     : <dfn>\[[viewFormats]]</dfn>, of type [=sequence=]&lt;{{GPUTextureFormat}}&gt;
     ::
         The set of {{GPUTextureFormat}}s that can be used {{GPUTextureViewDescriptor}}.{{GPUTextureViewDescriptor/format}}
         when creating views on this {{GPUTexture}}.
+</dl>
 
-    : <dfn>\[[destroyed]]</dfn>, of type `boolean`, initially false
+{{GPUTexture}} has the following [=device timeline properties=]:
+
+<dl dfn-type=attribute dfn-for=GPUTexture data-timeline=device>
+    : <dfn>\[[destroyed]]</dfn>, of type {{boolean}}, initially `false`
     ::
         If the texture is destroyed, it can no longer be used in any operation,
         and its underlying memory can be freed.
@@ -4110,7 +4119,6 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                         - [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns `true`.
                     </div>
 
-                1. Set |t|.{{GPUTexture/[[size]]}} to |descriptor|.{{GPUTextureDescriptor/size}}.
                 1. Set |t|.{{GPUTexture/[[viewFormats]]}} to |descriptor|.{{GPUTextureDescriptor/viewFormats}}.
             </div>
         </div>
@@ -4213,6 +4221,8 @@ garbage collection by calling {{GPUTexture/destroy()}}.
 Note: This allows the user agent to reclaim the GPU memory associated with the {{GPUTexture}} once
 all previously submitted operations using it are complete.
 
+{{GPUTexture}} has the following methods:
+
 <dl dfn-type=method dfn-for=GPUTexture>
     : <dfn>destroy()</dfn>
     ::
@@ -4225,6 +4235,11 @@ all previously submitted operations using it are complete.
                 **Returns:** {{undefined}}
 
                 [=Content timeline=] steps:
+
+                1. Issue the subsequent steps on the [=device timeline=].
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
                 1. Set |this|.{{GPUTexture/[[destroyed]]}} to true.
             </div>
@@ -4245,20 +4260,20 @@ interface GPUTextureView {
 GPUTextureView includes GPUObjectBase;
 </script>
 
-{{GPUTextureView}} has the following internal slots:
+{{GPUTextureView}} has the following [=immutable properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUTextureView>
-    : <dfn>\[[texture]]</dfn>
+<dl dfn-type=attribute dfn-for=GPUTextureView data-timeline=const>
+    : <dfn>\[[texture]]</dfn>, readonly
     ::
         The {{GPUTexture}} into which this is a view.
 
-    : <dfn>\[[descriptor]]</dfn>
+    : <dfn>\[[descriptor]]</dfn>, readonly
     ::
         The {{GPUTextureViewDescriptor}} describing this texture view.
 
         All optional fields of {{GPUTextureViewDescriptor}} are defined.
 
-    : <dfn>\[[renderExtent]]</dfn>
+    : <dfn>\[[renderExtent]]</dfn>, readonly
     ::
         For renderable views, this is the effective {{GPUExtent3DDict}} for rendering.
 
@@ -4573,7 +4588,7 @@ enum GPUTextureAspect {
                 1. Set |view|.{{GPUTextureView/[[texture]]}} to |this|.
                 1. Set |view|.{{GPUTextureView/[[descriptor]]}} to |descriptor|.
                 1. If |this|.{{GPUTexture/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
-                    1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/[[size]]}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
+                    1. Let |renderExtent| be [$compute render extent$]([|this|.{{GPUTexture/width}}, |this|.{{GPUTexture/height}}, |this|.{{GPUTexture/depthOrArrayLayers}}], |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
                     1. Set |view|.{{GPUTextureView/[[renderExtent]]}} to |renderExtent|.
             </div>
         </div>
@@ -4928,20 +4943,23 @@ interface GPUExternalTexture {
 GPUExternalTexture includes GPUObjectBase;
 </script>
 
-{{GPUExternalTexture}} has the following internal slots:
+{{GPUExternalTexture}} has the following [=immutable properties=]:
 
-<dl dfn-type=attribute dfn-for="GPUExternalTexture">
-    : <dfn>\[[expired]]</dfn>, of type `boolean`
-    ::
-        Indicates whether the object has expired (can no longer be used).
-        Initially set to `false`.
-
-        Note:
-        Unlike similar `\[[destroyed]]` slots, this can change from `true` back to `false`.
-
-    : <dfn>\[[descriptor]]</dfn>, of type {{GPUExternalTextureDescriptor}}
+<dl dfn-type=attribute dfn-for=GPUExternalTexture data-timeline=const>
+    : <dfn>\[[descriptor]]</dfn>, of type {{GPUExternalTextureDescriptor}}, readonly
     ::
         The descriptor with which the texture was created.
+</dl>
+
+{{GPUExternalTexture}} has the following [=immutable properties=]:
+
+<dl dfn-type=attribute dfn-for=GPUExternalTexture data-timeline=const>
+    : <dfn>\[[expired]]</dfn>, of type {{boolean}}, initially `false`
+    ::
+        Indicates whether the object has expired (can no longer be used).
+
+        Note:
+        Unlike `[[destroyed]]` slots, which are similar, this can change from `true` back to `false`.
 </dl>
 
 ### Importing External Textures ### {#external-texture-creation}
@@ -5161,18 +5179,18 @@ interface GPUSampler {
 GPUSampler includes GPUObjectBase;
 </script>
 
-{{GPUSampler}} has the following internal slots:
+{{GPUSampler}} has the following [=immutable properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUSampler>
+<dl dfn-type=attribute dfn-for=GPUSampler data-timeline=const>
     : <dfn>\[[descriptor]]</dfn>, of type {{GPUSamplerDescriptor}}, readonly
     ::
         The {{GPUSamplerDescriptor}} with which the {{GPUSampler}} was created.
 
-    : <dfn>\[[isComparison]]</dfn>, of type {{boolean}}
+    : <dfn>\[[isComparison]]</dfn>, of type {{boolean}}, readonly
     ::
         Whether the {{GPUSampler}} is used as a comparison sampler.
 
-    : <dfn>\[[isFiltering]]</dfn>, of type {{boolean}}
+    : <dfn>\[[isFiltering]]</dfn>, of type {{boolean}}, readonly
     ::
         Whether the {{GPUSampler}} weights multiple samples of a texture.
 </dl>
@@ -5454,10 +5472,10 @@ interface GPUBindGroupLayout {
 GPUBindGroupLayout includes GPUObjectBase;
 </script>
 
-{{GPUBindGroupLayout}} has the following internal slots:
+{{GPUBindGroupLayout}} has the following [=immutable properties=]:
 
 <dl dfn-type=attribute dfn-for=GPUBindGroupLayout>
-    : <dfn>\[[descriptor]]</dfn>, of type {{GPUBindGroupLayoutDescriptor}}
+    : <dfn>\[[descriptor]]</dfn>, of type {{GPUBindGroupLayoutDescriptor}}, readonly
     ::
 </dl>
 
@@ -5818,19 +5836,19 @@ dictionary GPUExternalTextureBindingLayout {
 };
 </script>
 
-A {{GPUBindGroupLayout}} object has the following internal slots:
+A {{GPUBindGroupLayout}} object has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUBindGroupLayout>
-    : <dfn>\[[entryMap]]</dfn>, of type [=ordered map=]&lt;{{GPUSize32}}, {{GPUBindGroupLayoutEntry}}&gt;
+<dl dfn-type=attribute dfn-for=GPUBindGroupLayout data-timeline=device>
+    : <dfn>\[[entryMap]]</dfn>, of type [=ordered map=]&lt;{{GPUSize32}}, {{GPUBindGroupLayoutEntry}}&gt;, readonly
     ::
         The map of binding indices pointing to the {{GPUBindGroupLayoutEntry}}s,
         which this {{GPUBindGroupLayout}} describes.
 
-    : <dfn>\[[dynamicOffsetCount]]</dfn>, of type {{GPUSize32}}
+    : <dfn>\[[dynamicOffsetCount]]</dfn>, of type {{GPUSize32}}, readonly
     ::
         The number of buffer bindings with dynamic offsets in this {{GPUBindGroupLayout}}.
 
-    : <dfn>\[[exclusivePipeline]]</dfn>, of type {{GPUPipelineBase}}?, initially `null`
+    : <dfn>\[[exclusivePipeline]]</dfn>, of type {{GPUPipelineBase}}?, readonly
     ::
         The pipeline that created this {{GPUBindGroupLayout}}, if it was created as part of a
         [[#default-pipeline-layout|default pipeline layout]]. If not `null`, {{GPUBindGroup}}s
@@ -5917,6 +5935,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                 1. Set |layout|.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}} to the number of
                     entries in |descriptor| where {{GPUBindGroupLayoutEntry/buffer}} is [=map/exist|provided=] and
                     {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`.
+                1. Set |layout|.{{GPUBindGroupLayout/[[exclusivePipeline]]}} to `null`.
                 1. For each {{GPUBindGroupLayoutEntry}} |entry| in
                     |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
                     1. Insert |entry| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
@@ -5955,9 +5974,9 @@ interface GPUBindGroup {
 GPUBindGroup includes GPUObjectBase;
 </script>
 
-A {{GPUBindGroup}} object has the following internal slots:
+{{GPUBindGroup}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUBindGroup>
+<dl dfn-type=attribute dfn-for=GPUBindGroup data-timeline=device>
     : <dfn>\[[layout]]</dfn>, of type {{GPUBindGroupLayout}}, readonly
     ::
         The {{GPUBindGroupLayout}} associated with this {{GPUBindGroup}}.
@@ -6044,10 +6063,10 @@ following members:
         {{GPUExternalTexture}}, or {{GPUBufferBinding}}.
 </dl>
 
-A {{GPUBindGroupEntry}} object also has the following internal slots:
+{{GPUBindGroupEntry}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUBindGroupEntry>
-    : <dfn>\[[prevalidatedSize]]</dfn>, of type boolean
+<dl dfn-type=attribute dfn-for=GPUBindGroupEntry data-timeline=device>
+    : <dfn>\[[prevalidatedSize]]</dfn>, of type {{boolean}}
     ::
         Whether or not this binding entry had it's buffer size validated at time of creation.
 </dl>
@@ -6278,10 +6297,10 @@ interface GPUPipelineLayout {
 GPUPipelineLayout includes GPUObjectBase;
 </script>
 
-{{GPUPipelineLayout}} has the following internal slots:
+{{GPUPipelineLayout}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUPipelineLayout>
-    : <dfn>\[[bindGroupLayouts]]</dfn>, of type [=list=]&lt;{{GPUBindGroupLayout}}&gt;
+<dl dfn-type=attribute dfn-for=GPUPipelineLayout data-timeline=device>
+    : <dfn>\[[bindGroupLayouts]]</dfn>, of type [=list=]&lt;{{GPUBindGroupLayout}}&gt;, readonly
     ::
         The {{GPUBindGroupLayout}} objects provided at creation in {{GPUPipelineLayoutDescriptor/bindGroupLayouts|GPUPipelineLayoutDescriptor.bindGroupLayouts}}.
 </dl>
@@ -6667,7 +6686,7 @@ any specific point in the code at all.
 
 {{GPUCompilationMessage}} has the following attributes:
 
-<dl dfn-type=attribute dfn-for=GPUCompilationMessage>
+<dl dfn-type=attribute dfn-for=GPUCompilationMessage data-timeline=content>
     : <dfn>message</dfn>
     ::
         The human-readable, [=localizable text=] for this compilation message.
@@ -6908,7 +6927,7 @@ enum GPUPipelineErrorReason {
 
 {{GPUPipelineError}} has the following attributes:
 
-<dl dfn-type=attribute dfn-for=GPUPipelineError>
+<dl dfn-type=attribute dfn-for=GPUPipelineError data-timeline=content>
     : <dfn>reason</dfn>
     ::
         A read-only [=slot-backed attribute=] exposing the type of error encountered in pipeline creation
@@ -6963,9 +6982,9 @@ interface mixin GPUPipelineBase {
 };
 </script>
 
-{{GPUPipelineBase}} has the following internal slots:
+{{GPUPipelineBase}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUPipelineBase>
+<dl dfn-type=attribute dfn-for=GPUPipelineBase data-timeline=device>
     : <dfn>\[[layout]]</dfn>, of type `GPUPipelineLayout`
     ::
         The definition of the layout of resources which can be used with `this`.
@@ -7772,19 +7791,19 @@ GPURenderPipeline includes GPUObjectBase;
 GPURenderPipeline includes GPUPipelineBase;
 </script>
 
-{{GPURenderPipeline}} has the following internal slots:
+{{GPURenderPipeline}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPURenderPipeline>
-    : <dfn>\[[descriptor]]</dfn>, of type {{GPURenderPipelineDescriptor}}
+<dl dfn-type=attribute dfn-for=GPURenderPipeline data-timeline=device>
+    : <dfn>\[[descriptor]]</dfn>, of type {{GPURenderPipelineDescriptor}}, readonly
     ::
         The {{GPURenderPipelineDescriptor}} describing this pipeline.
 
         All optional fields of {{GPURenderPipelineDescriptor}} are defined.
 
-    : <dfn>\[[writesDepth]]</dfn>, of type boolean
+    : <dfn>\[[writesDepth]]</dfn>, of type {{boolean}}, readonly
     :: True if the pipeline writes to the depth component of the depth/stencil attachment
 
-    : <dfn>\[[writesStencil]]</dfn>, of type boolean
+    : <dfn>\[[writesStencil]]</dfn>, of type {{boolean}}, readonly
     :: True if the pipeline writes to the stencil component of the depth/stencil attachment
 </dl>
 
@@ -9484,17 +9503,17 @@ interface GPUCommandBuffer {
 GPUCommandBuffer includes GPUObjectBase;
 </script>
 
-{{GPUCommandBuffer}} has the following internal slots:
+{{GPUCommandBuffer}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUCommandBuffer>
-    : <dfn>\[[command_list]]</dfn>, of type [=list=]&lt;[=GPU command=]&gt;
+<dl dfn-type=attribute dfn-for=GPUCommandBuffer data-timeline=device>
+    : <dfn>\[[command_list]]</dfn>, of type [=list=]&lt;[=GPU command=]&gt;, readonly
     ::
         A [=list=] of [=GPU commands=] to be executed on the [=Queue timeline=] when this command
         buffer is submitted.
 
-    : <dfn>\[[renderState]]</dfn>, of type [=RenderState=]
+    : <dfn>\[[renderState]]</dfn>, of type [=RenderState=], initially `null`
     ::
-        The current state used by any render pass commands being executed, initially `null`.
+        The current state used by any render pass commands being executed.
 </dl>
 
 ### Command Buffer Creation ### {#command-buffer-creation}
@@ -9520,9 +9539,9 @@ interface mixin GPUCommandsMixin {
 };
 </script>
 
-{{GPUCommandsMixin}} adds the following internal slots to interfaces which include it:
+{{GPUCommandsMixin}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUCommandsMixin>
+<dl dfn-type=attribute dfn-for=GPUCommandsMixin data-timeline=device>
     : <dfn>\[[state]]</dfn>, of type [=encoder state=], initially "[=encoder state/open=]"
     ::
         The current state of the encoder.
@@ -10416,16 +10435,16 @@ interface mixin GPUBindingCommandsMixin {
 {{GPUObjectBase}} and {{GPUCommandsMixin}} members on the same object.
 It must only be included by interfaces which also include those mixins.
 
-{{GPUBindingCommandsMixin}} has the following internal slots:
+{{GPUBindingCommandsMixin}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUBindingCommandsMixin>
-    : <dfn>\[[bind_groups]]</dfn>, of type [=ordered map=]&lt;{{GPUIndex32}}, {{GPUBindGroup}}&gt;
+<dl dfn-type=attribute dfn-for=GPUBindingCommandsMixin data-timeline=device>
+    : <dfn>\[[bind_groups]]</dfn>, of type [=ordered map=]&lt;{{GPUIndex32}}, {{GPUBindGroup}}&gt;, initially empty
     ::
-        The current {{GPUBindGroup}} for each index, initially empty.
+        The current {{GPUBindGroup}} for each index.
 
-    : <dfn>\[[dynamic_offsets]]</dfn>, of type [=ordered map=]&lt;{{GPUIndex32}}, [=list=]&lt;{{GPUBufferDynamicOffset}}&gt; &gt;
+    : <dfn>\[[dynamic_offsets]]</dfn>, of type [=ordered map=]&lt;{{GPUIndex32}}, [=list=]&lt;{{GPUBufferDynamicOffset}}&gt;&gt;, initally empty
     ::
-        The current dynamic offsets for each {{GPUBindingCommandsMixin/[[bind_groups]]}} entry, initially empty.
+        The current dynamic offsets for each {{GPUBindingCommandsMixin/[[bind_groups]]}} entry.
 </dl>
 
 ## Bind Groups ## {#programmable-passes-bind-groups}
@@ -10624,9 +10643,9 @@ It must only be included by interfaces which also include those mixins.
     [=Device timeline=] steps:
 
     1. For each |stage| in [{{GPUShaderStage/VERTEX}}, {{GPUShaderStage/FRAGMENT}}, {{GPUShaderStage/COMPUTE}}]:
-        1. Let |bufferBindings| be a [=list=] of ({{GPUBufferBinding}}, `boolean`) pairs,
+        1. Let |bufferBindings| be a [=list=] of ({{GPUBufferBinding}}, {{boolean}}) pairs,
             where the latter indicates whether the resource was used as writable.
-        1. Let |textureViews| be a [=list=] of ({{GPUTextureView}}, `boolean`) pairs,
+        1. Let |textureViews| be a [=list=] of ({{GPUTextureView}}, {{boolean}}) pairs,
             where the latter indicates whether the resource was used as writable.
         1. For each pair of ({{GPUIndex32}} |bindGroupIndex|, {{GPUBindGroupLayout}} |bindGroupLayout|) in
             |pipeline|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}:
@@ -10641,7 +10660,7 @@ It must only be included by interfaces which also include those mixins.
                 {{GPUBufferBinding}} |resource|) in |bufferRanges|, in which
                 |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/visibility}} contains |stage|:
                 1. Let |resourceWritable| be (|bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} == {{GPUBufferBindingType/"storage"}}).
-                1. For each pair ({{GPUBufferBinding}} |pastResource|, `boolean` |pastResourceWritable|) in |bufferBindings|:
+                1. For each pair ({{GPUBufferBinding}} |pastResource|, {{boolean}} |pastResourceWritable|) in |bufferBindings|:
                     1. If (|resourceWritable| or |pastResourceWritable|) is true, and
                         |pastResource| and |resource| are [=buffer-binding-aliasing=], return `true`.
                 1. [=list/append|Append=] (|resource|, |resourceWritable|) to |bufferBindings|.
@@ -10653,7 +10672,7 @@ It must only be included by interfaces which also include those mixins.
                     |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}}
                     is a writable access mode.
                 1. If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not [=map/exist|provided=], **continue**.
-                1. For each pair ({{GPUTextureView}} |pastResource|, `boolean` |pastResourceWritable|) in |textureViews|,
+                1. For each pair ({{GPUTextureView}} |pastResource|, {{boolean}} |pastResourceWritable|) in |textureViews|,
                     1. If (|resourceWritable| or |pastResourceWritable|) is true, and
                         |pastResource| and |resource| is [=texture-view-aliasing=], return `true`.
                 1. [=list/append|Append=] (|resource|, |resourceWritable|) to |textureViews|.
@@ -10685,15 +10704,15 @@ interface mixin GPUDebugCommandsMixin {
 {{GPUObjectBase}} and {{GPUCommandsMixin}} members on the same object.
 It must only be included by interfaces which also include those mixins.
 
-{{GPUDebugCommandsMixin}} adds the following internal slots to interfaces which include it:
+{{GPUDebugCommandsMixin}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUDebugCommandsMixin>
+<dl dfn-type=attribute dfn-for=GPUDebugCommandsMixin data-timeline=device>
     : <dfn>\[[debug_group_stack]]</dfn>, of type [=stack=]&lt;{{USVString}}&gt;
     ::
         A stack of active debug group labels.
 </dl>
 
-{{GPUDebugCommandsMixin}} adds the following methods to interfaces which include it:
+{{GPUDebugCommandsMixin}} has the following methods:
 
 <dl dfn-type=method dfn-for=GPUDebugCommandsMixin>
     : <dfn>pushDebugGroup(groupLabel)</dfn>
@@ -10803,20 +10822,20 @@ GPUComputePassEncoder includes GPUDebugCommandsMixin;
 GPUComputePassEncoder includes GPUBindingCommandsMixin;
 </script>
 
-{{GPUComputePassEncoder}} has the following internal slots:
+{{GPUComputePassEncoder}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUComputePassEncoder>
+<dl dfn-type=attribute dfn-for=GPUComputePassEncoder data-timeline=device>
     : <dfn>\[[command_encoder]]</dfn>, of type {{GPUCommandEncoder}}, readonly
     ::
         The {{GPUCommandEncoder}} that created this compute pass encoder.
 
-    : <dfn>\[[pipeline]]</dfn>, of type {{GPUComputePipeline}}, readonly
-    ::
-        The current {{GPUComputePipeline}}, initially `null`.
-
     : <dfn>\[[endTimestampWrite]]</dfn>, of type [=GPU command=]?, readonly, defaulting to `null`
     ::
         [=GPU command=], if any, writing a timestamp when the pass ends.
+
+    : <dfn>\[[pipeline]]</dfn>, of type {{GPUComputePipeline}}, initially `null`
+    ::
+        The current {{GPUComputePipeline}}.
 </dl>
 
 ### Compute Pass Encoder Creation ### {#compute-pass-encoder-creation}
@@ -11121,7 +11140,7 @@ GPURenderPassEncoder includes GPUBindingCommandsMixin;
 GPURenderPassEncoder includes GPURenderCommandsMixin;
 </script>
 
-{{GPURenderPassEncoder}} has the following internal slots used for validation while encoding:
+{{GPURenderPassEncoder}} has the following [=device timeline properties=]:
 
 <dl dfn-type=attribute dfn-for=GPURenderPassEncoder>
     : <dfn>\[[command_encoder]]</dfn>, of type {{GPUCommandEncoder}}, readonly
@@ -11139,10 +11158,6 @@ GPURenderPassEncoder includes GPURenderCommandsMixin;
         The {{GPUQuerySet}} to store occlusion query results for the pass, which is initialized with
         {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/occlusionQuerySet}} at pass creation time.
 
-    : <dfn>\[[occlusion_query_active]]</dfn>, of type {{boolean}}
-    ::
-        Whether the pass's {{GPURenderPassEncoder/[[occlusion_query_set]]}} is being written.
-
     : <dfn>\[[endTimestampWrite]]</dfn>, of type [=GPU command=]?, readonly, defaulting to `null`
     ::
         [=GPU command=], if any, writing a timestamp when the pass ends.
@@ -11150,14 +11165,18 @@ GPURenderPassEncoder includes GPURenderCommandsMixin;
     : <dfn>\[[maxDrawCount]]</dfn> of type {{GPUSize64}}, readonly
     ::
         The maximum number of draws allowed in this pass.
+
+    : <dfn>\[[occlusion_query_active]]</dfn>, of type {{boolean}}
+    ::
+        Whether the pass's {{GPURenderPassEncoder/[[occlusion_query_set]]}} is being written.
 </dl>
 
 When executing encoded render pass commands as part of a {{GPUCommandBuffer}}, an internal
 <dfn dfn>RenderState</dfn> object is used to track the current state required for rendering.
 
-[=RenderState=] contains the following internal slots used for execution of rendering commands:
+[=RenderState=] has the following [=queue timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=RenderState>
+<dl dfn-type=attribute dfn-for=RenderState data-timeline=queue>
     : <dfn>\[[occlusionQueryIndex]]</dfn>, of type {{GPUSize32}}
     ::
         The index into {{GPURenderPassEncoder/[[occlusion_query_set]]}} at which to store the
@@ -11879,28 +11898,28 @@ interface mixin GPURenderCommandsMixin {
 {{GPUObjectBase}}, {{GPUCommandsMixin}}, and {{GPUBindingCommandsMixin}} members on the same object.
 It must only be included by interfaces which also include those mixins.
 
-{{GPURenderCommandsMixin}} has the following internal slots:
+{{GPURenderCommandsMixin}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPURenderCommandsMixin>
+<dl dfn-type=attribute dfn-for=GPURenderCommandsMixin data-timeline=device>
     : <dfn>\[[layout]]</dfn>, of type {{GPURenderPassLayout}}, readonly
     ::
         The layout of the render pass.
 
-    : <dfn>\[[depthReadOnly]]</dfn>, of type boolean, readonly
+    : <dfn>\[[depthReadOnly]]</dfn>, of type {{boolean}}, readonly
     ::
         If `true`, indicates that the depth component is not modified.
 
-    : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean, readonly
+    : <dfn>\[[stencilReadOnly]]</dfn>, of type {{boolean}}, readonly
     ::
         If `true`, indicates that the stencil component is not modified.
 
-    : <dfn>\[[pipeline]]</dfn>, of type {{GPURenderPipeline}}
+    : <dfn>\[[pipeline]]</dfn>, of type {{GPURenderPipeline}}, initially `null`
     ::
-        The current {{GPURenderPipeline}}, initially `null`.
+        The current {{GPURenderPipeline}}.
 
-    : <dfn>\[[index_buffer]]</dfn>, of type {{GPUBuffer}}
+    : <dfn>\[[index_buffer]]</dfn>, of type {{GPUBuffer}}, initially `null`
     ::
-        The current buffer to read index data from, initially `null`.
+        The current buffer to read index data from.
 
     : <dfn>\[[index_format]]</dfn>, of type {{GPUIndexFormat}}
     ::
@@ -11915,14 +11934,13 @@ It must only be included by interfaces which also include those mixins.
         The size in bytes of the section of {{GPURenderCommandsMixin/[[index_buffer]]}} currently set,
         initially `0`.
 
-    : <dfn>\[[vertex_buffers]]</dfn>, of type [=ordered map=]&lt;slot, {{GPUBuffer}}&gt;
+    : <dfn>\[[vertex_buffers]]</dfn>, of type [=ordered map=]&lt;slot, {{GPUBuffer}}&gt;, initially empty
     ::
-        The current {{GPUBuffer}}s to read vertex data from for each slot, initially empty.
+        The current {{GPUBuffer}}s to read vertex data from for each slot.
 
-    : <dfn>\[[vertex_buffer_sizes]]</dfn>, of type [=ordered map=]&lt;slot, {{GPUSize64}}&gt;
+    : <dfn>\[[vertex_buffer_sizes]]</dfn>, of type [=ordered map=]&lt;slot, {{GPUSize64}}&gt;, initially empty
     ::
-        The size in bytes of the section of {{GPUBuffer}} currently set for each slot, initially
-        empty.
+        The size in bytes of the section of {{GPUBuffer}} currently set for each slot.
 
     : <dfn>\[[drawCount]]</dfn>, of type {{GPUSize64}}
     ::
@@ -12801,11 +12819,11 @@ GPURenderBundle includes GPUObjectBase;
     ::
         The layout of the render bundle.
 
-    : <dfn>\[[depthReadOnly]]</dfn>, of type boolean
+    : <dfn>\[[depthReadOnly]]</dfn>, of type {{boolean}}
     ::
         If `true`, indicates that the depth component is not modified by executing this render bundle.
 
-    : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean
+    : <dfn>\[[stencilReadOnly]]</dfn>, of type {{boolean}}
     ::
         If `true`, indicates that the stencil component is not modified by executing this render bundle.
 
@@ -13330,11 +13348,13 @@ GPUQueue includes GPUObjectBase;
                                 : {{GPUExternalTexture}} |et|
                                 :: |et|.{{GPUExternalTexture/[[expired]]}} must be `false`.
                                 : {{GPUQuerySet}} |qs|
-                                :: |qs| must be in the [=query set state/available=] state.
-                                    For occlusion queries, the {{GPURenderPassDescriptor/occlusionQuerySet}}
-                                    in {{GPUCommandEncoder/beginRenderPass()}} is not "used" unless
-                                    it is also used by {{GPURenderPassEncoder/beginOcclusionQuery()}}.
+                                :: |qs|.{{GPUQuerySet/[[destroyed]]}} must be `false`.
                             </dl>
+
+                            Note:
+                            For occlusion queries, the {{GPURenderPassDescriptor/occlusionQuerySet}}
+                            in {{GPUCommandEncoder/beginRenderPass()}} is not "used" unless
+                            it is also used by {{GPURenderPassEncoder/beginOcclusionQuery()}}.
                     </div>
 
                 1. For each |commandBuffer| in |commandBuffers|:
@@ -13410,9 +13430,9 @@ interface GPUQuerySet {
 GPUQuerySet includes GPUObjectBase;
 </script>
 
-{{GPUQuerySet}} has the following attributes:
+{{GPUQuerySet}} has the following [=immutable properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUQuerySet>
+<dl dfn-type=attribute dfn-for=GPUQuerySet data-timeline=const>
     : <dfn>type</dfn>
     ::
         The type of the queries managed by this {{GPUQuerySet}}.
@@ -13422,22 +13442,13 @@ GPUQuerySet includes GPUObjectBase;
         The number of queries managed by this {{GPUQuerySet}}.
 </dl>
 
-{{GPUQuerySet}} has the following internal slots:
+{{GPUQuerySet}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUQuerySet>
-    : <dfn>\[[state]]</dfn>, of type [=query set state=]
+<dl dfn-type=attribute dfn-for=GPUQuerySet data-timeline=device>
+    : <dfn>\[[destroyed]]</dfn>, of type {{boolean}}, initially `false`
     ::
-        The current state of the {{GPUQuerySet}}.
-</dl>
-
-Each {{GPUQuerySet}} has a current <dfn dfn>query set state</dfn> on the [=Device timeline=]
-which is one of the following:
-
-<dl dfn-type=dfn dfn-for="query set state">
-    : "<dfn>available</dfn>"
-    :: The {{GPUQuerySet}} is available for GPU operations on its content.
-    : "<dfn>destroyed</dfn>"
-    :: The {{GPUQuerySet}} is no longer available for any operations except {{GPUQuerySet/destroy}}.
+        If the query set is destroyed, it can no longer be used in any operation,
+        and its underlying memory can be freed.
 </dl>
 
 ### QuerySet Creation ### {#queryset-creation}
@@ -13500,8 +13511,6 @@ dictionary GPUQuerySetDescriptor
                         - |this| must not be [$invalid|lost$].
                         - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 4096.
                     </div>
-
-                1. Set |q|.{{GPUQuerySet/[[state]]}} to [=query set state/available=].
             </div>
         </div>
 </dl>
@@ -13517,10 +13526,12 @@ dictionary GPUQuerySetDescriptor
     </pre>
 </div>
 
-### QuerySet Destruction ### {#queryset-destruction}
+### Query Set Destruction ### {#queryset-destruction}
 
 An application that no longer requires a {{GPUQuerySet}} can choose to lose access to it before
 garbage collection by calling {{GPUQuerySet/destroy()}}.
+
+{{GPUQuerySet}} has the following methods:
 
 <dl dfn-type=method dfn-for=GPUQuerySet>
     : <dfn>destroy()</dfn>
@@ -13535,7 +13546,12 @@ garbage collection by calling {{GPUQuerySet/destroy()}}.
 
                 [=Content timeline=] steps:
 
-                1. Set |this|.{{GPUQuerySet/[[state]]}} to [=query set state/destroyed=].
+                1. Issue the subsequent steps on the [=device timeline=].
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
+                1. Set |this|.{{GPUQuerySet/[[destroyed]]}} to `true`.
             </div>
         </div>
 </dl>
@@ -13675,17 +13691,13 @@ interface GPUCanvasContext {
 };
 </script>
 
-{{GPUCanvasContext}} has the following attributes:
+{{GPUCanvasContext}} has the following [=content timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUCanvasContext>
+<dl dfn-type=attribute dfn-for=GPUCanvasContext data-timeline=content>
     : <dfn>canvas</dfn>
     ::
         The canvas this context was created from.
-</dl>
 
-{{GPUCanvasContext}} has the following internal slots:
-
-<dl dfn-type=attribute dfn-for=GPUCanvasContext>
     : <dfn>\[[configuration]]</dfn>, of type {{GPUCanvasConfiguration}}?, initially `null`
     ::
         The options this context is currently configured with.
@@ -14344,9 +14356,9 @@ this possibility, using only the error's {{GPUError/message}} when possible, and
 `instanceof`. Use `error.constructor.name` when it's necessary to serialize an error (e.g. into
 JSON, for a debug report).
 
-{{GPUError}} has the following attributes:
+{{GPUError}} has the following [=immutable properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUError>
+<dl dfn-type=attribute dfn-for=GPUError data-timeline=const>
     : <dfn>message</dfn>
     ::
         A human-readable, [=localizable text=] message providing information about the error that
@@ -14444,8 +14456,9 @@ A <dfn dfn>GPU error scope</dfn> captures {{GPUError}}s that were generated whil
 [=GPU error scope=] was current. Error scopes are used to isolate errors that occur within a set
 of WebGPU calls, typically for debugging purposes or to make an operation more fault tolerant.
 
-[=GPU error scope=] has the following internal slots:
-<dl dfn-type=attribute dfn-for="GPU error scope">
+[=GPU error scope=] has the following [=device timeline properties=]:
+
+<dl dfn-type=attribute dfn-for="GPU error scope" data-timeline=device>
     : <dfn>\[[errors]]</dfn>, of type [=list=]&lt;{{GPUError}}&gt;, initially []
     ::
         The {{GPUError}}s, if any, observed while the [=GPU error scope=] was current.
@@ -14485,9 +14498,9 @@ partial interface GPUDevice {
         Indicates that the error scope will catch a {{GPUInternalError}}.
 </dl>
 
-{{GPUDevice}} has the following internal slots:
+{{GPUDevice}} has the following [=device timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUDevice>
+<dl dfn-type=attribute dfn-for=GPUDevice data-timeline=device>
     : <dfn>\[[errorScopeStack]]</dfn>, of type [=stack=]&lt;[=GPU error scope=]&gt;
     ::
         A [=stack=] of [=GPU error scopes=] that have been pushed to the {{GPUDevice}}.
@@ -14733,7 +14746,7 @@ dictionary GPUUncapturedErrorEventInit : EventInit {
 
 {{GPUUncapturedErrorEvent}} has the following attributes:
 
-<dl dfn-type=attribute dfn-for=GPUUncapturedErrorEvent>
+<dl dfn-type=attribute dfn-for=GPUUncapturedErrorEvent data-timeline=content>
     : <dfn>error</dfn>
     ::
         A [=slot-backed attribute=] holding an object representing the error that was uncaptured.
@@ -14747,9 +14760,9 @@ partial interface GPUDevice {
 };
 </script>
 
-{{GPUDevice}} has the following attributes:
+{{GPUDevice}} has the following [=content timeline properties=]:
 
-<dl dfn-type=attribute dfn-for=GPUDevice>
+<dl dfn-type=attribute dfn-for=GPUDevice data-timeline=content>
     : <dfn>onuncapturederror</dfn>
     ::
         An [=event handler IDL attribute=] for the {{GPUDevice/uncapturederror}} event type.


### PR DESCRIPTION
- Add timelines (content/device/queue/immutable) to all attributes/slots
    - Move texture/queryset `destroy()` steps to device timeline
    - (Didn't add timelines to `<dl>`s for dictionaries, enum values, and consts, because they're effectively always immutable. Methods `<dl>`s of course shouldn't have them because methods have timeline steps inside of them.)
- Normalize most language for properties/attributes/internal slots
- Simplify `GPUQuerySet.[[state]]` into a boolean
- Order readonly properties first
- References to `{{boolean}}`
- Minor text clarifications

(Unfortunately will have some minor merge conflicts with other PRs I've opened.)