### PR TITLE
interstage-interpolation checks generate pipeline-creation errors, no…

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -290,6 +290,7 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
     type: abstract-op
         text: validating GPUProgrammableStage; url: abstract-opdef-validating-gpuprogrammablestage
         text: validating shader binding; url: abstract-opdef-validating-shader-binding
+        text: Interstage interface validation; url: abstract-opdef-validating-inter-stage-interfaces
 </pre>
 
 # Introduction # {#intro}
@@ -9791,9 +9792,10 @@ For user-defined IO of scalar or vector floating-point type:
 User-defined [=vertex=] outputs and [=fragment=] inputs of scalar or vector
 integer type [=shader-creation error|must=] always be specified with interpolation type `flat`.
 
-Interpolation attributes [=shader-creation error|must=] match between [=vertex=] outputs and [=fragment=]
-inputs with the same [=attribute/location=] assignment within the same [=pipeline=].
-
+[$Interstage interface validation$] checks that, within a [=GPURenderPipeline|render pipeline=],
+the interpolation properties of each user-defined [=fragment=] input match
+the interpolation properties of a vertex output with the same [=attribute/location=] assignment.
+If not, a [=pipeline-creation error=] [=behavioral requirement|will=] result.
 
 ### Resource Interface ### {#resource-interface}
 


### PR DESCRIPTION
…t shader-creation

Reference the validation algorithm in the WebGPU spec.

Fixed: #4836