### PR TITLE
wgsl: define 'extended real' numbers

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -19,6 +19,9 @@ Text Macro: ALLINTEGRALDECL S is AbstractInt, i32, or u32<br>T is S or vecN&lt;S
 Text Macro: ALLFLOATINGDECL S is AbstractFloat, f32, or f16<br>T is S or vecN&lt;S&gt;
 Text Macro: ALLNUMERICDECL S is AbstractInt, AbstractFloat, i32, u32, f32, or f16<br>T is S, or vecN&lt;S&gt;
 Text Macro: ALLSIGNEDNUMERICDECL S is AbstractInt, AbstractFloat, i32, f32, or f16<br>T is S, or vecN&lt;S&gt;
+Text Macro: INF &infin;
+Text Macro: PINF &plus;&infin;
+Text Macro: NINF &minus;&infin;
 Ignored Vars: i, c0, e, e1, e2, e3, edge, eN, p, s1, s2, sn, AS, AM, N, newbits, M, C, R, v, Stride, Offset, Align, Extent, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
@@ -481,7 +484,7 @@ Following syntax notation describes the conventions of the syntactic grammar of 
 
 <dfn noexport>Angles</dfn>:
 * By convention, angles are measured in radians.
-* The reference ray for measuring angles is the ray from the origin (0,0) toward (+&infin;,0).
+* The reference ray for measuring angles is the ray from the origin (0,0) toward ([PINF],0).
 * Let &theta; be the angle subtended by a comparison ray and the reference ray.
     Then &theta; increases as the comparison ray moves counterclockwise.
 * There are 2 &pi; radians in a complete circle.
@@ -508,28 +511,32 @@ sense. Specifically:
 Then the area |a| is a hyperbolic angle such that |x| is the hyperbolic cosine of |a|, and
 |y| is the hyperbolic sine of |a|.
 
+The <dfn>extended real</dfn> numbers
+(also known as the affinely extended real numbers) is the set of real numbers together with [PINF] and [NINF].
+Computers use [[#floating-point-types|floating point types]] to approximately represent the extended reals, including values for both infinities.
+
 An <dfn noexport>interval</dfn> is a contiguous set of numbers with a lower and upper bound.
 Depending on context, they are sets of integers, floating point numbers, or real numbers.
 * The closed interval [*a*,*b*] is the set of numbers *x* such that *a* &le; *x* &le; *b*.
 * The half-open interval [*a*,*b*) is the set of numbers *x* such that *a* &le; *x* &lt; *b*.
 * The half-open interval (*a*,*b*] is the set of numbers *x* such that *a* &lt; *x* &le; *b*.
 
-The <dfn noexport>floor expression</dfn> is defined over real numbers |x| extended with &plus;&infin; and &minus;&infin;:
+The <dfn noexport>floor expression</dfn> is defined for [=extended real=] numbers |x|:
 
-* &lfloor; &plus; &infin; &rfloor; = &plus;&infin;
-* &lfloor; &minus; &infin; &rfloor; = &minus;&infin;
+* &lfloor; [PINF] &rfloor; = [PINF]
+* &lfloor; [NINF] &rfloor; = [NINF]
 * for real number |x|, &lfloor;|x|&rfloor; = |k|, where |k| is the unique integer such that |k| &le; |x| &lt; |k|+1
 
-The <dfn noexport>ceiling expression</dfn> is defined over real numbers |x| extended with &plus;&infin; and &minus;&infin;:
+The <dfn noexport>ceiling expression</dfn> is defined for [=extended real=] numbers |x|:
 
-* &lceil; &plus;&infin; &rceil; = &plus;&infin;
-* &lceil; &minus;&infin; &rceil; = &minus;&infin;
+* &lceil; [PINF] &rceil; = [PINF]
+* &lceil; [NINF] &rceil; = [NINF]
 * for real number |x|, &lceil;|x|&rceil; = |k|, where |k| is the unique integer such that |k|-1 &lt; |x| &le; |k|
 
-The <dfn noexport>truncate</dfn> function is defined over real numbers |x| extended with &plus;&infin; and &minus;&infin;:
+The <dfn noexport>truncate</dfn> function is defined for [=extended real=] numbers |x|:
 
-* truncate(&plus;&infin;) = &plus;&infin;
-* truncate(&minus;&infin;) = &minus;&infin;
+* truncate([PINF]) = [PINF]
+* truncate([NINF]) = [NINF]
 * for real number |x|, computes the nearest whole number whose absolute value is less than or equal to the absolute value of |x|:
     * truncate(|x|) = &lfloor;|x|&rfloor; if |x| &ge; 0, and &lceil;|x|&rceil; if |x| &lt; 0.
 
@@ -12110,7 +12117,7 @@ the following differences:
         behaviors depending on whether the expression is
         a [=const-expression=], an [=override-expression=], or a [=runtime expression=].
     * IEEE-754 defines five kinds of exceptions:
-        * Invalid operation. These operations yield a NaN.  An example of an invalid operation is 0 &times; &infin;.
+        * Invalid operation. These operations yield a NaN.  An example of an invalid operation is 0 &times; [INF].
         * Division by zero. This occurs when an operation on finite operands is defined as having an exact infinite result.
             Examples are 1 &divide; 0, and log(0).
         * Overflow. See [[#floating-point-overflow]].
@@ -12167,11 +12174,11 @@ The final value of the expression is determined in two stages, via intermediate 
 From *X*, compute *X'* in *T* by rounding:
 * If *X* is in the finite range of *T* then *X'* is the result of rounding *X* up or down.
 * If *X* is NaN, then *X'* is NaN.
-* If *MAX(T)* &lt; *X* &lt; 2<sup>*EMAX(T)+1*</sup>, then either rounding direction is used: *X'* is *MAX(T)* or &plus;&infin;.
-* If 2<sup>*EMAX(T)+1*</sup> &le; *X*, then *X'* = &plus;&infin;.
+* If *MAX(T)* &lt; *X* &lt; 2<sup>*EMAX(T)+1*</sup>, then either rounding direction is used: *X'* is *MAX(T)* or [PINF].
+* If 2<sup>*EMAX(T)+1*</sup> &le; *X*, then *X'* = [PINF].
     * Note: This matches the [[!IEEE-754|IEEE-754]] rule.
-* If &minus;*MAX(T)* &gt; *X* &gt; &minus;2<sup>*EMAX(T)+1*</sup>, then either rounding direction is used: *X'* is &minus;*MAX(T)* or &minus;&infin;.
-* If &minus;2<sup>*EMAX(T)+1*</sup> &ge; *X*, then *X'* = &minus;&infin;.
+* If &minus;*MAX(T)* &gt; *X* &gt; &minus;2<sup>*EMAX(T)+1*</sup>, then either rounding direction is used: *X'* is &minus;*MAX(T)* or [NINF].
+* If &minus;2<sup>*EMAX(T)+1*</sup> &ge; *X*, then *X'* = [NINF].
     * Note: This matches the IEEE-754 rule.
 
 From *X'*, compute the final value of the expression, *X''*, or detect a program error:
@@ -13842,7 +13849,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
   <tr>
     <td>Description
     <td>Returns the inverse hyperbolic cosine (cosh<sup>-1</sup>) of `x`, as a [=hyperbolic angle=].<br>
-    That is, approximates `a` with 0 &le; a &le; &infin;, such that `cosh`(`a`) = `x`.
+    That is, approximates `a` with 0 &le; a &le; [INF], such that `cosh`(`a`) = `x`.
 
     [=Component-wise=] when `T` is a vector.
   <tr>


### PR DESCRIPTION
This will help when defining the domain of a numerical function.

Also, create [INF],[PINF],[NINF] macros to ensure consistent typography for infinities.

Issue: #2765