### PR TITLE
wsgl: remove TODO about acos, asin accuracy for f16

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12283,7 +12283,6 @@ the rules in [[#floating-point-overflow]] apply.
       <td>The worse of:
        * Absolute error 3.91&times;10<sup>-3</sup>
        * Inherited from `atan2(sqrt(1.0 - x * x), x)`
-          <p>TODO: check this with conformance tests
   <tr><td>`acosh(x)`<td colspan=2 style="text-align:left;">Inherited from `log(x + sqrt(x * x - 1.0))`
   <tr><td>`asin(x)`<td>
        The worse of:
@@ -12293,7 +12292,6 @@ the rules in [[#floating-point-overflow]] apply.
       <td>The worse of:
        * Absolute error 3.91&times;10<sup>-3</sup>
        * Inherited from `atan2(x, sqrt(1.0 - x * x))`
-          <p>TODO: check this with conformance tests
   <tr><td>`asinh(x)`<td colspan=2 style="text-align:left;">Inherited from `log(x + sqrt(x * x + 1.0))`
   <tr><td>`atan(x)`<td>4096 ULP<td>5 ULP
   <tr><td>`atan2(y, x)`<td>4096 ULP for `|x|` in the range [2<sup>-126</sup>, 2<sup>126</sup>], and `y` is finite and normal<td>5 ULP for `|x|` in the range [2<sup>-14</sup>, 2<sup>14</sup>], and `y` is finite and normal


### PR DESCRIPTION
Conformance tests now check the stated accuracy.