### PR TITLE
Clarify validation of storage texture texel-format and access modes

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -289,6 +289,7 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
             text: wgslLanguageFeatures; url: gpuwgsllanguagefeatures
     type: abstract-op
         text: validating GPUProgrammableStage; url: abstract-opdef-validating-gpuprogrammablestage
+        text: validating shader binding; url: abstract-opdef-validating-shader-binding
 </pre>
 
 # Introduction # {#intro}
@@ -4217,7 +4218,7 @@ Note: The channel transfer function for 8snorm maps {-128,...,127} to the floati
 The texel formats listed in the
 <dfn lt="storage-texel-formats">Texel Formats for Storage Textures</dfn> table
 correspond to the [[WebGPU#plain-color-formats|WebGPU plain color formats]]
-which support the WebGPU {{GPUTextureUsage/STORAGE_BINDING}} usage.
+which support the WebGPU {{GPUTextureUsage/STORAGE_BINDING}} usage with at least one [=access mode=].
 These texel formats are used to parameterize the [=type/storage texture=] types defined
 in [[#texture-storage]].
 
@@ -4400,6 +4401,10 @@ used to convert the shader value to the stored texel.
 
 * *Format* [=shader-creation error|must=] be an [=enumerant=] for one of the [=storage-texel-formats|texel formats for storage textures=]
 * *Access* [=shader-creation error|must=] be an [=enumerant=] for one of the [=access modes=].
+* No [=shader-creation error=] occurs due to an invalid combination of *Format* and *Access*.
+    Combinations of *Format* with *Access* are checked in the [$validating shader binding|shader binding validation$]
+    step during pipeline creation.
+    An invalid combination [=behavioral requirement|will=] result in a [=pipeline-creation error=].
 
 ### Depth Texture Types ### {#texture-depth}
 


### PR DESCRIPTION
- a texel mode is valid for storage textures if STORAGE_BINDING is valid with any access mode.
- validation of texel-format and access-mode occurs at pipeline-creation time, not shader-creation time.

Fixed: #4711