### PR TITLE
wsgl: clarify fp edge cases

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2524,7 +2524,7 @@ and with a numeric range and precision that may be larger than directly implemen
 WGSL defines two <dfn>abstract numeric types</dfn> for these evaluations:
 * The <dfn noexport>AbstractInt</dfn> type is the set of integers |i|, with -2<sup>63</sup> &leq; |i| &lt; 2<sup>63</sup>.
 * The <dfn noexport>AbstractFloat</dfn> type is the set of finite floating point numbers representable
-    in the [[!IEEE-754|IEEE-754]] binary64 (double precision) format.
+    in the [[!IEEE-754|IEEE-754]] [=ieee754/binary64=] (double precision) format.
 
 An evaluation of an expression in one of these types [=shader-creation
 error|must not=] overflow or produce an infinite or NaN value.
@@ -2725,11 +2725,11 @@ Note: [=AbstractInt=] is also an integer type.
 ### Floating Point Types ### {#floating-point-types}
 
 The <dfn noexport>f32</dfn> type is the set of 32-bit floating point values of the
-[[!IEEE-754|IEEE-754]] binary32 (single precision) format.
+[[!IEEE-754|IEEE-754]] [=ieee754/binary32=] (single precision) format.
 See [[#floating-point-evaluation]] for details.
 
 The <dfn noexport>f16</dfn> type is the set of 16-bit floating point values of the
-[[!IEEE-754|IEEE-754]] binary16 (half precision) format. It is a [=shader-creation error=]
+[[!IEEE-754|IEEE-754]] [=ieee754/binary16=] (half precision) format. It is a [=shader-creation error=]
 if the [=f16=] type is used unless the program contains the `enable f16;` directive to enable
 the [=extension/f16|f16 extension=]. See [[#floating-point-evaluation]] for details.
 
@@ -4208,10 +4208,10 @@ Note: The channel transfer function for 8snorm maps {-128,...,127} to the floati
   <tr><td>8sint<td>8<td>signed integer |v| &isinv; {-128,...,127}<td>i32<td> |v|<td> max(-128, min(127, `T`))
   <tr><td>16uint<td>16<td>unsigned integer |v| &isinv; {0,...,65535}<td>u32<td> |v|<td> min(65535, `T`)
   <tr><td>16sint<td>16<td>signed integer |v| &isinv; {-32768,...,32767}<td>i32<td> |v|<td> max(-32768, min(32767, `T`))
-  <tr><td>16float<td>16<td>[[!IEEE-754|IEEE-754]] binary16 16-bit floating point value |v|, with 1 sign bit, 5 exponent bits, 10 mantissa bits<td>f32<td>|v|<td>`quantizeToF16(T)`
+  <tr><td>16float<td>16<td>[[!IEEE-754|IEEE-754]] [=ieee754/binary16=] 16-bit floating point value |v|<td>f32<td>|v|<td>`quantizeToF16(T)`
   <tr><td>32uint<td>32<td>32-bit unsigned integer value |v|<td>u32<td>|v|<td>`T`
   <tr><td>32sint<td>32<td>32-bit signed integer value |v|<td>i32<td>|v|<td>`T`
-  <tr><td>32float<td>32<td>[[!IEEE-754|IEEE-754]] binary32 32-bit floating point value |v|<td>f32<td>|v|<td>`T`
+  <tr><td>32float<td>32<td>[[!IEEE-754|IEEE-754]] [=ieee754/binary32=] 32-bit floating point value |v|<td>f32<td>|v|<td>`T`
 </table>
 
 The texel formats listed in the
@@ -10454,7 +10454,7 @@ offset |k| of a host-shared buffer, then:
 
 Note: WGSL does not have a [=type/concrete=] [=64-bit integer=] type.
 
-A value |V| of type [=f32=] is represented in [[!IEEE-754|IEEE-754]] binary32 format.
+A value |V| of type [=f32=] is represented in [[!IEEE-754|IEEE-754]] [=ieee754/binary32=] format.
 It has one sign bit, 8 exponent bits, and 23 fraction bits.
 When |V| is placed at byte offset |k| of host-shared buffer, then:
    * Byte |k| contains bits 0 through 7 of the fraction.
@@ -10464,7 +10464,7 @@ When |V| is placed at byte offset |k| of host-shared buffer, then:
    * Bits 0 through 6 of byte |k|+3 contain bits 1 through 7 of the exponent.
    * Bit 7 of byte |k|+3 contains the sign bit.
 
-A value |V| of type [=f16=] is represented in [[!IEEE-754|IEEE-754]] binary16 format.
+A value |V| of type [=f16=] is represented in [[!IEEE-754|IEEE-754]] [=ieee754/binary16=] format.
 It has one sign bit, 5 exponent bits, and 10 fraction bits.
 When |V| is placed at byte offset |k| of host-shared buffer, then:
    * Byte |k| contains bits 0 through 7 of the fraction.
@@ -12578,9 +12578,9 @@ The accuracy of an [=AbstractFloat=] operation is as follows:
 depends critically on the underlying floating point type.
 
 The [=ULP=] for an [=AbstractFloat=] value assumes
-AbstractFloat is identical to the [[!IEEE-754|IEEE-754]] binary64 type.
+AbstractFloat is identical to the [[!IEEE-754|IEEE-754]] [=ieee754/binary64=] type.
 
-One [=ULP=] for an f32 value is 2<sup>29</sup> times larger than 1 ULP for an IEEE 754 binary64 value,
+One [=ULP=] for an f32 value is 2<sup>29</sup> times larger than 1 ULP for an IEEE-754 binary64 value,
 since the significand in the binary64 format is 29 bits longer than the significand in the f32 type.
 
 For example, suppose the true result value of an operation is |x|, but it is computed as <var>x'</var>.
@@ -12614,7 +12614,7 @@ In this section, a floating point type may be any of:
 * A hypothetical type corresponding to a binary format defined by the [[!IEEE-754|IEEE-754]]
     floating point standard.
 
-Note: Recall that the [=f32=] WGSL type corresponds to the IEEE-754 binary32 format, and the [=f16=] WGSL type corresponds to the IEEE-754 binary16 format.
+Note: Recall that the [=f32=] WGSL type corresponds to the IEEE-754 [=ieee754/binary32=] format, and the [=f16=] WGSL type corresponds to the IEEE-754 [=ieee754/binary16=] format.
 
 The <dfn noexport>scalar floating point to integral conversion</dfn> algorithm is:
 <blockquote algorithm="convert a float value to an integral value">
@@ -15068,7 +15068,7 @@ but a value may infer the type.
     Here, *bias* is the exponent bias of the floating point format:
     * 15 for `f16`
     * 127 for `f32`
-    * 1023 for AbstractFloat, when AbstractFloat is [[!IEEE-754|IEEE-754]] binary64
+    * 1023 for AbstractFloat, when AbstractFloat is [[!IEEE-754|IEEE-754]] [=ieee754/binary64=]
 
     If `x` is zero or a finite normal value for its type, then:
 
@@ -15520,8 +15520,8 @@ but a value may infer the type.
   <tr>
     <td>Description
     <td>Quantizes a 32-bit floating point value `e` as if `e` were converted to
-        a [[!IEEE-754|IEEE 754]] binary16 value, and then converted back to a
-        IEEE 754 binary32 value.
+        a [[!IEEE-754|IEEE-754]] [=ieee754/binary16=] value, and then converted back to a
+        IEEE-754 [=ieee754/binary32=] value.
 
         If `e` is outside the finite range of binary16, then:
         * It is a [=shader-creation error=] if `e` is a [=const-expression=].
@@ -18003,7 +18003,7 @@ Note: For packing snorm values, the normalized floating point values are in the 
     <td>Description
     <td>Converts two floating point values to half-precision floating point numbers, and then combines
         them into one `u32` value.<br>
-        Component `e[i]` of the input is converted to a [[!IEEE-754|IEEE-754]] binary16 value, which is then
+        Component `e[i]` of the input is converted to a [[!IEEE-754|IEEE-754]] [=ieee754/binary16=] value, which is then
         placed in bits
         16 &times; `i` through
         16 &times; `i` + 15 of the result.
@@ -18133,7 +18133,7 @@ Note: For unpacking snorm values, the normalized floating point result is in the
         as a floating point value.<br>
         Component `i` of the result is the f32 representation of `v`,
         where `v` is the interpretation of bits 16&times;`i` through 16&times;`i + 15` of `e`
-        as an [[!IEEE-754|IEEE-754]] binary16 value.
+        as an [[!IEEE-754|IEEE-754]] [=ieee754/binary16=] value.
         See [[#floating-point-conversion]].
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12330,7 +12330,7 @@ For a floating point type *T*, define *MAX(T)* as the largest positive finite va
 and 2<sup>*EMAX(T)*</sup> as the largest power of 2 representable by *T*.
 In particular, EMAX([=f32=]) = 127, and EMAX([=f16=]) = 15.
 
-Let *X* be an infinite-precision [=intermediate result=] from a floating point computation.
+Let *X* be an infinitely precise [=intermediate result=] from a floating point computation.
 The final value of the expression is determined in two stages, via [=intermediate result=] values *X'* and *X''* as follows:
 
 From *X*, compute *X'* in *T* by rounding:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12710,8 +12710,8 @@ This uses two floating point multiplications, and one floating point addition.
         * |a|[i] is zero and |b|[i] is infinite.
         * |a|[i] is infinite and |b|[i] is zero.
     * Implied from the addition:
-        * |a|[0]&times;|b|[0] is [PINF] and |a|[1]&times;|b|[1] is [PINF]
-        * |a|[0]&times;|b|[0] is [NINF] and |a|[1]&times;|b|[1] is [NINF]
+        * |a|[0] &times; |b|[0] is [PINF] and |a|[1] &times; |b|[1] is [PINF]
+        * |a|[0] &times; |b|[0] is [NINF] and |a|[1] &times; |b|[1] is [NINF]
 
 
 # Keyword and Token Summary # {#grammar}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -518,6 +518,7 @@ Then the area |a| is a hyperbolic angle such that |x| is the hyperbolic cosine o
 The <dfn>extended real</dfn> numbers
 (also known as the affinely extended real numbers) is the set of real numbers together with [PINF] and [NINF].
 Computers use [[#floating-point-types|floating point types]] to approximately represent the extended reals, including values for both infinities.
+See [[#floating-point-evaluation]].
 
 An <dfn noexport>interval</dfn> is a contiguous set of numbers with a lower and upper bound.
 Depending on context, they are sets of integers, floating point numbers, real numbers, or [=extended real=] numbers.
@@ -12179,7 +12180,8 @@ An [[!IEEE-754|IEEE-754]] binary floating point type approximates the [=extended
     * [=Positive infinity=] and [=negative infinity=].
     * NaN values. A <dfn noexport>NaN</dfn>, short for "Not a Number", represents the result of an [=ieee754/invalid operation=].
         IEEE-754 requires both signalling and quiet NaNs, for distinguishing cases related to error reporting.
-        As described in the next section, WGSL does require such error reporting.
+        WGSL does not require such error reporting, and may yield [=indeterminate values=] instead of NaNs.
+        See [[#differences-from-ieee754]].
 * The type supports operations including:
     * Basic arithmetic such as: addition (`+`), subtraction (`-`), mutiplication (`*`), and division (`/`).
     * Conversion to and from other numeric types.
@@ -12241,10 +12243,13 @@ The following algorithm maps a bit representation of a floating point value to i
 
 
 The <dfn>domain</dfn> of a floating point operation is the set of [=extended real=] number inputs for which the operation is well defined.
-For example, the domain of the mathematical function &radic; is the interval [0,[PINF]]: &radic; is not well defined for inputs less than zero.
 
-When applied to inputs in its [=domain=], an operation is defined in terms of an infinitely precise [=extended real=] <dfn>intermediate result</dfn>,
-which is then converted to a floating point result.
+* For example, the domain of the mathematical function &radic; is the interval [0,[PINF]]: &radic; is not well defined for inputs less than zero.
+* When applied to an input *inside* its [=domain=], an operation is defined in terms of an infinitely precise [=extended real=] <dfn>intermediate result</dfn>,
+    which is then converted to a floating point result, via [=rounding=].
+* When an operation is evaluated *outside* its [=domain=],
+    the default exception handling rules of IEEE-754 require an implementation to generate an [=ieee754/exception=] and yield a [=NaN=] value.
+    In contrast, WGSL does not mandate floating point exceptions, and may instead yield an [=indeterminate value=]. See [[#differences-from-ieee754]].
 
 <dfn noexport>Rounding</dfn> maps an [=extended real=] value |x| to a value <var>x'</var> in the floating point type.
 When |x| is in the floating point type, then rounding maps |x| to itself: |x| &equals; <var>x'</var>.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -14345,9 +14345,9 @@ fn num_point_lights() -> u32 {
     <td>Domain
     <td>[=Implied from linear terms=] given by a possible implementation:
 
-         * |a|[1] &times; |b|[2] &minus; a[2] &times; b[1]
-         * |a|[2] &times; |b|[0] &minus; a[0] &times; b[2]
-         * |a|[0] &times; |b|[1] &minus; a[1] &times; b[0]
+         * |a|[1] &times; |b|[2] &minus; |a|[2] &times; |b|[1]
+         * |a|[2] &times; |b|[0] &minus; |a|[0] &times; |b|[2]
+         * |a|[0] &times; |b|[1] &minus; |a|[1] &times; |b|[0]
 </table>
 
 ### `degrees` ### {#degrees-builtin}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12461,7 +12461,7 @@ the rules in [[#floating-point-overflow]] apply.
       <td>Absolute error at most 2<sup>-11</sup> when `x` is in the interval [-&pi;, &pi;]
       <td>Absolute error at most 2<sup>-7</sup> when `x` is in the interval [-&pi;, &pi;]
   <tr><td>`cosh(x)`<td colspan=2 style="text-align:left;">Inherited from `(exp(x) + exp(-x)) * 0.5`
-  <tr><td>`cross(a, b)`<td colspan=2 style="text-align:left;">Inherited from `(a[i] * b[j] - a[j] * b[i])` where `i` &ne; `j`
+  <tr><td>`cross(x, x)`<td colspan=2 style="text-align:left;">Inherited from `(x[i] * y[j] - x[j] * y[i])` where `i` &ne; `j`
   <tr><td>`degrees(x)`<td colspan=2 style="text-align:left;">Inherited from `x * 57.295779513082322865`
   <tr><td>`determinant(m:mat2x2<T>)`<br>
           `determinant(m:mat3x3<T>)`<br>
@@ -14328,7 +14328,7 @@ fn num_point_lights() -> u32 {
     <td class="nowrap">
       <xmp highlight=wgsl>
         @const @must_use fn cross(a: vec3<T>,
-                                  e2: vec3<T>) -> vec3<T>
+                                  b: vec3<T>) -> vec3<T>
       </xmp>
   <tr>
     <td style="width:10%">Parameterization

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12225,7 +12225,7 @@ The following algorithm maps a bit representation of a floating point value to i
     * The result |F| &equals; [NINF] when <var>Sign</var> &equals; 1 and |T| &equals; 0.
     * The result |F| is a [=NaN=] when |T| &ne; 0.
 * Otherwise, if the [=ieee754/exponent field=] is all 0 bits, then:
-    * The result |F| &equals; (&minus; 1)<sup><var>Sign</var></sup> &times; 2<sup>(|E|&minus;<var>bias</var>)</sup> &times; |T| &times; 2<sup>&minus;<var>tsw</var>&plus;1</sup>.
+    * The result |F| &equals; (&minus; 1)<sup><var>Sign</var></sup> &times; 2<sup>&minus;<var>bias</var></sup> &times; |T| &times; 2<sup>&minus;<var>tsw</var>&plus;1</sup>.
     * If |T| = 0, then the value is a zero.
          * Each floating point type has both a positive zero and a negative zero.
              A <dfn noexport>negative zero</dfn> is a zero value with `1` for its [=ieee754/sign field|sign=] bit.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -14698,7 +14698,7 @@ the sign bit appears in the most significant bit position.
     operation is not "fused" at all.
   <tr>
     <td>Domain
-    <td>[=Implied from linear terms=] of the expressions |e2|[i] &times; |e2|[i] &plus; |e3|[i].
+    <td>[=Implied from linear terms=] of the expressions |e2| &times; |e2| &plus; |e3|.
 </table>
 
 ### `fract` ### {#fract-builtin}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12701,7 +12701,7 @@ When listing the domain for one of these operations, either:
      * Applying and combining the domain restrictions for those remaining operations over the given parameters.
 
 For example: The `dot(a,b)` function over 2-element vectors |a| and |b| has its accuracy [=inherited from=] the expression
-    |a[0]| * |b[0]| + |a[1]| * |b[1]|.
+    |a|[0] * |b|[0] + |a|[1] * |b|[1].
 This uses two floating point multiplications, and one floating point addition.
 * Floating point multiplication is well defined over the extended reals except when one operand is zero and the other is infinite.
 * Floating point addition is well defined except when the two operands are infinites of opposite sign.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -22,7 +22,7 @@ Text Macro: ALLSIGNEDNUMERICDECL S is AbstractInt, AbstractFloat, i32, f32, or f
 Text Macro: INF &infin;
 Text Macro: PINF &plus;&infin;
 Text Macro: NINF &minus;&infin;
-Ignored Vars: i, c0, e, e1, e2, e3, edge, eN, p, s1, s2, sn, AS, AM, N, newbits, M, C, R, v, Stride, Offset, Align, Extent, T, T1
+Ignored Vars: i, c0, e, e1, e2, e3, edge, eN, p, s1, s2, sn, AS, AM, N, newbits, M, C, R, v, Stride, Offset, Align, Extent, T, T1, E, S, F, x, y, a, b
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
 !Tests: <a href=https://github.com/gpuweb/cts/tree/main/src/webgpu/shader/>WebGPU CTS shader/</a>
@@ -511,12 +511,16 @@ sense. Specifically:
 Then the area |a| is a hyperbolic angle such that |x| is the hyperbolic cosine of |a|, and
 |y| is the hyperbolic sine of |a|.
 
+<dfn noexport>Positive infinity</dfn>, denoted by &infin; or [PINF], is a unique value strictly greater than all real numbers.
+
+<dfn noexport>Negative infinity</dfn>, denoted by [NINF], is a unique value strictly lower than all real numbers.
+
 The <dfn>extended real</dfn> numbers
 (also known as the affinely extended real numbers) is the set of real numbers together with [PINF] and [NINF].
 Computers use [[#floating-point-types|floating point types]] to approximately represent the extended reals, including values for both infinities.
 
 An <dfn noexport>interval</dfn> is a contiguous set of numbers with a lower and upper bound.
-Depending on context, they are sets of integers, floating point numbers, or real numbers.
+Depending on context, they are sets of integers, floating point numbers, real numbers, or [=extended real=] numbers.
 * The closed interval [*a*,*b*] is the set of numbers *x* such that *a* &le; *x* &le; *b*.
 * The half-open interval [*a*,*b*) is the set of numbers *x* such that *a* &le; *x* &lt; *b*.
 * The half-open interval (*a*,*b*] is the set of numbers *x* such that *a* &lt; *x* &le; *b*.
@@ -1553,7 +1557,7 @@ Let |TemplateList| be a record type containing:
 
 **Output:** |DiscoveredTemplateLists|, a list of |TemplateList| records.
 
-**Algorithm:**
+**Procedure:**
 * Initialize |DiscoveredTemplateLists| to an empty list.
 * Initialize a |Pending| variable to be an empty stack of |UnclosedCandidate| records.
 * Initialize a |CurrentPosition| integer variable to 0.
@@ -2733,7 +2737,7 @@ Each has a corresponding negative value.
 <table class='data'>
   <caption>Extreme values for floating point types</caption>
   <thead>
-    <tr><th>Type<th>Smallest positive denormal<th>Smallest positive normal<th>Largest positive finite<th>Largest finite power of 2
+    <tr><th>Type<th>Smallest positive [=ieee754/subnormal=]<th>Smallest positive [=ieee754/normal=]<th>Largest positive finite<th>Largest finite power of 2
   </thead>
     <tr><td rowspan=2>f32<td>1.40129846432481707092e-45f<td>1.17549435082228750797e-38f<td>3.40282346638528859812e+38f<td rowspan=2>0x1p+127f
     <tr><td>0x1p-149f<td>0x1p-126f<td>0x1.fffffep+127f
@@ -5213,7 +5217,7 @@ The type of a `const` expression [=shader-creation error|must=] [=type rules|res
 Note: [=type/abstract|Abstract types=] can be the inferred type of a const-expression.
 
 A const-expression |E| [=behavioral requirement|will=] be evaluated if and only if:
-* |E| is [=top-level expression=], 
+* |E| is [=top-level expression=],
 * |E| is a [=subexpression=] of an expression |OuterE|, and |OuterE|
     [=behavioral requirement|will=] be evaluated, and evaluation of |OuterE|
     requires |E| to be evaluated,
@@ -6006,15 +6010,32 @@ See [[#sync-builtin-functions]].
     <td>|e1| `+` |e2| : |T|
     <td>Addition. [=Component-wise=] when |T| is a vector.
 
+        If |T| is a floating point type, the scalar [=domain=] is
+        the set of all pairs of [=extended reals=] (|x|,|y|) except:
+           * ([NINF],[PINF])
+           * ([PINF],[NINF])
+
   <tr algorithm="subtraction">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `-` |e2| : |T|
     <td>Subtraction [=Component-wise=] when |T| is a vector.
 
+        If |T| is a floating point type, the scalar [=domain=] is
+        the set of all pairs of [=extended reals=] (|x|,|y|) except:
+           * ([NINF],[NINF])
+           * ([PINF],[PINF])
+
   <tr algorithm="multiplication">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `*` |e2| : |T|
     <td>Multiplication. [=Component-wise=] when |T| is a vector.
+
+        If |T| is a floating point type, the scalar [=domain=] is
+        the set of all pairs of [=extended reals=] (|x|,|y|) except:
+           * (0,[NINF])
+           * (0,[PINF])
+           * ([NINF], 0)
+           * ([PINF], 0)
 
   <tr algorithm="division">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
@@ -6052,6 +6073,14 @@ See [[#sync-builtin-functions]].
         * Otherwise, the integer |q| such that
             |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
             where 0 &le; |r| &lt; |e2|.
+
+        If |T| is a floating point type, the scalar [=domain=] is
+        the set of all pairs of [=extended reals=] (|x|,|y|) except:
+           * (0,0)
+           * ([NINF],[NINF])
+           * ([NINF],[PINF])
+           * ([PINF],[NINF])
+           * ([PINF],[PINF])
 
   <tr algorithm="Remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
@@ -6092,7 +6121,25 @@ See [[#sync-builtin-functions]].
            |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
            where |q| is an integer and 0 &le; |r| &lt; |e2|.
 
-       If |T| is a floating point type, the result is equal to:<br> |e1| - |e2| * trunc(|e1| / |e2|)
+       If |T| is a floating point type, the result is equal to:<br> |e1| - |e2| * trunc(|e1| / |e2|).
+
+       If |T| is a floating point type, the scalar [=domain=] is
+       the set of all pairs of [=extended reals=] (|x|,|y|) except:
+
+       * Cases outside the domain of |x| / |y|:
+           * (0,0)
+           * ([NINF],[NINF])
+           * ([NINF],[PINF])
+           * ([PINF],[NINF])
+           * ([PINF],[PINF])
+       * Additional cases outside the domain of |y| * trunc(|x| / |y|):
+           * |y| is infinite, and |x| is finite, implying trunc(|x| / |y|) is 0.
+           * |y| is 0, and |x| is infinite, implying trunc(|x| / |y|) is infinite.
+       <!---  what about subtraction of infinities of the same sign:
+              |x| = [PINF],  |y| * trunc(|x| / |y|) = [PINF] which happens when
+                    |x| is finite and,... but already a contradition
+              |x| = [NINF],  |y| * trunc(|x| / |y|) = [NINF] which happens when
+                    |x| is finite and,... but already a contradition -->
 
 </table>
 
@@ -12118,31 +12165,131 @@ If one of these functions is called in non-uniform control flow, then the result
 
 ## Floating Point Evaluation ## {#floating-point-evaluation}
 
-WGSL follows the [[!IEEE-754|IEEE-754]] standard for floating point computation with
-the following differences:
-* No rounding mode is specified. An implementation may round a value up or down.
+WGSL floating point features are based on the [[!IEEE-754|IEEE-754]] standard for floating point,
+but with reduced functionality reflecting the compromises made by GPUs, and with some additional guardrails for portability.
+
+### Overview of IEEE-754 ### {#overview-of-ieee-754}
+
+WGSL floating point types are based on [[!IEEE-754|IEEE-754]] binary floating point types.
+
+An [[!IEEE-754|IEEE-754]] binary floating point type approximates the [=extended real=] number line as follows:
+* The type has a finite set of values, including distinct categories for:
+    * Positive and negative rational numbers.
+        * Each of these is finite, and is either [=ieee754/normal=] or [=ieee754/subnormal=] as defined below.
+    * [=Positive infinity=] and [=negative infinity=].
+    * NaN values. A <dfn noexport>NaN</dfn>, short for "Not a Number", represents the result of an [=ieee754/invalid operation=].
+        IEEE-754 requires both signalling and quiet NaNs, for distinguishing cases related to error reporting.
+        As described in the next section, WGSL does require such error reporting.
+* The type supports operations including:
+    * Basic arithmetic such as: addition (`+`), subtraction (`-`), mutiplication (`*`), and division (`/`).
+    * Conversion to and from other numeric types.
+    * Built-in functions such as: [[#max-float-builtin|max]], [[#sqrt-builtin|sqrt]], [[#cos-builtin|cos]]
+    * <div class=note>Note: Infinities are ordinary participants in most operations. For example adding [PINF] to 5 produces [PINF].</div>
+* The type has a bit representation characterized by:
+    * A fixed bit width, where each value's bit representation has three contiguous bit fields, ordered from most significant bit to least:
+        * A 1-bit <dfn dfn-for="ieee754" noexport>sign field</dfn>.
+        * A fixed-width <dfn dfn-for="ieee754" noexport>exponent field</dfn>.
+        * A fixed-width <dfn dfn-for="ieee754" noexport>trailing significand field</dfn>.
+    * An integer-valued <dfn dfn-for="ieee754" noexport>exponent bias</dfN> related to interpretation of the [=ieee754/exponent field=].
+
+The IEEE-754 floating point types of interest are:
+
+* <dfn dfn-for="ieee754" noexport>binary16</dfn>:
+    * [=ieee754/exponent field=] width 5
+    * [=ieee754/trailing significand field=] width 10
+    * [=ieee754/exponent bias=] 15
+* <dfn dfn-for="ieee754" noexport>binary32</dfn>:
+    * [=ieee754/exponent field=] width 8
+    * [=ieee754/trailing significand field=] width 23
+    * [=ieee754/exponent bias=] 127
+* <dfn dfn-for="ieee754" noexport>binary64</dfn>:
+    * [=ieee754/exponent field=] width 11
+    * [=ieee754/trailing significand field=] width 52
+    * [=ieee754/exponent bias=] 1023
+
+The following algorithm maps a bit representation of a floating point value to its corresponding [=extended real=] value, or NaN:
+<blockquote algorithm="floating point interpretation of bits">
+**Algorithm:** <dfn noexport>Floating point interpretation of bits</dfn>
+
+**Input**: <var>Bits</var>, a bit representation for a value in a binary floating point type.
+
+**Output:** |F|, the floating point value represented by |Bits|.
+
+**Procedure:**
+* Let <var>bias</var> be the [=ieee754/exponent bias=] for the type.
+* Let <var>tsw</var> be the bit width of the [=ieee754/trailing significand field=] for the type.
+* Partition <var>Bits</var> into the [=ieee754/sign field=], [=ieee754/exponent field=], and the [=ieee754/trailing significand field=].
+* Let <var>Sign</var>, |E|, and |T| be the interpretations of those respective fields as unsigned integers.
+* If the [=ieee754/exponent field=] is all 1 bits, then:
+    * The result |F| &equals; [PINF] when <var>Sign</var> &equals; 0 and |T| &equals; 0.
+    * The result |F| &equals; [NINF] when <var>Sign</var> &equals; 1 and |T| &equals; 0.
+    * The result |F| is a [=NaN=] when |T| &ne; 0.
+* Otherwise, if the [=ieee754/exponent field=] is all 0 bits, then:
+    * The result |F| &equals; (&minus; 1)<sup><var>Sign</var></sup> &times; 2<sup>(|E|&minus;<var>bias</var>)</sup> &times; |T| &times; 2<sup>&minus;<var>tsw</var>&plus;1</sup>.
+    * If |T| = 0, then the value is a zero.
+         * Each floating point type has both a positive zero and a negative zero.
+             A <dfn noexport>negative zero</dfn> is a zero value with `1` for its [=ieee754/sign field|sign=] bit.
+             Negative zero and positive zero compare as equal.
+             IEEE-754 uses negative zero to indicate certain edge cases unimportant to WGSL.
+    * If |T| &ne; 0, then the value |F| is <dfn dfn-for="ieee754" noexport>subnormal</dfn>.
+         (<dfn noexport>Denormalized</dfn> is a synonym for subnormal.)
+* Otherwise, the [=ieee754/exponent field=] is neither all 1 bits, nor all 0 bits:
+    * The result |F| &equals; (&minus; 1)<sup><var>Sign</var></sup> &times; 2<sup>(|E|&minus;<var>bias</var>)</sup> &times; ( 1 + |T| &times; 2<sup>&minus;<var>tsw</var></sup>).
+    * The value |F| is <dfn dfn-for="ieee754" noexport>normal</dfn>.
+
+</blockquote>
+
+
+The <dfn>domain</dfn> of a floating point operation is the set of [=extended real=] number inputs for which the operation is well defined.
+For example, the domain of the mathematical function &radic; is the interval [0,[PINF]]: &radic; is not well defined for inputs less than zero.
+
+When applied to inputs in its [=domain=], an operation is defined in terms of an infinitely precise [=extended real=] <dfn>intermediate result</dfn>,
+which is then converted to a floating point result.
+
+<dfn noexport>Rounding</dfn> maps an [=extended real=] value |x| to a value <var>x'</var> in the floating point type.
+When |x| is in the floating point type, then rounding maps |x| to itself: |x| &equals; <var>x'</var>.
+Rounding may [=ieee754/overflow=] when |x| is outside the finite range of the type.
+Otherwise <var>x'</var> is the either the lowest floating point value above |x|, or
+the highest floating point value below |x|;
+a <dfn dfn-for="ieee754">rounding mode</dfn> determines which one is chosen.
+
+Generally, an operation with a [=NaN=] input will yield a [=NaN=] output.
+Exceptions include:
+* A NaN is never equal to, less than, or greater than any other floating point value. Such comparisons yield false.
+* For `minimum(x,y)` and `maximum(x,y)` operations, if one of the inputs is NaN, the result is the other input.
+
+IEEE-754 defines five kinds of <dfn dfn-for="ieee754">exceptions</dfn>:
+
+* <dfn dfn-for="ieee754">Invalid operation</dfn>.
+    This occurs when an operation is evaluated on [=extended real=] inputs outside its [=domain=].
+    Such operations yield a NaN.
+    Examples of invalid operations are 0 &times; [INF], and `sqrt`(&minus;1).
+* <dfn dfn-for="ieee754">Division by zero</dfn>.
+    This occurs when an operation on finite operands is defined as having an exact infinite result.
+    Examples are 1 &divide; 0, and log(0).
+* <dfn dfn-for="ieee754">Overflow</dfn>. This occurs when an [=intermediate result=] exceeds the finite range of the type. See [[#floating-point-overflow]].
+* <dfn dfn-for="ieee754" noexport>Underflow</dfn>. This occurs when the [=intermediate result=] or the rounded result is [=ieee754/subnormal=].
+* <dfn dfn-for="ieee754" noexport>Inexact</dfn>. This occurs when the rounded result is different from the [=intermediate result=],
+    or when overflow occurs.
+
+### Differences from IEEE-754 ### {#differences-from-ieee754}
+
+WGSL follows the [[!IEEE-754|IEEE-754]] standard, but with the following differences:
+* No [=ieee754/rounding mode=] is specified. An implementation may round an [=intermediate result=] up or down.
 * No floating point exceptions are generated.
-    * A floating point operation in WGSL [=behavioral requirement|will=] produce an intermediate result
-        according to IEEE-754 rules, but exceptions mandated by IEEE-754 will map to different
+    * A floating point operation in WGSL [=behavioral requirement|will=] produce an [=intermediate result=]
+        according to IEEE-754 rules, but [=ieee754/exceptions=] mandated by IEEE-754 will map to different
         behaviors depending on whether the expression is
         a [=const-expression=], an [=override-expression=], or a [=runtime expression=].
-    * IEEE-754 defines five kinds of exceptions:
-        * Invalid operation. These operations yield a NaN.  An example of an invalid operation is 0 &times; [INF].
-        * Division by zero. This occurs when an operation on finite operands is defined as having an exact infinite result.
-            Examples are 1 &divide; 0, and log(0).
-        * Overflow. See [[#floating-point-overflow]].
-        * Underflow. This occurs when the rounded or unrounded result is subnormal.
-        * Inexact. This occurs when the rounded result is different from the intermediate result,
-            or when overflow occurs.
     * Consider an operation on finite operands.
         The operation produces overflow, infinity, or a NaN if and only if IEEE-754 would require the
-        operation to signal an invalid operation, division-by-zero, or overflow exception.
+        operation to signal an [=ieee754/overflow=], [=ieee754/invalid operation=], or [=ieee754/division by zero=] exception.
 * Signaling NaNs may not be generated.
     Any signaling NaN may be converted to a quiet NaN.
-* Overflow, infinities, and NaNs generated before runtime are errors.
+* Overflow, infinities, and NaNs generated before [=shader execution start|runtime=] [=behavioral requirement|will=] generate errors.
     * [=Const-expressions=] and [=override-expressions=] over finite values
         [=behavioral requirement|will=] generate overflow, infinities, and NaNs
-        as intermediate values, following IEEE-754 rules.
+        as [=intermediate result=] values, following IEEE-754 rules.
         * Note: This rule requires implementations to reliably detect overflow, infinities, and NaNs
             to within accuracy limits for these kinds of expressions, so that errors can be generated consistently.
     * A [=shader-creation error=] results if any [=const-expression=] of
@@ -12150,22 +12297,27 @@ the following differences:
     * A [=pipeline-creation error=] results if any [=override-expression=] of
         floating-point type overflows or evaluates to NaN or infinity.
 * Implementations may assume that overflow, infinities, and NaNs are not present at runtime.
-    * In such an implementation, if the intermediate result of evaluating a [=runtime expression=] overflows,
+    * In such an implementation, if the [=intermediate result=] of evaluating a [=runtime expression=] overflows,
         or yields infinity or a NaN, the final result [=behavioral requirement|will=] be
         an [=indeterminate value=] of the target type.
     * Note: This means some functions (e.g. `min` and `max`)
         may not return the expected result due to optimizations about the presence
         of NaNs and infinities.
-* Implementations may ignore the sign of a zero.
+* Implementations may ignore the [=ieee754/sign field=]of a zero.
     That is, a zero with a positive sign may behave like a zero a with a negative sign, and vice versa.
-* To <dfn noexport title="flushed to zero">flush to zero</dfn> is to replace a denormalized value for a floating point type
+* To <dfn noexport title="flushed to zero">flush to zero</dfn> is to replace a [=ieee754/subnormal=] value for a floating point type
     with a zero value of that type.
     * Any inputs or outputs of operations listed in [[#floating-point-accuracy]] may be flushed to zero.
-    * Additionally, intermediate values of operations listed in
+    * Additionally, [=intermediate result=] values of operations listed in
         [[#bit-reinterp-builtin-functions]], [[#pack-builtin-functions]], or
         [[#unpack-builtin-functions]] may be flushed to zero.
-    * Other operations are required to preserve denormalized numbers.
+    * Other operations are required to preserve [=ieee754/subnormal=] numbers.
 * The accuracy of operations is given in [[#floating-point-accuracy]].
+* Some built-in functions in WGSL have different semantics from the corresponding IEEE-754 operation.
+    Such cases are listed as needed at the definition of the WGSL built-in function.
+
+    For example the WGSL [[#fma-builtin]] function expands to an ordinary multiply (including a rounding step) and an add (and another rounding step),
+    while the IEEE-754 `fusedMultiplyAdd` operation requires that only final rounding step occurs.
 
 ### Floating Point Overflow ### {#floating-point-overflow}
 
@@ -12178,8 +12330,8 @@ For a floating point type *T*, define *MAX(T)* as the largest positive finite va
 and 2<sup>*EMAX(T)*</sup> as the largest power of 2 representable by *T*.
 In particular, EMAX([=f32=]) = 127, and EMAX([=f16=]) = 15.
 
-Let *X* be an infinite-precision intermediate result from a floating point computation.
-The final value of the expression is determined in two stages, via intermediate values *X'* and *X''* as follows:
+Let *X* be an infinite-precision [=intermediate result=] from a floating point computation.
+The final value of the expression is determined in two stages, via [=intermediate result=] values *X'* and *X''* as follows:
 
 From *X*, compute *X'* in *T* by rounding:
 * If *X* is in the finite range of *T* then *X'* is the result of rounding *X* up or down.
@@ -12211,8 +12363,8 @@ The <dfn>correctly rounded</dfn> result of the operation for floating point type
 
 </div>
 
-That is, the result may be rounded up or down:
-WGSL does not specify a rounding mode.
+That is, the result may be [=rounding|rounded=] up or down:
+WGSL does not specify a [=ieee754/rounding mode=].
 
 Note: Floating point types include positive and negative infinity, so
 the correctly rounded result may be finite or infinite.
@@ -12237,8 +12389,8 @@ possibilities:
     The given expression is only one valid implementation of the function.
     A WebGPU implementation may implement the operation differently, with better accuracy
     or with greater tolerance for extreme inputs.
-    Additionally, an implementation may treat intermediate results as subject to the rules for
-    floating-point evaluation (e.g. they may be rounded and/or [=flush to zero|flushed-to-zero=]).
+    Additionally, an implementation may treat [=intermediate result=] as subject to the rules for
+    floating-point evaluation (e.g. they may be [=rounding|rounded=] and/or [=flush to zero|flushed-to-zero=]).
 
 When the accuracy for an operation is specified over an input range,
 the accuracy is undefined for input values outside that range.
@@ -12303,13 +12455,13 @@ the rules in [[#floating-point-overflow]] apply.
     The infinitely precise result is computed as either `min(max(x,low),high)`, or with a median-of-3-values formulation.
     These may differ when `low > high`.
 
-    If `x` and either `low` or `high` are denormalized, the result may be any of the denormalized values.
-    This follows from the possible results from the `min` and `max` functions on denormalized inputs.
+    If `x` and either `low` or `high` are [=ieee754/subnormal=], the result may be any of the [=ieee754/subnormal=] values.
+    This follows from the possible results from the `min` and `max` functions on [=ieee754/subnormal=] inputs.
   <tr><td>`cos(x)`
       <td>Absolute error at most 2<sup>-11</sup> when `x` is in the interval [-&pi;, &pi;]
       <td>Absolute error at most 2<sup>-7</sup> when `x` is in the interval [-&pi;, &pi;]
   <tr><td>`cosh(x)`<td colspan=2 style="text-align:left;">Inherited from `(exp(x) + exp(-x)) * 0.5`
-  <tr><td>`cross(x, y)`<td colspan=2 style="text-align:left;">Inherited from `(x[i] * y[j] - x[j] * y[i])`
+  <tr><td>`cross(a, b)`<td colspan=2 style="text-align:left;">Inherited from `(a[i] * b[j] - a[j] * b[i])` where `i` &ne; `j`
   <tr><td>`degrees(x)`<td colspan=2 style="text-align:left;">Inherited from `x * 57.295779513082322865`
   <tr><td>`determinant(m:mat2x2<T>)`<br>
           `determinant(m:mat3x3<T>)`<br>
@@ -12354,18 +12506,18 @@ the rules in [[#floating-point-overflow]] apply.
       <td>Absolute error at most 2<sup>-7</sup> when `x` is in the interval [0.5, 2.0].<br>
           3 ULP when `x` is outside the interval [0.5, 2.0].<br>
   <tr><td>`max(x, y)`<td colspan=2 style="text-align:left;">Correctly rounded
-  <p>If both `x` and `y` are denormalized, the result may be either input.
+  <p>If both `x` and `y` are [=ieee754/subnormal=], the result may be either input.
   <tr><td>`min(x, y)`<td colspan=2 style="text-align:left;">Correctly rounded.
-  <p>If both `x` and `y` are denormalized, the result may be either input.
+  <p>If both `x` and `y` are [=ieee754/subnormal=], the result may be either input.
   <tr><td>`mix(x, y, z)`<td colspan=2 style="text-align:left;">Inherited from `x * (1.0 - z) + y * z`
   <tr><td>`modf(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`normalize(x)`<td colspan=2 style="text-align:left;">Inherited from `x / length(x)`
 
-  <tr><td>`pack4x8snorm(x)`<td colspan=2 style="text-align:left;">Correctly rounded intermediate value. Correct result.
-  <tr><td>`pack4x8unorm(x)`<td colspan=2 style="text-align:left;">Correctly rounded intermediate value. Correct result.
-  <tr><td>`pack2x16snorm(x)`<td colspan=2 style="text-align:left;">Correctly rounded intermediate value. Correct result.
-  <tr><td>`pack2x16unorm(x)`<td colspan=2 style="text-align:left;">Correctly rounded intermediate value. Correct result.
-  <tr><td>`pack2x16float(x)`<td colspan=2 style="text-align:left;">Correctly rounded intermediate value. Correct result.
+  <tr><td>`pack4x8snorm(x)`<td colspan=2 style="text-align:left;">Correctly rounded [=intermediate result=] value. Correct result.
+  <tr><td>`pack4x8unorm(x)`<td colspan=2 style="text-align:left;">Correctly rounded [=intermediate result=] value. Correct result.
+  <tr><td>`pack2x16snorm(x)`<td colspan=2 style="text-align:left;">Correctly rounded [=intermediate result=] value. Correct result.
+  <tr><td>`pack2x16unorm(x)`<td colspan=2 style="text-align:left;">Correctly rounded [=intermediate result=] value. Correct result.
+  <tr><td>`pack2x16float(x)`<td colspan=2 style="text-align:left;">Correctly rounded [=intermediate result=] value. Correct result.
 
   <tr><td>`pow(x, y)`<td colspan=2 style="text-align:left;">Inherited from `exp2(y * log2(x))`
   <tr><td>`quantizeToF16(x)`<td colspan=2 style="text-align:left;">Correctly rounded
@@ -12441,7 +12593,7 @@ expression such that the answer is the same if computed exactly. For example:
 
 However, the result may not be the same when computed in floating point.
 The reassociated result may be inaccurate due to approximation, or may trigger
-an overflow or NaN when computing intermediate results.
+an overflow or NaN when computing [=intermediate results=].
 
 An implementation may reassociate operations.
 
@@ -12468,6 +12620,8 @@ To convert a floating point scalar value |X| to an [=integer scalar=] type |T|:
 </blockquote>
 
 Note: In other words, floating point to integer conversion rounds toward zero, then saturates in the target type.
+This saturation requirement the result is one place where WGSL mandates a meaningful result,
+but where [[!IEEE-754|IEEE-754]] mandates an invalid operation exception and a NaN result.
 
 <div class=note><span class=marker>Note:</span> For example:
 * 3.9f converted to [=u32=] is 3u
@@ -12484,6 +12638,7 @@ The <dfn noexport>numeric scalar conversion to floating point</dfn> algorithm is
 When converting a [=numeric scalar=] value to a floating point type:
 * If the original value is exactly representable in the destination type, then the result is that value.
     * Additionally, if the original value is zero and of [=integer scalar=] type, then the resulting value has a zero sign bit.
+* If the original value is a NaN for the source type, then the result is a NaN in the destination type.
 * Otherwise, the original value is not exactly representable.
     * If the original value is different from but lies between two adjacent finite values representable in the destination type,
          then the result is one of those two values.
@@ -12499,7 +12654,6 @@ When converting a [=numeric scalar=] value to a floating point type:
                  Update |X| accordingly.
              3. If |X| is the most-positive or most-negative normal value of the destination type, then the result is |X|.
              4. Otherwise, the result is the infinity value of the destination type, with the same sign as |X|.
-    * Otherwise, if the original value is a NaN for the source type, then the result is a NaN in the destination type.
 
 </blockquote>
 
@@ -12516,6 +12670,44 @@ the original type is one of [=i32=] or [=u32=] and the destination type is [=f32
 
 Note: The original value is always within range of the destination type when
 the source type is a floating point type with fewer exponent and mantissa bits than the target floating point type.
+
+### Domains of Floating Point Expressions and Built-in Functions ### {#domains-of-floating-point-expressions-and-builtins}
+
+Previous sections describe the expected behavior when a floating point expression is evaluated
+outside its [=domain=].
+
+Sections [[#arithmetic-expr]] and [[#numeric-builtin-functions]] define the [=domains=] for floating point expressions and built-in functions, respectively.
+If no restriction is listed for a given operation, then the domain is total: the domain includes all finite and infinite inputs.
+Otherwise an explicit domain is listed.
+
+In many cases where a WGSL operation corresponds to an operation defined by [[!IEEE-754|IEEE-754]], they will have the same domain.
+For example the both the WGSL and IEEE-754 `acos` operations have a domain of [&minus;1,1].
+
+For a [=component-wise=] WGSL operation with an explicitly listed domain, only the scalar case is described. The vector case is inferred from the component-wise semantics.
+
+Some WGSL operations may be implemented in terms of other WGSL expressions.
+Section [[#floating-point-accuracy]] lists these as having [=inherited from=] accuracy.
+When listing the domain for one of these operations, either:
+
+* The domain is explicitly described, or
+* The domain is stated as <dfn noexport>implied from linear terms</dfn>, meaning the domain
+    is derived by:
+     * Assuming the original operation was replaced by the "inherited from" expression, which is a combination of floating point addition, subtraction, and mulitiplication operations.
+     * Applying and combining the domain restrictions for those remaining operations over the given parameters.
+
+For example: The `dot(a,b)` function over 2-element vectors |a| and |b| has its accuracy [=inherited from=] the expression
+    |a[0]| * |b[0]| + |a[1]| * |b[1]|.
+This uses two floating point multiplications, and one floating point addition.
+* Floating point multiplication is well defined over the extended reals except when one operand is zero and the other is infinite.
+* Floating point addition is well defined except when the two operands are infinites of opposite sign.
+* Therefore, the domain is all pairs of extended real two-element vectors |a| and |b| except:
+    * Implied from the multiplications:
+        * |a|[i] is zero and |b|[i] is infinite.
+        * |a|[i] is infinite and |b|[i] is zero.
+    * Implied from the addition:
+        * |a|[0]&times;|b|[0] is [PINF] and |a|[1]&times;|b|[1] is [PINF]
+        * |a|[0]&times;|b|[0] is [NINF] and |a|[1]&times;|b|[1] is [NINF]
+
 
 # Keyword and Token Summary # {#grammar}
 
@@ -12851,7 +13043,7 @@ specify the component type; the component type is inferred from the constructor 
 
       If `T` is [=i32=], this is an identity operation.<br>
       If `T` is [=u32=], this is a reinterpretation of bits (i.e. the result is the unique value in [=i32=] that has the same bit pattern as `e`).<br>
-      If `T` is a [[#floating-point-types|floating point type]], `e` is [=scalar floating point to integral conversion|converted=] to [=i32=], rounding towards zero.<br>
+      If `T` is a [[#floating-point-types|floating point type]], `e` is [=scalar floating point to integral conversion|converted=] to [=i32=], [=rounding=] towards zero.<br>
       If `T` is [=bool=], the result is `1i` if `e` is `true` and `0i` otherwise.<br>
       If `T` is an [=AbstractInt=], this is an identity operation if `e` can be represented in [=i32=], otherwise it produces a [=shader-creation error=].
 </table>
@@ -13307,7 +13499,7 @@ specify the component type; the component type is inferred from the constructor 
 
       If `T` is [=u32=], this is an identity operation.<br>
       If `T` is [=i32=], this is a reinterpretation of bits (i.e. the result is the unique value in [=u32=] that has the same bit pattern as `e`).<br>
-      If `T` is a [[#floating-point-types|floating point type]], `e` is [=scalar floating point to integral conversion|converted=] to [=u32=], rounding towards zero.<br>
+      If `T` is a [[#floating-point-types|floating point type]], `e` is [=scalar floating point to integral conversion|converted=] to [=u32=], [=rounding=] towards zero.<br>
       If `T` is [=bool=], the result is `1u` if `e` is `true` and `0u` otherwise.<br>
       If `T` is [=AbstractInt=], this is an identity operation if the `e` can be represented in [=u32=], otherwise it produces a [=shader-creation error=].
   <tr><td>
@@ -13837,10 +14029,8 @@ fn num_point_lights() -> u32 {
 
     [=Component-wise=] when `T` is a vector.
   <tr>
-    <td>
-    <td>
-
-Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
+    <td>Scalar [=domain=]
+    <td>Interval [&minus;1, 1]
 </table>
 
 ### `acosh` ### {#acosh-builtin}
@@ -13861,11 +14051,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
 
     [=Component-wise=] when `T` is a vector.
   <tr>
-    <td>
-    <td>
-
-Note: The result is not mathematically meaningful when `x` &lt; 1.
-
+    <td>Scalar [=domain=]
+    <td>Interval [1, [PINF]]
 </table>
 
 ### `asin` ### {#asin-builtin}
@@ -13886,10 +14073,8 @@ Note: The result is not mathematically meaningful when `x` &lt; 1.
 
     [=Component-wise=] when `T` is a vector.
   <tr>
-    <td>
-    <td>
-
-Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
+    <td>Scalar [=domain=]
+    <td>Interval [&minus;1, 1]
 </table>
 
 ### `asinh` ### {#asinh-builtin}
@@ -13909,6 +14094,11 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
     That is, approximates `a` such that `sinh`(`y`) = `a`.
 
     [=Component-wise=] when `T` is a vector.
+
+  <!-- No restriction on scalar domain.
+      log(x + sqrt( x * x + 1)) requires
+          x + sqrt( x * x + 1) >= 0
+         But the sqrt term is always at least as large as abs(x). QED -->
 </table>
 
 ### `atan` ### {#atan-builtin}
@@ -13948,10 +14138,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
 
     [=Component-wise=] when `T` is a vector.
   <tr>
-    <td>
-    <td>
-
-Note: The result is not mathematically meaningful when `abs(t)` &ge; 1.
+    <td>Scalar [=domain=]
+    <td>Interval [&minus;1, 1]
 
 </table>
 
@@ -13980,7 +14168,7 @@ Note: The result is not mathematically meaningful when `abs(t)` &ge; 1.
 
     <div class=note>
     <span class=marker>Note:</span> The error in the result is unbounded:
-    * When `abs(x)` is very small, e.g. subnormal for its type,
+    * When `abs(x)` is very small, e.g. [=ieee754/subnormal=] for its type,
     * At the origin (`x`,`y`) = (0,0), or
     * When `y` is subnormal or infinite.
 
@@ -14048,6 +14236,9 @@ Note: The result is not mathematically meaningful when `abs(t)` &ge; 1.
     <td>Description
     <td>Returns the cosine of `e`, where `e` is in radians.
     [=Component-wise=] when `T` is a vector.
+  <tr>
+    <td>Scalar [=domain=]
+    <td>Interval ([NINF], [PINF])
 </table>
 
 ### `cosh` ### {#cosh-builtin}
@@ -14068,6 +14259,10 @@ Note: The result is not mathematically meaningful when `abs(t)` &ge; 1.
     but not necessarily computed that way.
 
     [=Component-wise=] when `T` is a vector
+
+   <!-- No restriction on domain from the inehrited formula:
+       (exp(x) + (exp(-x))) * 0.5
+       No danger from subtracting infinites of the same sign. -->
 </table>
 
 ### `countLeadingZeros` ### {#countLeadingZeros-builtin}
@@ -14132,7 +14327,7 @@ Note: The result is not mathematically meaningful when `abs(t)` &ge; 1.
     <td style="width:10%">Overload
     <td class="nowrap">
       <xmp highlight=wgsl>
-        @const @must_use fn cross(e1: vec3<T>,
+        @const @must_use fn cross(a: vec3<T>,
                                   e2: vec3<T>) -> vec3<T>
       </xmp>
   <tr>
@@ -14141,6 +14336,13 @@ Note: The result is not mathematically meaningful when `abs(t)` &ge; 1.
   <tr>
     <td>Description
     <td>Returns the cross product of `e1` and `e2`.
+  <tr>
+    <td>Domain
+    <td>[=Implied from linear terms=] given by a possible implementation:
+
+         * |a|[1] &times; |b|[2] &minus; a[2] &times; b[1]
+         * |a|[2] &times; |b|[0] &minus; a[0] &times; b[2]
+         * |a|[0] &times; |b|[1] &minus; a[1] &times; b[0]
 </table>
 
 ### `degrees` ### {#degrees-builtin}
@@ -14174,6 +14376,9 @@ Note: The result is not mathematically meaningful when `abs(t)` &ge; 1.
   <tr>
     <td>Description
     <td>Returns the determinant of `e`.
+  <tr>
+    <td>Domain
+    <td>[=Implied from linear terms=] in a standard mathematical definition of the determinant.
 </table>
 
 ### `distance` ### {#distance-builtin}
@@ -14191,6 +14396,10 @@ Note: The result is not mathematically meaningful when `abs(t)` &ge; 1.
   <tr>
     <td>Description
     <td>Returns the distance between `e1` and `e2` (e.g. `length(e1 - e2)`).
+
+    The [=domain=] is all vectors (|e1|,|e2|) where the subtraction |e1|&minus;|e2| is valid.
+    That is, the set of all vectors except where `e1[i]` and `e2[i]` are the same infinite value,
+    for some component `i`.
 </table>
 
 ### `dot` ### {#dot-builtin}
@@ -14208,6 +14417,9 @@ Note: The result is not mathematically meaningful when `abs(t)` &ge; 1.
   <tr>
     <td>Description
     <td>Returns the dot product of `e1` and `e2`.
+  <tr>
+    <td>Domain
+    <td>[=Implied from linear terms=] of the sum over terms |e1|[i] &times; |e2|[i].
 </table>
 
 ### `dot4U8Packed` ### {#dot4U8Packed-builtin}
@@ -14360,6 +14572,9 @@ Note: The result is not mathematically meaningful when `abs(t)` &ge; 1.
   <tr>
     <td>Description
     <td>Returns `e1` if `dot(e2, e3)` is negative, and `-e1` otherwise.
+  <tr>
+    <td>Domain
+    <td>The domain restrictions arise from the `dot(e2,e3)` operation: they are [=implied from linear terms=] of the sum over terms |e2|[i] &times; |e3|[i].
 </table>
 
 ### `firstLeadingBit` (signed) ### {#firstLeadingBit-signed-builtin}
@@ -14474,13 +14689,16 @@ the sign bit appears in the most significant bit position.
     Note: The name `fma` is short for "fused multiply add".
 
     Note:
-    The [[!IEEE-754|IEEE-754]] `fusedMultiplyAdd` operation computes the intermediate results
-    as if with unbounded range and precision, and only the final result is rounded
-    to the destination type.
+    The [[!IEEE-754|IEEE-754]] `fusedMultiplyAdd` operation computes the [=intermediate results=]
+    as if with unbounded range and precision, and only the final result is [=rounding|rounded=]
+    to a value in the destination type.
     However, the [[#floating-point-accuracy]] rule for `fma` allows an implementation
     which performs an ordinary multiply to the target type followed by an ordinary addition.
-    In this case the intermediate values may overflow or lose accuracy, and the overall
+    In this case the [=intermediate result=] values may overflow or lose accuracy, and the overall
     operation is not "fused" at all.
+  <tr>
+    <td>Domain
+    <td>[=Implied from linear terms=] of the expressions |e2|[i] &times; |e2|[i] &plus; |e3|[i].
 </table>
 
 ### `fract` ### {#fract-builtin}
@@ -14525,7 +14743,7 @@ For example, if `e` is a very small negative number, then `fract(e)` may be 1.0.
     * When `e` is zero, the fraction is zero.
     * When `e` is non-zero and normal, `e` &equals; `fraction * 2`<sup>`exponent`</sup>, where
         the fraction is in the range [0.5, 1.0) or (-1.0, -0.5].
-    * Otherwise, `e` is denormalized, NaN, or infinite. The result fraction and exponent are [=indeterminate values=].
+    * Otherwise, `e` is [=ieee754/subnormal=], NaN, or infinite. The result fraction and exponent are [=indeterminate values=].
 
     Returns the `__frexp_result_f32` built-in structure, defined as follows:
     ```wgsl
@@ -14573,7 +14791,7 @@ but a value may infer the type.
     * When `e` is zero, the fraction is zero.
     * When `e` is non-zero and normal, `e` &equals; `fraction * 2`<sup>`exponent`</sup>, where
         the fraction is in the range [0.5, 1.0) or (-1.0, -0.5].
-    * Otherwise, `e` is denormalized, NaN, or infinite. The result fraction and exponent are [=indeterminate values=].
+    * Otherwise, `e` is [=ieee754/subnormal=], NaN, or infinite. The result fraction and exponent are [=indeterminate values=].
 
     Returns the `__frexp_result_f16` built-in structure, defined as if as follows:
     ```wgsl
@@ -14610,7 +14828,7 @@ but a value may infer the type.
     * When `e` is zero, the fraction is zero.
     * When `e` is non-zero and normal, `e` &equals; `fraction * 2`<sup>`exponent`</sup>, where
         the fraction is in the range [0.5, 1.0) or (-1.0, -0.5].
-    * When `e` is denormalized, the fraction and exponent are have unbounded error.
+    * When `e` is [=ieee754/subnormal=], the fraction and exponent are have unbounded error.
         The fraction may be any AbstractFloat value, and the exponent may be any AbstractInt value.
 
     Note: AbstractFloat expressions resulting in infinity or NaN cause a [=shader-creation error=].
@@ -14735,7 +14953,7 @@ but a value may infer the type.
     * When `ei` is zero, the fraction is zero.
     * When `ei` is non-zero and normal, `ei` &equals; `fraction * 2`<sup>`exponent`</sup>, where
         the fraction is in the range [0.5, 1.0) or (-1.0, -0.5].
-    * When `ei` is denormalized, the fraction and exponent are have unbounded error.
+    * When `ei` is [=ieee754/subnormal=], the fraction and exponent are have unbounded error.
         The fraction may be any AbstractFloat value, and the exponent may be any AbstractInt value.
 
     Note: AbstractFloat expressions resulting in infinity or NaN cause a [=shader-creation error=].
@@ -14809,10 +15027,8 @@ but a value may infer the type.
     <td>Returns the reciprocal of `sqrt(e)`.
     [=Component-wise=] when `T` is a vector.
   <tr>
-    <td>
-    <td>
-
-Note: The result is not mathematically meaningful if `e` &le; 0.
+    <td>Scalar [=domain=]
+    <td>Interval [0, [PINF]]
 </table>
 
 ### `ldexp` ### {#ldexp-builtin}
@@ -14881,6 +15097,7 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
 
         Note: The scalar case may be evaluated as `sqrt(e * e)`,
         which may unnecessarily overflow or lose accuracy.
+   <!-- No restriction on domain from formula sqrt(x*x) -->
 </table>
 
 ### `log` ### {#log-builtin}
@@ -14899,10 +15116,8 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
     <td>Returns the natural logarithm of `e`.
     [=Component-wise=] when `T` is a vector.
   <tr>
-    <td>
-    <td>
-
-Note: The result is not mathematically meaningful if `e` &lt; 0.
+    <td>Scalar [=domain=]
+    <td>Interval [0, [PINF]]
 </table>
 
 ### `log2` ### {#log2-builtin}
@@ -14921,10 +15136,8 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
     <td>Returns the base-2 logarithm of `e`.
     [=Component-wise=] when `T` is a vector.
   <tr>
-    <td>
-    <td>
-
-Note: The result is not mathematically meaningful if `e` &lt; 0.
+    <td>Scalar [=domain=]
+    <td>Interval [0, [PINF]]
 </table>
 
 ### `max` ### {#max-float-builtin}
@@ -14945,7 +15158,7 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
     [=Component-wise=] when `T` is a vector.
 
     If `e1` and `e2` are floating-point values, then:
-    * If both `e1` and `e2` are denormalized, then the result may be *either* value.
+    * If both `e1` and `e2` are [=ieee754/subnormal=], then the result may be *either* value.
     * If one operand is a NaN, the other is returned.
     * If both operands are NaNs, a NaN is returned.
 </table>
@@ -14968,7 +15181,7 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
     [=Component-wise=] when `T` is a vector.
 
     If `e1` and `e2` are floating-point values, then:
-    * If both `e1` and `e2` are denormalized, then the result may be *either* value.
+    * If both `e1` and `e2` are [=ieee754/subnormal=], then the result may be *either* value.
     * If one operand is a NaN, the other is returned.
     * If both operands are NaNs, a NaN is returned.
 </table>
@@ -14988,8 +15201,12 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the linear blend of `e1` and `e2` (e.g. `e1 * (1 - e3) + e2 * e3`).
+    <td>Returns the linear blend of `e1` and `e2` (e.g. `e1 * (T(1) - e3) + e2 * e3`).
     [=Component-wise=] when `T` is a vector.
+  <tr>
+    <td>Domain
+    <td>[=Implied from linear terms=] of the expressions: |e1|[i] &times; (1 &minus; |e3|[i]) &plus; |e2|[i] &times; |e3|[i].
+|e2|[i] &times; |e2|[i] &plus; |e3|[i].
 </table>
 
 <table class='data builtin'>
@@ -15010,6 +15227,9 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
     <td>Returns the component-wise linear blend of `e1` and `e2`,
         using scalar blending factor `e3` for each component.<br>
         Same as `mix(e1, e2, T2(e3))`.
+  <tr>
+    <td>Domain
+    <td>[=Implied from linear terms=] of the expressions: |e1|[i] &times; (1 &minus; |e3|) &plus; |e2|[i] &times; |e3|.
 </table>
 
 ### `modf` ### {#modf-builtin}
@@ -15248,6 +15468,8 @@ but a value may infer the type.
   <tr>
     <td>Description
     <td>Returns a unit vector in the same direction as `e`.
+
+    The [=domain=] is all vectors except the zero vector.
 </table>
 
 ### `pow` ### {#pow-builtin}
@@ -15266,6 +15488,17 @@ but a value may infer the type.
     <td>Description
     <td>Returns `e1` raised to the power `e2`.
     [=Component-wise=] when `T` is a vector.
+  <tr>
+    <td>Scalar [=domain=]
+    <td>The set of all pairs of [=extended reals=] (|x|,|y|) except:
+
+         * |x| < 0.
+         * |x| is 1 and |y| is infinite.
+         * |x| is infinite and |y| is 0.
+
+        This rule arises from the fact the result may be computed as
+        `exp2(y * log2(x))`.
+
 </table>
 
 ### `quantizeToF16` ### {#quantizeToF16-builtin}
@@ -15291,7 +15524,7 @@ but a value may infer the type.
         * Otherwise the result is an [=indeterminate value=] for `T`.
 
         The intermediate binary16 value may be [=flushed to zero=], i.e. the final
-        result may be zero if the intermediate binary16 value is denormalized.
+        result may be zero if the intermediate binary16 value is [=ieee754/subnormal=].
 
         See [[#floating-point-conversion]].
 
@@ -15452,6 +15685,9 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>Description
     <td>Returns the sine of `e`, where `e` is in radians.
     [=Component-wise=] when `T` is a vector.
+  <tr>
+    <td>Scalar [=domain=]
+    <td>Interval ([NINF], [PINF])
 </table>
 
 ### `sinh` ### {#sinh-builtin}
@@ -15517,6 +15753,9 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>Description
     <td>Returns the square root of `e`.
     [=Component-wise=] when `T` is a vector.
+  <tr>
+    <td>Scalar [=domain=]
+    <td>Interval [0, [PINF]]
 </table>
 
 ### `step` ### {#step-builtin}
@@ -15552,6 +15791,9 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>Description
     <td>Returns the tangent of `e`, where `e` is in radians.
     [=Component-wise=] when `T` is a vector.
+  <tr>
+    <td>Scalar [=domain=]
+    <td>Interval ([NINF], [PINF])
 </table>
 
 ### `tanh` ### {#tanh-builtin}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12316,7 +12316,7 @@ WGSL follows the [[!IEEE-754|IEEE-754]] standard, but with the following differe
 * Some built-in functions in WGSL have different semantics from the corresponding IEEE-754 operation.
     Such cases are listed as needed at the definition of the WGSL built-in function.
 
-    For example the WGSL [[#fma-builtin]] function expands to an ordinary multiply (including a rounding step) and an add (and another rounding step),
+    For example the WGSL [[#fma-builtin]] function may expand to an ordinary multiply (including a rounding step) and an add (and another rounding step),
     while the IEEE-754 `fusedMultiplyAdd` operation requires that only final rounding step occurs.
 
 ### Floating Point Overflow ### {#floating-point-overflow}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1127,16 +1127,16 @@ or a [=hexadecimal floating point literal=].
 path: syntax/float_literal.syntax.bs.include
 </pre>
 
-A [=floating point literal=] has two logical parts: a mantissa to representing a fraction, and an optional exponent.
-Roughly, the value of the literal is the mantissa multiplied by a base value raised to the given exponent.
-A mantissa digit is <dfn dfn-for="mantissa">significant</dfn> if it is non-zero,
-or if there are mantissa digits to its left and to its right that are both non-zero.
+A [=floating point literal=] has two logical parts: a significand to represent a fraction, and an optional exponent.
+Roughly, the value of the literal is the significand multiplied by a base value raised to the given exponent.
+A significand digit is <dfn dfn-for="significand">significant</dfn> if it is non-zero,
+or if there are significand digits to its left and to its right that are both non-zero.
 Significant digits are counted from left-to-right: the *N*'th significant digit has *N*-1 significant digits
 to its left.
 
 A <dfn noexport>decimal floating point literal</dfn> is:
-* A mantissa, specified as a sequence of digits, with an optional decimal point (`.`) somewhere among them.
-    The mantissa represents a fraction in base 10 notation.
+* A significand, specified as a sequence of digits, with an optional decimal point (`.`) somewhere among them.
+    The significand represents a fraction in base 10 notation.
 * Then an optional exponent suffix consisting of:
     * `e` or `E`.
     * Then an exponent specified as an decimal number with an optional leading sign (`+` or `-`).
@@ -1163,30 +1163,30 @@ path: syntax/decimal_float_literal.syntax.bs.include
 
 <div algorithm="mathematical value of decimal floating point literal">
 The mathematical value of a [=decimal floating point literal=] is computed as follows:
-* Compute |effective_mantissa| from |mantissa|:
-    * If |mantissa| has 20 or fewer [=mantissa/significant=] digits, then |effective_mantissa| is |mantissa|.
+* Compute |effective_significand| from |significand|:
+    * If |significand| has 20 or fewer [=significand/significant=] digits, then |effective_significand| is |significand|.
     * Otherwise:
-        * Let |truncated_mantissa| be the same as |mantissa| except each digit to the
+        * Let |truncated_significand| be the same as |significand| except each digit to the
              right of the 20th significant digit is replaced with 0.
-        * Let |truncated_mantissa_next| be the same as |mantissa| except:
+        * Let |truncated_significand_next| be the same as |significand| except:
              * the 20th significant digit is incremented by 1, and carries are propagated to the left as needed
                  needed to ensure each digit remains in the range 0 through 9, and
              * each digit to the right of the 20th significant digit is replaced with 0.
-        * Set |effective_mantissa| to either |truncated_mantissa| or |truncated_mantissa_next|.
+        * Set |effective_significand| to either |truncated_significand| or |truncated_significand_next|.
              This is an implementation choice.
-* The mathematical value of the literal is the mathematical value of |effective_mantissa| as a decimal fraction,
+* The mathematical value of the literal is the mathematical value of |effective_significand| as a decimal fraction,
     multiplied by 10 to the power of the exponent.
     When no exponent is specified, an exponent of 0 is assumed.
 
 </div>
 
-Note: The decimal mantissa is truncated after 20 decimal digits, preserving approximately log(10)/log(2)&times;20 &approx; 66.4 significant bits in the fraction.
+Note: The decimal significand is truncated after 20 decimal digits, preserving approximately log(10)/log(2)&times;20 &approx; 66.4 significant bits in the fraction.
 
 
 A <dfn noexport>hexadecimal floating point literal</dfn> is:
 * A `0x` or `0X` prefix
-* Then a mantissa, specified as a sequence of hexadecimal digits, with an optional hexadecimal point (`.`) somewhere among them.
-    The mantissa represents a fraction in base 16 notation.
+* Then a significand, specified as a sequence of hexadecimal digits, with an optional hexadecimal point (`.`) somewhere among them.
+    The significand represents a fraction in base 16 notation.
 * Then an optional exponent suffix consisting of:
     * `p` or `P`
     * Then an exponent specified as an decimal number with an optional leading sign (`+` or `-`).
@@ -1211,24 +1211,24 @@ path: syntax/hex_float_literal.syntax.bs.include
 
 <div algorithm="mathematical value of hexadecimal floating point literal">
 The mathematical value of a [=hexadecimal floating point literal=] is computed as follows:
-* Compute *effective_mantissa* from *mantissa*:
-    * If *mantissa* has 16 or fewer [=mantissa/significant=] digits, then *effective_mantissa* is *mantissa*.
+* Compute |effective_significand| from |significand|:
+    * If |significand| has 16 or fewer [=significand/significant=] digits, then |effective_significand| is |significand|.
     * Otherwise:
-        * Let |truncated_mantissa| be the same as |mantissa| except each digit to the
+        * Let |truncated_significand| be the same as |significand| except each digit to the
              right of the 16th significant digit is replaced with 0.
-        * Let |truncated_mantissa_next| be the same as |mantissa| except:
+        * Let |truncated_significand_next| be the same as |significand| except:
              * the 16th significant digit is incremented by 1, and carries are propagated to the left as needed
                  needed to ensure each digit remains in the range 0 through `f`, and
              * each digit to the right of the 16th significant digit is replaced with 0.
-        * Set |effective_mantissa| to either |truncated_mantissa| or |truncated_mantissa_next|.
+        * Set |effective_significand| to either |truncated_significand| or |truncated_significand_next|.
              This is an implementation choice.
-* The mathematical value of the literal is the mathematical value of |effective_mantissa| as a hexadecimal fraction,
+* The mathematical value of the literal is the mathematical value of |effective_significand| as a hexadecimal fraction,
     multiplied by 2 to the power of the exponent.
     When no exponent is specified, an exponent of 0 is assumed.
 
 </div>
 
-Note: The hexadecimal mantissa is truncated after 16 hexadecimal digits, preserving approximately 4 &times;16 &equals; 64 significant bits in the fraction.
+Note: The hexadecimal significand is truncated after 16 hexadecimal digits, preserving approximately 4 &times;16 &equals; 64 significant bits in the fraction.
 
 
 When a [=numeric literal=] has a suffix, the literal denotes a value in a specific [=type/concrete=] [=scalar=] type.
@@ -1256,8 +1256,8 @@ A [=shader-creation error=] results if:
 * A [=decimal floating point literal=] with a `f` or `h` suffix overflows the target type.
 * A [=floating point literal=] with a `h` suffix is used while the [=extension/f16|f16 extension=] is not enabled.
 
-Note: The hexadecimal float value 0x1.00000001p0 requires 33 mantissa bits to be represented exactly,
-but [=f32=] only has 23 explicit mantissa bits.
+Note: The hexadecimal float value 0x1.00000001p0 requires 33 significand bits to be represented exactly,
+but [=f32=] only has 23 explicit significand bits.
 
 Note: If you want to use an `f` suffix to force a hexadecimal float literal to be of type, the literal must also
 use a binary exponent.  For example, write `0x1p0f`.  In comparison, `0x1f` is a hexadecimal integer literal.
@@ -12654,8 +12654,8 @@ When converting a [=numeric scalar=] value to a floating point type:
          * A [=pipeline-creation error=] results if the original expression is an [=override-expression=].
          * Otherwise the conversion proceeds as follows:
              1. Set |X| to the original value.
-             2. If the source type is a floating point type with more mantissa bits than the destination type,
-                 the extra mantissa bits of the source value *may* be discarded (i.e. treated as if they are 0).
+             2. If the source type is a floating point type with more significand bits than the destination type,
+                 the extra significand bits of the source value *may* be discarded (i.e. treated as if they are 0).
                  Update |X| accordingly.
              3. If |X| is the most-positive or most-negative normal value of the destination type, then the result is |X|.
              4. Otherwise, the result is the infinity value of the destination type, with the same sign as |X|.
@@ -12664,7 +12664,7 @@ When converting a [=numeric scalar=] value to a floating point type:
 
 NOTE: An integer value may lie between two adjacent representable floating point values.
 In particular, the [=f32=] type uses 23 explicit fractional bits.
-Additionally, when the floating point value is in the normal range (the exponent is neither extreme value), then the mantissa is
+Additionally, when the floating point value is in the normal range (the exponent is neither extreme value), then the significand is
 the set of fractional bits together with an extra 1-bit at the most significant position at bit position 23.
 Then, for example, integers 2<sup>28</sup> and 1+2<sup>28</sup> both map to the same floating point value: the difference in the
 least significant 1 bit is not representable by the floating point format.
@@ -12674,7 +12674,7 @@ Note: The original value is always within range of the destination type when
 the original type is one of [=i32=] or [=u32=] and the destination type is [=f32=].
 
 Note: The original value is always within range of the destination type when
-the source type is a floating point type with fewer exponent and mantissa bits than the target floating point type.
+the source type is a floating point type with fewer exponent and significand bits than the target floating point type.
 
 ### Domains of Floating Point Expressions and Built-in Functions ### {#domains-of-floating-point-expressions-and-builtins}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12256,7 +12256,7 @@ a <dfn dfn-for="ieee754">rounding mode</dfn> determines which one is chosen.
 Generally, an operation with a [=NaN=] input will yield a [=NaN=] output.
 Exceptions include:
 * A NaN is never equal to, less than, or greater than any other floating point value. Such comparisons yield false.
-* For `minimum(x,y)` and `maximum(x,y)` operations, if one of the inputs is NaN, the result is the other input.
+* For `min(x,y)` and `max(x,y)` operations, if one of the inputs is NaN, the result is the other input.
 
 IEEE-754 defines five kinds of <dfn dfn-for="ieee754">exceptions</dfn>:
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12281,9 +12281,9 @@ IEEE-754 defines five kinds of <dfn dfn-for="ieee754">exceptions</dfn>:
 
 WGSL follows the [[!IEEE-754|IEEE-754]] standard, but with the following differences:
 * No [=ieee754/rounding mode=] is specified. An implementation may round an [=intermediate result=] up or down.
-* No floating point exceptions are generated.
+* No floating point [=ieee754/exceptions=] are generated.
     * A floating point operation in WGSL [=behavioral requirement|will=] produce an [=intermediate result=]
-        according to IEEE-754 rules, but [=ieee754/exceptions=] mandated by IEEE-754 will map to different
+        according to IEEE-754 rules, but exceptions mandated by IEEE-754 will map to different
         behaviors depending on whether the expression is
         a [=const-expression=], an [=override-expression=], or a [=runtime expression=].
     * Consider an operation on finite operands.
@@ -12308,7 +12308,7 @@ WGSL follows the [[!IEEE-754|IEEE-754]] standard, but with the following differe
     * Note: This means some functions (e.g. `min` and `max`)
         may not return the expected result due to optimizations about the presence
         of NaNs and infinities.
-* Implementations may ignore the [=ieee754/sign field=]of a zero.
+* Implementations may ignore the [=ieee754/sign field=] of a zero.
     That is, a zero with a positive sign may behave like a zero a with a negative sign, and vice versa.
 * To <dfn noexport title="flushed to zero">flush to zero</dfn> is to replace a [=ieee754/subnormal=] value for a floating point type
     with a zero value of that type.


### PR DESCRIPTION
* Refactor the inital material in the "Floating point evaluation" section into two new secitons:
* Add subsection "Overview of IEEE-754" which:
   * Defines enough of IEEE-754 behaviour needed to describe the WGSL's differences.
   * Defines 'subnormal' and 'normal'.
   * Defines 'intermediate result', 'rounding', and 'rounding mode'.
   * Defines key characteristics of binary16, binary32, binary64 formats.
   * Gives the algorithm to compute a floating point value from its it representation.
   * Describes operation on infinite values.
   * Absorbs description of 'domain' of an fp operation.
   * Describes operation on NaN values.
   * Absorbs description of IEEE 754 exceptions.
* Add subsection "Differences from IEEE-754"
   * Has most of the other material that used to be at the top of "Floating point evaluation"
   * Adds a clause about differences between corresponding WGSL and IEEE operations.
* Add a new section "Domains of Floating Point Expressions and Built-in Functions"
   * Describes how the rest of the spec defines the domains of specific operations.
   * Often the same from IEEE-754
   * Describes inferring the domain of component-wise operations from scalar domain.
   * Describes general rule of "inferred from linear terms", for inherited-from implementations that are linear expansions.
* Replace existing uses of 'denormalized' to 'subnormal'.
* Link uses of 'intermediate result' to the definition.
* List domain restrictions as needed for all operations:
   * add, subtract, multiply, divide, remainder
   * acos, acosh, asin, astanh, cos, distance, inverseSqrt, log, log2, normalize, pow, sin, sqrt, tan
* In float conversion to float, move the NaN clause to be second, instead of subordinate to the third. It reads better that way

Fixed: #2765, #2884, #3135, #3220, #4219