### PR TITLE
Clarify const-expression eval and type checking

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5200,9 +5200,12 @@ A const-expression |E| [=behavioral requirement|will=] be evaluated if and only 
 * |E| is [=top-level expression=], 
 * |E| is a [=subexpression=] of an expression |OuterE|, and |OuterE|
     [=behavioral requirement|will=] be evaluated, and evaluation of |OuterE|
-    requires |E| to be evaluated, or
+    requires |E| to be evaluated,
 * |E| is a [=subexpression=] of an expression |OuterE| such that evaluation of
-    |E| is required to determine the [=static type=] of |OuterE|.
+    |E| is required to determine the [=static type=] of |OuterE|, or
+* |E| is a [=subexpression=] of an expression |OuterE| such that |OuterE| requires
+    |E| to be evaluated to produce a [=shader-creation error=]
+    (e.g. [[#arithmetic-expr|integer division]]).
 
 Note: The evaluation rule implies that short-circuiting operators `&&` and `||` guard evaluation of their right-hand
 side subexpressions unless there is a [=subexpression=] that requires evaluation to determine
@@ -5279,10 +5282,13 @@ If an [=override-declaration=] has its value substituted via the API, its
 initializer expression, if present, will not be evaluated.
 Otherwise, an override-expression |E| [=behavioral requirement|will=] be
 evaluated if and only if:
-* |E| is [=top-level expression=] (after value substitution), or
+* |E| is [=top-level expression=] (after value substitution),
 * |E| is a [=subexpression=] of an expression |OuterE|, and |OuterE|
     [=behavioral requirement|will=] be evaluated, and evaluation of |OuterE|
-    requires |E| to be evaluated.
+    requires |E| to be evaluated, or
+* |E| is a [=subexpression=] of an expression |OuterE| such that |OuterE| requires
+    |E| to be evaluated to produce a [=pipeline-creation error=]
+    (e.g. [[#arithmetic-expr|integer division]]).
 
 Note: Not all override-expressions may be usable as the initializer for an
 [=override-declaration=], because such initializers must [=type rules|resolve=]

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2169,6 +2169,8 @@ A [=type rule=] has two parts:
     * For expressions:
         * Type assertions for subexpressions, when it has subexpressions.
              Each may be satisfied directly, or via a [=feasible automatic conversion=] (as defined in [[#conversion-rank]]).
+             WGSL [=behavioral requirement|will=] evaluate all [=const-expressions=] required
+             to determine the [=static types=] of a program.
         * How the expression is used in a statement.
     * For statements:
         * The syntactic form of the statement, and
@@ -5195,13 +5197,16 @@ The type of a `const` expression [=shader-creation error|must=] [=type rules|res
 Note: [=type/abstract|Abstract types=] can be the inferred type of a const-expression.
 
 A const-expression |E| [=behavioral requirement|will=] be evaluated if and only if:
-* |E| is [=top-level expression=], or
+* |E| is [=top-level expression=], 
 * |E| is a [=subexpression=] of an expression |OuterE|, and |OuterE|
     [=behavioral requirement|will=] be evaluated, and evaluation of |OuterE|
-    requires |E| to be evaluated.
+    requires |E| to be evaluated, or
+* |E| is [=subexpression=] of an expression |OuterE| such that evaluation of
+    |E| is required to determine the [=static type=] of |OuterE|.
 
 Note: The evaluation rule implies that short-circuiting operators `&&` and `||` guard evaluation of their right-hand
-side subexpressions.
+side subexpressions unless their is a [=subexpression=] that requires evaluation to determine
+a [=static type=].
 
 A const-expression may be evaluated by the CPU implementing the WebGPU API methods.
 Therefore accuracy requirements for operations on [=AbstractFloat=] values are *no more strict* than
@@ -5244,6 +5249,16 @@ Example:  `false && (10i < i32(5 * 1000 * 1000 * 1000))` is analyzed as follows:
     the left-hand side evaluates to `false`, and so the right-hand side is *not evaluated*.
 * Evaluation of i32(5 * 1000 * 1000 * 1000) would have caused a [=shader-creation error=]
     because the [=AbstractInt=] value 5000000000 overflows the [=i32=] type.
+
+Example: `false && array<u32, 1 + 2>(0, 1, 2)[0] == 0`
+* The entire expression is a const-expression.
+* Type checking requires the `e1 : bool && e2 : bool`:
+    * `false` is a bool type.
+    * Type checking proceeds on the right-hand side and eventually evaluates `1 + 2`
+        in the array element count expression.
+* `1 + 2` is evaluates to an i32 with a value of `3`.
+    * The array is typed `array<u32, 3i>`.
+* Neither the array access expression nor the equality operator are evaluated.
 
 ### `override` Expressions ### {#override-expr}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5201,7 +5201,7 @@ A const-expression |E| [=behavioral requirement|will=] be evaluated if and only 
 * |E| is a [=subexpression=] of an expression |OuterE|, and |OuterE|
     [=behavioral requirement|will=] be evaluated, and evaluation of |OuterE|
     requires |E| to be evaluated, or
-* |E| is [=subexpression=] of an expression |OuterE| such that evaluation of
+* |E| is a [=subexpression=] of an expression |OuterE| such that evaluation of
     |E| is required to determine the [=static type=] of |OuterE|.
 
 Note: The evaluation rule implies that short-circuiting operators `&&` and `||` guard evaluation of their right-hand

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5256,7 +5256,7 @@ Example: `false && array<u32, 1 + 2>(0, 1, 2)[0] == 0`
     * `false` is a bool value.
     * Type checking proceeds on the right-hand side and eventually evaluates `1 + 2`
         in the array element count expression.
-* `1 + 2` is evaluates to an i32 with a value of `3`.
+* `1 + 2` evaluates to an i32 value of `3`.
     * The array is typed `array<u32, 3i>`.
 * Neither the array access expression nor the equality operator are evaluated.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5205,7 +5205,7 @@ A const-expression |E| [=behavioral requirement|will=] be evaluated if and only 
     |E| is required to determine the [=static type=] of |OuterE|.
 
 Note: The evaluation rule implies that short-circuiting operators `&&` and `||` guard evaluation of their right-hand
-side subexpressions unless their is a [=subexpression=] that requires evaluation to determine
+side subexpressions unless there is a [=subexpression=] that requires evaluation to determine
 a [=static type=].
 
 A const-expression may be evaluated by the CPU implementing the WebGPU API methods.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5253,7 +5253,7 @@ Example:  `false && (10i < i32(5 * 1000 * 1000 * 1000))` is analyzed as follows:
 Example: `false && array<u32, 1 + 2>(0, 1, 2)[0] == 0`
 * The entire expression is a const-expression.
 * Type checking requires the `e1 : bool && e2 : bool`:
-    * `false` is a bool type.
+    * `false` is a bool value.
     * Type checking proceeds on the right-hand side and eventually evaluates `1 + 2`
         in the array element count expression.
 * `1 + 2` is evaluates to an i32 with a value of `3`.


### PR DESCRIPTION
Fixes #4551
Fixes #4558

* Type checking occurs on all expressions and will evaluate any const-expression required to determine a static type
* Const-expressions will additionally be evaluated if they are required to determine a static type