### PR TITLE
[editorial] Simplify attachment usage validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1077,10 +1077,16 @@ We define <dfn dfn>subresource</dfn> to be either a whole buffer, or a [=texture
     a <dfn dfn>compatible usage list</dfn> if (and only if) it satisfies any of the following rules:
 
     - Each usage in |U| is [=internal usage/input=], [=internal usage/constant=], [=internal usage/storage-read=], or [=internal usage/attachment-read=].
+
     - Each usage in |U| is [=internal usage/storage=].
-        Multiple such usages are allowed even though they are writable;
-        this is the <dfn dfn>usage scope storage exception</dfn>.
-    - |U| contains exactly one element: [=internal usage/attachment=].
+
+        Multiple such usages are allowed even though they are writable.
+        This is the [=usage scope storage exception=].
+
+    - Each usage in |U| is [=internal usage/attachment=].
+
+        Multiple such usages are allowed even though they are writable.
+        This is the [=usage scope attachment exception=].
 </div>
 
 Enforcing that the usages are only combined into a [=compatible usage list=]
@@ -1110,14 +1116,26 @@ WebGPU more likely to run without modification on different platforms.
 </div>
 
 <div class=example heading>
-    The following operations are allowed by the [=usage scope storage exception=]:
+    The <dfn dfn>usage scope storage exception</dfn> allows two cases that would
+    not be allowed otherwise:
 
     - A buffer or texture may be bound as [=internal usage/storage=] to two
         different draw calls in a render pass.
     - Disjoint ranges of a single buffer may be bound to two different binding
         points as [=internal usage/storage=].
 
-        This case is governed by "[$Encoder bind groups alias a writable resource$]".
+        Overlapping ranges may *not* be bound to a single dispatch/draw call;
+        this is checked by "[$Encoder bind groups alias a writable resource$]".
+</div>
+
+<div class=example heading>
+    The <dfn dfn>usage scope attachment exception</dfn> allows a texture subresource
+    to be used as [=internal usage/attachment=] more than once.
+    This is necessary to allow disjoint slices of 3D textures
+    to be bound as different attachments to a single render pass.
+
+    One slice may *not* be bound twice for two different attachments;
+    this is checked by {{GPUCommandEncoder/beginRenderPass()}}.
 </div>
 
 ### Synchronization ### {#programming-model-synchronization}
@@ -9799,9 +9817,6 @@ dictionary GPUCommandEncoderDescriptor
                 1. [$usage scope/Add$] each [=texture subresource=] in |attachmentRegions|
                     to |pass|.{{GPURenderCommandsMixin/[[usage scope]]}}
                     with usage [=internal usage/attachment=].
-
-                    If a subresource is seen more than once, consider it used only once.
-                    (Attachments are already checked for overlaps in the validation rules above.)
                 1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}},
                     or `null` if not [=map/exist|provided=].
                 1. If |depthStencilAttachment| is not `null`:


### PR DESCRIPTION
Resolves https://github.com/gpuweb/gpuweb/pull/4797#discussion_r1693283722

Previously, the usage scope validation is sort of described as a "single writer multiple reader" check, but with an exception to this rule that allows races between draw calls on writable storage buffers/textures.

The rule `U contains exactly one element: attachment.` is a "single writer" case which looks like it should disallow overlapping render pass attachments - it used to, _however_, `beginRenderPass()` added its _own_ exception which opts it out of this rule, in order to implement render-to-3d-slice (#4252 + #4592): `If a subresource is seen more than once, consider it used only once. (Attachments are already checked for overlaps in the validation rules above.)`

Changing attachments to match storage makes usage scope validation more self-consistent.