### PR TITLE
Proposal: expose GPUAdapterInfo from GPUDevice

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1832,7 +1832,9 @@ agent's discretion which values to reveal, and it is likely that on some devices
 will be populated. As such, applications **must** be able to handle any possible {{GPUAdapterInfo}} values,
 including the absence of those values.
 
-The information exposed by a {{GPUAdapter}} or {{GPUDevice}} (for the adapter that created this device) is immutable:
+The {{GPUAdapterInfo}} for an adapter is exposed via {{GPUAdapter/info|GPUAdapter.info}}
+and {{GPUDevice/adapterInfo|GPUDevice.adapterInfo}}).
+This info is immutable: 
 for a given adapter, each {{GPUAdapterInfo}} attribute will return the same value every time it's accessed.
 
 Note:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1832,8 +1832,8 @@ agent's discretion which values to reveal, and it is likely that on some devices
 will be populated. As such, applications **must** be able to handle any possible {{GPUAdapterInfo}} values,
 including the absence of those values.
 
-The information exposed by a {{GPUAdapter}} is immutable: for a given adapter, each {{GPUAdapterInfo}}
-attribute will return the same value every time it's accessed.
+The information exposed by a {{GPUAdapter}} or {{GPUDevice}} (for the adapter that created this device) is immutable:
+for a given adapter, each {{GPUAdapterInfo}} attribute will return the same value every time it's accessed.
 
 Note:
 Though the {{GPUAdapterInfo}} attributes are immutable *once accessed*, an implementation may delay the decision on
@@ -2778,6 +2778,7 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
+    [SameObject] readonly attribute GPUAdapterInfo adapterInfo;
 
     [SameObject] readonly attribute GPUQueue queue;
 
@@ -2821,6 +2822,26 @@ GPUDevice includes GPUObjectBase;
     : <dfn>queue</dfn>
     ::
         The primary {{GPUQueue}} for this device.
+
+    : <dfn>adapterInfo</dfn>
+    ::
+        Information about the physical adapter which created the [=device=] that this {{GPUDevice}} refers to.
+
+        For a given {{GPUDevice}}, the {{GPUAdapterInfo}} values exposed are constant over time.
+
+        The same object is returned each time. To create that object for the first time:
+
+        <div algorithm=GPUDevice.adapterInfo>
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} |this|.
+
+                **Returns:** {{GPUAdapterInfo}}
+
+                [=Content timeline=] steps:
+
+                1. Return a [$new adapter info$] for |this|.{{GPUObjectBase/[[device]]}}.{{device/[[adapter]]}}.
+            </div>
+        </div>
 </dl>
 
 The {{GPUObjectBase/[[device]]}} for a {{GPUDevice}} is the [=device=] that the {{GPUDevice}} refers


### PR DESCRIPTION
This PR is a proposal to enable accessing the GPUAdapterInfo of the physical adapter that create a GPUDevice by using GPUDevice.adapterInfo.

Issue: #4810