### PR TITLE
Fixed two "it's" -> "its" typos.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3694,7 +3694,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
     : <dfn>unmap()</dfn>
     ::
-        Unmaps the mapped range of the {{GPUBuffer}} and makes it's contents available for use by the
+        Unmaps the mapped range of the {{GPUBuffer}} and makes its contents available for use by the
         GPU again.
 
         <div algorithm=GPUBuffer.unmap>
@@ -6132,7 +6132,7 @@ A {{GPUBindGroupEntry}} object also has the following internal slots:
 <dl dfn-type=attribute dfn-for=GPUBindGroupEntry>
     : <dfn>\[[prevalidatedSize]]</dfn>, of type boolean
     ::
-        Whether or not this binding entry had it's buffer size validated at time of creation.
+        Whether or not this binding entry had its buffer size validated at time of creation.
 </dl>
 
 <script type=idl>


### PR DESCRIPTION
Fixed two "it's" -> "its" typos - 
Learning to do this kind of stuff.