### PR TITLE
Better explain that you can't assign to a multi-letter swizzle

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5569,23 +5569,30 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            |e|`.x`: |T|<br>
            |e|`.r`: |T|
        <td>Select the first component of |e|
+
+       This is a single-letter [=swizzle=].
   <tr algorithm="second vector component selection"><td>|e|: vec|N|&lt;|T|&gt;<br>
        <td class="nowrap">
            |e|`.y`: |T|<br>
            |e|`.g`: |T|
        <td>Select the second component of |e|
+
+       This is a single-letter [=swizzle=].
   <tr algorithm="third vector component selection"><td>|e|: vec|N|&lt;|T|&gt;<br>
           |N| is 3 or 4
        <td class="nowrap">
            |e|`.z`: |T|<br>
            |e|`.b`: |T|
        <td>Select the third component of |e|
+
+       This is a single-letter [=swizzle=].
   <tr algorithm="fourth vector component selection"><td>|e|: vec4&lt;|T|&gt;
        <td class="nowrap">
            |e|`.w`: |T|<br>
            |e|`.a`: |T|
        <td>Select the fourth component of |e|
 
+       This is a single-letter [=swizzle=].
   <tr algorithm="vector indexed component selection concrete">
        <td>|e|: vec|N|&lt;|T|&gt;<br>
            |i|: [INT]<br>
@@ -5618,6 +5625,13 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
 </table>
 
 #### Vector Multiple Component Selection #### {#vector-multi-component}
+
+The expressions in this section are all multi-letter [=swizzles=].
+Each forms a [=vector=] from the components of another vector.
+
+A multi-letter [=swizzle=] cannot appear on the left-hand side of an [=statement/assignment=]:
+The left-hand side of an assignment must be of [=reference type=],
+but a multi-letter swizzle expression always yields a value of [=vector=] type.
 
 <table class='data'>
   <caption>Vector decomposition: multiple component selection
@@ -5708,10 +5722,18 @@ Note: In the table above, [=reference types=] are implicitly handled via the [=l
 
 #### Component Reference from Vector Memory View #### {#component-reference-from-vector-memory-view}
 
+The expressions in this section form a [=memory view=] of a single component of a [=vector=] from
+the memory view of the whole vector.
+
+The WGSL [=type rules=] imply that such expressions can appear:
+* on the left-hand side of an [=statement/assignment=], to write to that component in memory, or
+* any place where a value of the vector component type can appear.
+    In this case the [=Load Rule=] applies, loading the vector component from memory and yielding that component as the result.
+
 A [=write access=] to component of a vector **may** access all of the [=memory
 location|memory locations=] associated with that vector.
 
-Note: This means accesses to different components of a vector by different
+Note: This means accesses to different components of a vector in memory by different
 invocations must be synchronized if at least one access is a [=write access=].
 See [[#sync-builtin-functions]].
 


### PR DESCRIPTION
It's a consequence of the type rules. But causual readers won't see that.

Fixed: #4833