### PR TITLE
Add shader module creation validation for features

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6622,6 +6622,9 @@ dictionary GPUShaderModuleDescriptor
                     <div class=validusage>
                         - |this| must not be [$invalid|lost$].
                         - |error| must not be a [=shader-creation error|shader-creation=] [=program error=].
+                        - For each `enable` extension in |descriptor|.{{GPUShaderModuleDescriptor/code}},
+                            the corresponding {{GPUFeatureName}} must be enabled
+                            (see the [[#feature-index|Feature Index]]).
                     </div>
 
                     Note: [=Uncategorized errors=] cannot arise from shader module creation.


### PR DESCRIPTION
Validation of GPUShaderModule was missing the check that the corresponding feature for each enable extension was enabled. This requirement was listed in the features section only.