### PR TITLE
Rename image copies -> texel copies

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13229,7 +13229,7 @@ interface GPUQueue {
     undefined writeTexture(
         GPUImageCopyTexture destination,
         AllowSharedBufferSource data,
-        GPUImageDataLayout dataLayout,
+        GPUTexelCopyBufferLayout dataLayout,
         GPUExtent3D size);
 
     undefined copyExternalImageToTexture(
@@ -13353,7 +13353,7 @@ GPUQueue includes GPUObjectBase;
                         Note: unlike
                         {{GPUCommandEncoder}}.{{GPUCommandEncoder/copyBufferToTexture()}},
                         there is no alignment requirement on either
-                        |dataLayout|.{{GPUImageDataLayout/bytesPerRow}} or |dataLayout|.{{GPUImageDataLayout/offset}}.
+                        |dataLayout|.{{GPUTexelCopyBufferLayout/bytesPerRow}} or |dataLayout|.{{GPUTexelCopyBufferLayout/offset}}.
                     </div>
 
                 1. Issue the subsequent steps on the [=Queue timeline=] of |this|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4579,7 +4579,7 @@ enum GPUTextureViewDimension {
             <figcaption>
                 Cubemap faces.
                 The +U/+V axes indicate the individual faces' texture coordinates,
-                and thus the [=image copy=] memory layout of each face.
+                and thus the [=texel copy=] memory layout of each face.
             </figcaption>
             <object type="image/svg+xml" data="img/cubemap.svg" width=350 height=260></object>
         </figure>
@@ -4877,7 +4877,7 @@ The <dfn dfn>texel block width</dfn> and <dfn dfn>texel block height</dfn> speci
     of values for every texture format.
 
 The <dfn dfn>texel block copy footprint</dfn> of an [=aspect=] of a {{GPUTextureFormat}} is the number of
-bytes one texel block occupies during an [=image copy=], if applicable.
+bytes one texel block occupies during a [=texel copy=], if applicable.
 
 Note:
 The <dfn dfn>texel block memory cost</dfn> of a {{GPUTextureFormat}} is the number of
@@ -16910,8 +16910,8 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers even if they use fi
             <th class=note heading>[=Texel block memory cost=] (Bytes)
             <th>Aspect
             <th>{{GPUTextureSampleType}}
-            <th>Valid [=image copy=] source
-            <th>Valid [=image copy=] destination
+            <th>Valid [=texel copy=] source
+            <th>Valid [=texel copy=] destination
             <th>[=Texel block copy footprint=] (Bytes)
             <th><dfn dfn>Aspect-specific format</dfn>
     </thead>
@@ -17024,7 +17024,7 @@ As a result, copies into such textures are only valid from other textures of the
 The depth aspects of depth24plus formats
 ({{GPUTextureFormat/"depth24plus"}} and {{GPUTextureFormat/"depth24plus-stencil8"}})
 have opaque representations (implemented as either [=24-bit depth=] or {{GPUTextureFormat/"depth32float"}}).
-As a result, depth-aspect [=image copies=] are not allowed with these formats.
+As a result, depth-aspect [=texel copies=] are not allowed with these formats.
 
 <div class=note heading>
     It is possible to imitate these disallowed copies:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9780,17 +9780,17 @@ interface GPUCommandEncoder {
 
     undefined copyBufferToTexture(
         GPUTexelCopyBufferInfo source,
-        GPUImageCopyTexture destination,
+        GPUTexelCopyTextureInfo destination,
         GPUExtent3D copySize);
 
     undefined copyTextureToBuffer(
-        GPUImageCopyTexture source,
+        GPUTexelCopyTextureInfo source,
         GPUTexelCopyBufferInfo destination,
         GPUExtent3D copySize);
 
     undefined copyTextureToTexture(
-        GPUImageCopyTexture source,
-        GPUImageCopyTexture destination,
+        GPUTexelCopyTextureInfo source,
+        GPUTexelCopyTextureInfo destination,
         GPUExtent3D copySize);
 
     undefined clearBuffer(
@@ -10252,7 +10252,7 @@ dictionary GPUCommandEncoderDescriptor
 
                 [=Content timeline=] steps:
 
-                1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
+                1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUTexelCopyTextureInfo/origin}}).
                 1. [=?=] [$validate GPUExtent3D shape$](|copySize|).
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             </div>
@@ -10277,10 +10277,10 @@ dictionary GPUCommandEncoderDescriptor
             <div data-timeline=queue>
                 [=Queue timeline=] steps:
 
-                1. Let |blockWidth| be the [=texel block width=] of |destination|.{{GPUImageCopyTexture/texture}}.
-                1. Let |blockHeight| be the [=texel block height=] of |destination|.{{GPUImageCopyTexture/texture}}.
+                1. Let |blockWidth| be the [=texel block width=] of |destination|.{{GPUTexelCopyTextureInfo/texture}}.
+                1. Let |blockHeight| be the [=texel block height=] of |destination|.{{GPUTexelCopyTextureInfo/texture}}.
 
-                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}}.
+                1. Let |dstOrigin| be |destination|.{{GPUTexelCopyTextureInfo/origin}}.
                 1. Let |dstBlockOriginX| be (|dstOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
                 1. Let |dstBlockOriginY| be (|dstOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
 
@@ -10295,7 +10295,7 @@ dictionary GPUCommandEncoderDescriptor
                     1. For each |y| in the range [0, |blockRows| &minus; 1]:
                         1. For each |x| in the range [0, |blockColumns| &minus; 1]:
                             1. Let |blockOffset| be the [$texel block byte offset$] of |source| for (|x|, |y|, |z|) of
-                                |destination|.{{GPUImageCopyTexture/texture}}.
+                                |destination|.{{GPUTexelCopyTextureInfo/texture}}.
 
                             1. Set [=texel block=] (|dstBlockOriginX| &plus; |x|, |dstBlockOriginY| &plus; |y|) of
                                 |dstSubregion| to be an [=equivalent texel representation=] to the [=texel block=]
@@ -10325,7 +10325,7 @@ dictionary GPUCommandEncoderDescriptor
 
                 [=Content timeline=] steps:
 
-                1. [=?=] [$validate GPUOrigin3D shape$](|source|.{{GPUImageCopyTexture/origin}}).
+                1. [=?=] [$validate GPUOrigin3D shape$](|source|.{{GPUTexelCopyTextureInfo/origin}}).
                 1. [=?=] [$validate GPUExtent3D shape$](|copySize|).
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             </div>
@@ -10350,10 +10350,10 @@ dictionary GPUCommandEncoderDescriptor
             <div data-timeline=queue>
                 [=Queue timeline=] steps:
 
-                1. Let |blockWidth| be the [=texel block width=] of |source|.{{GPUImageCopyTexture/texture}}.
-                1. Let |blockHeight| be the [=texel block height=] of |source|.{{GPUImageCopyTexture/texture}}.
+                1. Let |blockWidth| be the [=texel block width=] of |source|.{{GPUTexelCopyTextureInfo/texture}}.
+                1. Let |blockHeight| be the [=texel block height=] of |source|.{{GPUTexelCopyTextureInfo/texture}}.
 
-                1. Let |srcOrigin| be |source|.{{GPUImageCopyTexture/origin}}.
+                1. Let |srcOrigin| be |source|.{{GPUTexelCopyTextureInfo/origin}}.
                 1. Let |srcBlockOriginX| be (|srcOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
                 1. Let |srcBlockOriginY| be (|srcOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
 
@@ -10368,7 +10368,7 @@ dictionary GPUCommandEncoderDescriptor
                     1. For each |y| in the range [0, |blockRows| &minus; 1]:
                         1. For each |x| in the range [0, |blockColumns| &minus; 1]:
                             1. Let |blockOffset| be the [$texel block byte offset$] of |destination| for (|x|, |y|, |z|) of
-                                |source|.{{GPUImageCopyTexture/texture}}.
+                                |source|.{{GPUTexelCopyTextureInfo/texture}}.
 
                             1. Set |destination|.{{GPUTexelCopyBufferInfo/buffer}} at offset |blockOffset| to be an
                                 [=equivalent texel representation=] to [=texel block=]
@@ -10399,8 +10399,8 @@ dictionary GPUCommandEncoderDescriptor
 
                 [=Content timeline=] steps:
 
-                1. [=?=] [$validate GPUOrigin3D shape$](|source|.{{GPUImageCopyTexture/origin}}).
-                1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
+                1. [=?=] [$validate GPUOrigin3D shape$](|source|.{{GPUTexelCopyTextureInfo/origin}}).
+                1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUTexelCopyTextureInfo/origin}}).
                 1. [=?=] [$validate GPUExtent3D shape$](|copySize|).
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             </div>
@@ -10411,17 +10411,17 @@ dictionary GPUCommandEncoderDescriptor
                 1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
-                        - Let |srcTexture| be |source|.{{GPUImageCopyTexture/texture}}.
-                        - Let |dstTexture| be |destination|.{{GPUImageCopyTexture/texture}}.
-                        - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
+                        - Let |srcTexture| be |source|.{{GPUTexelCopyTextureInfo/texture}}.
+                        - Let |dstTexture| be |destination|.{{GPUTexelCopyTextureInfo/texture}}.
+                        - [$validating GPUTexelCopyTextureInfo$](|source|, |copySize|) returns `true`.
                         - |srcTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
-                        - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
+                        - [$validating GPUTexelCopyTextureInfo$](|destination|, |copySize|) returns `true`.
                         - |dstTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_DST}}.
                         - |srcTexture|.{{GPUTexture/sampleCount}} is equal to |dstTexture|.{{GPUTexture/sampleCount}}.
                         - |srcTexture|.{{GPUTexture/format}} and |dstTexture|.{{GPUTexture/format}}
                             must be [=copy-compatible=].
                         - If |srcTexture|.{{GPUTexture/format}} is a depth-stencil format:
-                            - |source|.{{GPUImageCopyTexture/aspect}} and |destination|.{{GPUImageCopyTexture/aspect}}
+                            - |source|.{{GPUTexelCopyTextureInfo/aspect}} and |destination|.{{GPUTexelCopyTextureInfo/aspect}}
                                 must both refer to all aspects of |srcTexture|.{{GPUTexture/format}}
                                 and |dstTexture|.{{GPUTexture/format}}, respectively.
                         - The [$set of subresources for texture copy$](|source|, |copySize|) and
@@ -10434,14 +10434,14 @@ dictionary GPUCommandEncoderDescriptor
             <div data-timeline=queue>
                 [=Queue timeline=] steps:
 
-                1. Let |blockWidth| be the [=texel block width=] of |source|.{{GPUImageCopyTexture/texture}}.
-                1. Let |blockHeight| be the [=texel block height=] of |source|.{{GPUImageCopyTexture/texture}}.
+                1. Let |blockWidth| be the [=texel block width=] of |source|.{{GPUTexelCopyTextureInfo/texture}}.
+                1. Let |blockHeight| be the [=texel block height=] of |source|.{{GPUTexelCopyTextureInfo/texture}}.
 
-                1. Let |srcOrigin| be |source|.{{GPUImageCopyTexture/origin}}.
+                1. Let |srcOrigin| be |source|.{{GPUTexelCopyTextureInfo/origin}}.
                 1. Let |srcBlockOriginX| be (|srcOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
                 1. Let |srcBlockOriginY| be (|srcOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
 
-                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}}.
+                1. Let |dstOrigin| be |destination|.{{GPUTexelCopyTextureInfo/origin}}.
                 1. Let |dstBlockOriginX| be (|dstOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
                 1. Let |dstBlockOriginY| be (|dstOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
 
@@ -13227,7 +13227,7 @@ interface GPUQueue {
         optional GPUSize64 size);
 
     undefined writeTexture(
-        GPUImageCopyTexture destination,
+        GPUTexelCopyTextureInfo destination,
         AllowSharedBufferSource data,
         GPUTexelCopyBufferLayout dataLayout,
         GPUExtent3D size);
@@ -13329,7 +13329,7 @@ GPUQueue includes GPUObjectBase;
 
                 [=Content timeline=] steps:
 
-                1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
+                1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUTexelCopyTextureInfo/origin}}).
                 1. [=?=] [$validate GPUExtent3D shape$](|size|).
                 1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
 
@@ -13347,7 +13347,7 @@ GPUQueue includes GPUObjectBase;
                     [$generate a validation error$] and return.
 
                     <div class=validusage>
-                        - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[destroyed]]}} is `false`.
+                        - |destination|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/[[destroyed]]}} is `false`.
                         - [$validating texture buffer copy$](|destination|, |dataLayout|, |dataLength|, |size|, {{GPUTextureUsage/COPY_DST}}, |aligned|) returns `true`.
 
                         Note: unlike
@@ -13361,10 +13361,10 @@ GPUQueue includes GPUObjectBase;
             <div data-timeline=queue>
                 [=Queue timeline=] steps:
 
-                1. Let |blockWidth| be the [=texel block width=] of |destination|.{{GPUImageCopyTexture/texture}}.
-                1. Let |blockHeight| be the [=texel block height=] of |destination|.{{GPUImageCopyTexture/texture}}.
+                1. Let |blockWidth| be the [=texel block width=] of |destination|.{{GPUTexelCopyTextureInfo/texture}}.
+                1. Let |blockHeight| be the [=texel block height=] of |destination|.{{GPUTexelCopyTextureInfo/texture}}.
 
-                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}};
+                1. Let |dstOrigin| be |destination|.{{GPUTexelCopyTextureInfo/origin}};
                 1. Let |dstBlockOriginX| be (|dstOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
                 1. Let |dstBlockOriginY| be (|dstOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
 
@@ -13379,7 +13379,7 @@ GPUQueue includes GPUObjectBase;
                     1. For each |y| in the range [0, |blockRows| &minus; 1]:
                         1. For each |x| in the range [0, |blockColumns| &minus; 1]:
                             1. Let |blockOffset| be the [$texel block byte offset$] of |dataLayout| for (|x|, |y|, |z|) of
-                                |destination|.{{GPUImageCopyTexture/texture}}.
+                                |destination|.{{GPUTexelCopyTextureInfo/texture}}.
 
                             1. Set [=texel block=] (|dstBlockOriginX| &plus; |x|, |dstBlockOriginY| &plus; |y|) of
                                 |dstSubregion| to be an [=equivalent texel representation=] to the [=texel block=]
@@ -13434,7 +13434,7 @@ GPUQueue includes GPUObjectBase;
                 [=Content timeline=] steps:
 
                 1. [=?=] [$validate GPUOrigin2D shape$](|source|.{{GPUImageCopyExternalImage/origin}}).
-                1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
+                1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUTexelCopyTextureInfo/origin}}).
                 1. [=?=] [$validate GPUExtent3D shape$](|copySize|).
                 1. Let |sourceImage| be |source|.{{GPUImageCopyExternalImage/source}}
                 1. If |sourceImage| <l spec=html>[=is not origin-clean=]</l>,
@@ -13455,14 +13455,14 @@ GPUQueue includes GPUObjectBase;
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
+                1. Let |texture| be |destination|.{{GPUTexelCopyTextureInfo/texture}}.
                 1. If any of the following requirements are unmet, [$generate a validation error$] and return.
 
                     <div class=validusage>
                         - |usability| must be `good`.
                         - |texture|.{{GPUTexture/[[destroyed]]}} must be `false`.
                         - |texture| must be [$valid to use with$] |this|.
-                        - [$validating GPUImageCopyTexture$](destination, copySize) must return `true`.
+                        - [$validating GPUTexelCopyTextureInfo$](destination, copySize) must return `true`.
                         - |texture|.{{GPUTexture/usage}} must include both
                             {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/COPY_DST}}.
                         - |texture|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
@@ -13490,12 +13490,12 @@ GPUQueue includes GPUObjectBase;
             <div data-timeline=queue>
                 [=Queue timeline=] steps:
 
-                1. [=Assert=] that the [=texel block width=] of |destination|.{{GPUImageCopyTexture/texture}} is 1,
-                    the [=texel block height=] of |destination|.{{GPUImageCopyTexture/texture}} is 1, and that
+                1. [=Assert=] that the [=texel block width=] of |destination|.{{GPUTexelCopyTextureInfo/texture}} is 1,
+                    the [=texel block height=] of |destination|.{{GPUTexelCopyTextureInfo/texture}} is 1, and that
                     |copySize|.[=GPUExtent3D/depthOrArrayLayers=] is 1.
 
                 1. Let |srcOrigin| be |source|.{{GPUImageCopyExternalImage/origin}}.
-                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}}.
+                1. Let |dstOrigin| be |destination|.{{GPUTexelCopyTextureInfo/origin}}.
                 1. Let |dstSubregion| be [$texture copy sub-region$] (|dstOrigin|.[=GPUOrigin3D/z=]) of |destination|.
 
                 1. For each |y| in the range [0, |copySize|.[=GPUExtent3D/height=] &minus; 1]:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13234,7 +13234,7 @@ interface GPUQueue {
 
     undefined copyExternalImageToTexture(
         GPUImageCopyExternalImage source,
-        GPUImageCopyTextureTagged destination,
+        GPUCopyExternalImageDestInfo destination,
         GPUExtent3D copySize);
 };
 GPUQueue includes GPUObjectBase;
@@ -13393,7 +13393,7 @@ GPUQueue includes GPUObjectBase;
         into the destination texture.
 
         This operation performs [[#color-space-conversions|color encoding]] into the destination
-        encoding according to the parameters of {{GPUImageCopyTextureTagged}}.
+        encoding according to the parameters of {{GPUCopyExternalImageDestInfo}}.
 
         Copying into a `-srgb` texture results in the same texture bytes, not the same decoded
         values, as copying into the corresponding non-`-srgb` format.
@@ -13508,8 +13508,8 @@ GPUQueue includes GPUObjectBase;
                             (|srcOrigin|.[=GPUOrigin2D/x=] &plus; |x|, |srcOrigin|.[=GPUOrigin2D/y=] &plus; |srcY|) of
                             |source|.{{GPUImageCopyExternalImage/source}} after applying any
                             [[#color-space-conversions|color encoding]] required by
-                            |destination|.{{GPUImageCopyTextureTagged/colorSpace}} and
-                            |destination|.{{GPUImageCopyTextureTagged/premultipliedAlpha}}.
+                            |destination|.{{GPUCopyExternalImageDestInfo/colorSpace}} and
+                            |destination|.{{GPUCopyExternalImageDestInfo/premultipliedAlpha}}.
             </div>
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2112,7 +2112,7 @@ implementations **should** elide it, for performance.
 
 For optimal performance, applications **should** set their color space and encoding
 options so that the number of necessary conversions is minimized throughout the process.
-For various image sources of {{GPUImageCopyExternalImage}}:
+For various image sources of {{GPUCopyExternalImageSourceInfo}}:
 
 - {{ImageBitmap}}:
     - Premultiplication is controlled via {{ImageBitmapOptions/premultiplyAlpha}}.
@@ -13233,7 +13233,7 @@ interface GPUQueue {
         GPUExtent3D size);
 
     undefined copyExternalImageToTexture(
-        GPUImageCopyExternalImage source,
+        GPUCopyExternalImageSourceInfo source,
         GPUCopyExternalImageDestInfo destination,
         GPUExtent3D copySize);
 };
@@ -13433,10 +13433,10 @@ GPUQueue includes GPUObjectBase;
 
                 [=Content timeline=] steps:
 
-                1. [=?=] [$validate GPUOrigin2D shape$](|source|.{{GPUImageCopyExternalImage/origin}}).
+                1. [=?=] [$validate GPUOrigin2D shape$](|source|.{{GPUCopyExternalImageSourceInfo/origin}}).
                 1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUTexelCopyTextureInfo/origin}}).
                 1. [=?=] [$validate GPUExtent3D shape$](|copySize|).
-                1. Let |sourceImage| be |source|.{{GPUImageCopyExternalImage/source}}
+                1. Let |sourceImage| be |source|.{{GPUCopyExternalImageSourceInfo/source}}
                 1. If |sourceImage| <l spec=html>[=is not origin-clean=]</l>,
                     throw a {{SecurityError}} and return.
                 1. If any of the following requirements are unmet, throw an {{OperationError}} and return.
@@ -13494,19 +13494,19 @@ GPUQueue includes GPUObjectBase;
                     the [=texel block height=] of |destination|.{{GPUTexelCopyTextureInfo/texture}} is 1, and that
                     |copySize|.[=GPUExtent3D/depthOrArrayLayers=] is 1.
 
-                1. Let |srcOrigin| be |source|.{{GPUImageCopyExternalImage/origin}}.
+                1. Let |srcOrigin| be |source|.{{GPUCopyExternalImageSourceInfo/origin}}.
                 1. Let |dstOrigin| be |destination|.{{GPUTexelCopyTextureInfo/origin}}.
                 1. Let |dstSubregion| be [$texture copy sub-region$] (|dstOrigin|.[=GPUOrigin3D/z=]) of |destination|.
 
                 1. For each |y| in the range [0, |copySize|.[=GPUExtent3D/height=] &minus; 1]:
-                    1. Let |srcY| be |y| if |source|.{{GPUImageCopyExternalImage/flipY}} is `false` and
+                    1. Let |srcY| be |y| if |source|.{{GPUCopyExternalImageSourceInfo/flipY}} is `false` and
                         (|copySize|.[=GPUExtent3D/height=] &minus; 1 &minus; |y|) otherwise.
                     1. For each |x| in the range [0, |copySize|.[=GPUExtent3D/width=] &minus; 1]:
                         1. Set [=texel block=]
                             (|dstOrigin|.[=GPUOrigin3D/x=] &plus; |x|, |dstOrigin|.[=GPUOrigin3D/y=] &plus; |y|) of
                             |dstSubregion| to be an [=equivalent texel representation=] of the pixel at
                             (|srcOrigin|.[=GPUOrigin2D/x=] &plus; |x|, |srcOrigin|.[=GPUOrigin2D/y=] &plus; |srcY|) of
-                            |source|.{{GPUImageCopyExternalImage/source}} after applying any
+                            |source|.{{GPUCopyExternalImageSourceInfo/source}} after applying any
                             [[#color-space-conversions|color encoding]] required by
                             |destination|.{{GPUCopyExternalImageDestInfo/colorSpace}} and
                             |destination|.{{GPUCopyExternalImageDestInfo/premultipliedAlpha}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10228,7 +10228,9 @@ dictionary GPUCommandEncoderDescriptor
         </div>
 </dl>
 
-## Image Copy Commands ## {#commands-image-copies}
+<h3 id=commands-texel-copies>Texel Copy Commands
+<span id=commands-image-copies></span>
+</h3>
 
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>copyBufferToTexture(source, destination, copySize)</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9779,13 +9779,13 @@ interface GPUCommandEncoder {
         GPUSize64 size);
 
     undefined copyBufferToTexture(
-        GPUImageCopyBuffer source,
+        GPUTexelCopyBufferInfo source,
         GPUImageCopyTexture destination,
         GPUExtent3D copySize);
 
     undefined copyTextureToBuffer(
         GPUImageCopyTexture source,
-        GPUImageCopyBuffer destination,
+        GPUTexelCopyBufferInfo destination,
         GPUExtent3D copySize);
 
     undefined copyTextureToTexture(
@@ -10261,12 +10261,12 @@ dictionary GPUCommandEncoderDescriptor
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. Let |aligned| be `true`.
-                1. Let |dataLength| be |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}}.
+                1. Let |dataLength| be |source|.{{GPUTexelCopyBufferInfo/buffer}}.{{GPUBuffer/size}}.
                 1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
-                        - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
-                        - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/usage}} contains
+                        - [$validating GPUTexelCopyBufferInfo$](|source|) returns `true`.
+                        - |source|.{{GPUTexelCopyBufferInfo/buffer}}.{{GPUBuffer/usage}} contains
                             {{GPUBufferUsage/COPY_SRC}}.
                         - [$validating texture buffer copy$](|destination|, |source|, |dataLength|, |copySize|, {{GPUTextureUsage/COPY_DST}}, |aligned|) returns `true`.
                     </div>
@@ -10299,7 +10299,7 @@ dictionary GPUCommandEncoderDescriptor
 
                             1. Set [=texel block=] (|dstBlockOriginX| &plus; |x|, |dstBlockOriginY| &plus; |y|) of
                                 |dstSubregion| to be an [=equivalent texel representation=] to the [=texel block=]
-                                described by |source|.{{GPUImageCopyBuffer/buffer}} at offset |blockOffset|.
+                                described by |source|.{{GPUTexelCopyBufferInfo/buffer}} at offset |blockOffset|.
             </div>
 
         </div>
@@ -10334,12 +10334,12 @@ dictionary GPUCommandEncoderDescriptor
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. Let |aligned| be `true`.
-                1. Let |dataLength| be |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}}.
+                1. Let |dataLength| be |destination|.{{GPUTexelCopyBufferInfo/buffer}}.{{GPUBuffer/size}}.
                 1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
-                        - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
-                        - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/usage}} contains
+                        - [$validating GPUTexelCopyBufferInfo$](|destination|) returns `true`.
+                        - |destination|.{{GPUTexelCopyBufferInfo/buffer}}.{{GPUBuffer/usage}} contains
                             {{GPUBufferUsage/COPY_DST}}.
                         - [$validating texture buffer copy$](|source|, |destination|, |dataLength|, |copySize|, {{GPUTextureUsage/COPY_SRC}}, |aligned|) returns `true`.
                     </div>
@@ -10370,7 +10370,7 @@ dictionary GPUCommandEncoderDescriptor
                             1. Let |blockOffset| be the [$texel block byte offset$] of |destination| for (|x|, |y|, |z|) of
                                 |source|.{{GPUImageCopyTexture/texture}}.
 
-                            1. Set |destination|.{{GPUImageCopyBuffer/buffer}} at offset |blockOffset| to be an
+                            1. Set |destination|.{{GPUTexelCopyBufferInfo/buffer}} at offset |blockOffset| to be an
                                 [=equivalent texel representation=] to [=texel block=]
                                 (|srcBlockOriginX| &plus; |x|, |srcBlockOriginY| &plus; |y|) of |srcSubregion|.
             </div>

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -143,16 +143,16 @@ dictionary GPUTexelCopyBufferInfo
         </div>
 </div>
 
-<h4 id=gpuimagecopytexture data-dfn-type=dictionary>`GPUImageCopyTexture`
+<h4 id=gpuimagecopytexture data-dfn-type=dictionary>`GPUTexelCopyTextureInfo`
 <span id=gpu-image-copy-texture></span>
 </h4>
 
-In an [=image copy=] operation, a {{GPUImageCopyTexture}} defines a {{GPUTexture}} and, together with
+In an [=image copy=] operation, a {{GPUTexelCopyTextureInfo}} defines a {{GPUTexture}} and, together with
 the `copySize`, the sub-region of the texture (spanning one or more contiguous
 [=texture subresources=] at the same mip-map level).
 
 <script type=idl>
-dictionary GPUImageCopyTexture {
+dictionary GPUTexelCopyTextureInfo {
     required GPUTexture texture;
     GPUIntegerCoordinate mipLevel = 0;
     GPUOrigin3D origin = {};
@@ -160,14 +160,14 @@ dictionary GPUImageCopyTexture {
 };
 </script>
 
-<dl dfn-type=dict-member dfn-for=GPUImageCopyTexture>
+<dl dfn-type=dict-member dfn-for=GPUTexelCopyTextureInfo>
     : <dfn>texture</dfn>
     ::
         Texture to copy to/from.
 
     : <dfn>mipLevel</dfn>
     ::
-        Mip-map level of the {{GPUImageCopyTexture/texture}} to copy to/from.
+        Mip-map level of the {{GPUTexelCopyTextureInfo/texture}} to copy to/from.
 
     : <dfn>origin</dfn>
     ::
@@ -176,14 +176,14 @@ dictionary GPUImageCopyTexture {
 
     : <dfn>aspect</dfn>
     ::
-        Defines which aspects of the {{GPUImageCopyTexture/texture}} to copy to/from.
+        Defines which aspects of the {{GPUTexelCopyTextureInfo/texture}} to copy to/from.
 </dl>
 
 <div algorithm data-timeline=const>
-    The <dfn abstract-op>texture copy sub-region</dfn> for depth slice or array layer |index| of {{GPUImageCopyTexture}}
+    The <dfn abstract-op>texture copy sub-region</dfn> for depth slice or array layer |index| of {{GPUTexelCopyTextureInfo}}
     |copyTexture| is determined by running the following steps:
 
-        1. Let |texture| be |copyTexture|.{{GPUImageCopyTexture/texture}}.
+        1. Let |texture| be |copyTexture|.{{GPUTexelCopyTextureInfo/texture}}.
         1. If |texture|.{{GPUTexture/dimension}} is:
             <dl class=switch>
                 : {{GPUTextureDimension/1d}}
@@ -196,8 +196,8 @@ dictionary GPUImageCopyTexture {
                 : {{GPUTextureDimension/3d}}
                 :: Let |depthSliceOrLayer| be depth slice |index| of |texture|
             </dl>
-        1. Let |textureMip| be mip level |copyTexture|.{{GPUImageCopyTexture/mipLevel}} of |depthSliceOrLayer|.
-        1. Return aspect |copyTexture|.{{GPUImageCopyTexture/aspect}} of |textureMip|.
+        1. Let |textureMip| be mip level |copyTexture|.{{GPUTexelCopyTextureInfo/mipLevel}} of |depthSliceOrLayer|.
+        1. Return aspect |copyTexture|.{{GPUTexelCopyTextureInfo/aspect}} of |textureMip|.
 </div>
 
 <div algorithm data-timeline=const>
@@ -214,33 +214,33 @@ dictionary GPUImageCopyTexture {
 </div>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>validating GPUImageCopyTexture</dfn>(|imageCopyTexture|, |copySize|)
+    <dfn abstract-op>validating GPUTexelCopyTextureInfo</dfn>(|imageCopyTexture|, |copySize|)
 
     **Arguments:**
 
-    - {{GPUImageCopyTexture}} |imageCopyTexture|
+    - {{GPUTexelCopyTextureInfo}} |imageCopyTexture|
     - {{GPUExtent3D}} |copySize|
 
     **Returns:** {{boolean}}
 
     [=Device timeline=] steps:
 
-    1. Let |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
-    1. Let |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
+    1. Let |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
+    1. Let |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
 
     1. Return `true` if and only if all of the following conditions apply:
 
         <div class=validusage>
             - [$validating texture copy range$](|imageCopyTexture|, |copySize|) returns `true`.
-            - |imageCopyTexture|.{{GPUImageCopyTexture/texture}} must be a [=valid=] {{GPUTexture}}.
-            - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be &lt;
-                |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/mipLevelCount}}.
-            - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/x=] must be a multiple of |blockWidth|.
-            - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/y=] must be a multiple of |blockHeight|.
+            - |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}} must be a [=valid=] {{GPUTexture}}.
+            - |imageCopyTexture|.{{GPUTexelCopyTextureInfo/mipLevel}} must be &lt;
+                |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/mipLevelCount}}.
+            - |imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/x=] must be a multiple of |blockWidth|.
+            - |imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/y=] must be a multiple of |blockHeight|.
             - The [=imageCopyTexture physical subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
                 the following conditions is true:
-                - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}} is a depth-stencil format.
-                - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/sampleCount}} &gt; 1.
+                - |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}} is a depth-stencil format.
+                - |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/sampleCount}} &gt; 1.
         </div>
 </div>
 
@@ -249,7 +249,7 @@ dictionary GPUImageCopyTexture {
 
     **Arguments:**
 
-    - {{GPUImageCopyTexture}} |imageCopyTexture|
+    - {{GPUTexelCopyTextureInfo}} |imageCopyTexture|
     - {{GPUTexelCopyBufferLayout}} |dataLayout|
     - {{GPUSize64Out}} |dataLength|
     - {{GPUExtent3D}} |copySize|
@@ -260,18 +260,18 @@ dictionary GPUImageCopyTexture {
 
     [=Device timeline=] steps:
 
-    1. Let |texture| be |imageCopyTexture|.{{GPUImageCopyTexture/texture}}
+    1. Let |texture| be |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}
     1. Let |aspectSpecificFormat| = |texture|.{{GPUTexture/format}}.
     1. Let |offsetAlignment| = [=texel block copy footprint=] of |texture|.{{GPUTexture/format}}.
 
     1. Return `true` if and only if all of the following conditions apply:
 
         <div class=validusage>
-            1. [$validating GPUImageCopyTexture$](|imageCopyTexture|, |copySize|) returns `true`.
+            1. [$validating GPUTexelCopyTextureInfo$](|imageCopyTexture|, |copySize|) returns `true`.
             1. |texture|.{{GPUTexture/sampleCount}} is 1.
             1. |texture|.{{GPUTexture/usage}} contains |textureUsage|.
             1. If |texture|.{{GPUTexture/format}} is a [=depth-or-stencil format=] format:
-                1. |imageCopyTexture|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
+                1. |imageCopyTexture|.{{GPUTexelCopyTextureInfo/aspect}} must refer to a single aspect of
                     |texture|.{{GPUTexture/format}}.
                 1. If |textureUsage| is:
                     <dl class=switch>
@@ -299,7 +299,7 @@ dictionary GPUImageCopyTexture {
 WebGPU textures hold raw numeric data, and are not tagged with semantic metadata describing colors.
 However, {{GPUQueue/copyExternalImageToTexture()}} copies from sources that describe colors.
 
-A {{GPUImageCopyTextureTagged}} is a {{GPUImageCopyTexture}} which is additionally tagged with
+A {{GPUImageCopyTextureTagged}} is a {{GPUTexelCopyTextureInfo}} which is additionally tagged with
 color space/encoding and alpha-premultiplication metadata, so that semantic color data may be
 preserved during copies.
 This metadata affects only the semantics of the {{GPUQueue/copyExternalImageToTexture()}}
@@ -307,7 +307,7 @@ operation, not the semantics of the destination texture.
 
 <script type=idl>
 dictionary GPUImageCopyTextureTagged
-         : GPUImageCopyTexture {
+         : GPUTexelCopyTextureInfo {
     PredefinedColorSpace colorSpace = "srgb";
     boolean premultipliedAlpha = false;
 };
@@ -437,15 +437,15 @@ are defined by the source type, given by this table:
 
     **Arguments:**
 
-    - {{GPUImageCopyTexture}} |imageCopyTexture|
+    - {{GPUTexelCopyTextureInfo}} |imageCopyTexture|
 
     **Returns:** {{GPUExtent3D}}
 
     The [=imageCopyTexture physical subresource size=] of |imageCopyTexture| is calculated as follows:
 
     Its [=GPUExtent3D/width=], [=GPUExtent3D/height=] and [=GPUExtent3D/depthOrArrayLayers=] are the width, height, and depth, respectively,
-    of the [=physical miplevel-specific texture extent=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} [=subresource=] at [=mipmap level=]
-    |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}}.
+    of the [=physical miplevel-specific texture extent=] of |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}} [=subresource=] at [=mipmap level=]
+    |imageCopyTexture|.{{GPUTexelCopyTextureInfo/mipLevel}}.
 </div>
 
 <div algorithm data-timeline=device>
@@ -508,22 +508,22 @@ are defined by the source type, given by this table:
 
     **Arguments:**
 
-    : {{GPUImageCopyTexture}} |imageCopyTexture|
+    : {{GPUTexelCopyTextureInfo}} |imageCopyTexture|
     :: The texture subresource being copied into and copy origin.
     : {{GPUExtent3D}} |copySize|
     :: The size of the texture.
 
     [=Device timeline=] steps:
 
-    1. Let |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
-    1. Let |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
+    1. Let |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
+    1. Let |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
     1. Let |subresourceSize| be the [=imageCopyTexture physical subresource size=] of |imageCopyTexture|.
     1. Return whether all the conditions below are satisfied:
 
         <div class=validusage>
-            - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/x=] + |copySize|.[=GPUExtent3D/width=]) &le; |subresourceSize|.[=GPUExtent3D/width=]
-            - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/y=] + |copySize|.[=GPUExtent3D/height=]) &le; |subresourceSize|.[=GPUExtent3D/height=]
-            - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/z=] + |copySize|.[=GPUExtent3D/depthOrArrayLayers=]) &le; |subresourceSize|.[=GPUExtent3D/depthOrArrayLayers=]
+            - (|imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/x=] + |copySize|.[=GPUExtent3D/width=]) &le; |subresourceSize|.[=GPUExtent3D/width=]
+            - (|imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/y=] + |copySize|.[=GPUExtent3D/height=]) &le; |subresourceSize|.[=GPUExtent3D/height=]
+            - (|imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/z=] + |copySize|.[=GPUExtent3D/depthOrArrayLayers=]) &le; |subresourceSize|.[=GPUExtent3D/depthOrArrayLayers=]
             - |copySize|.[=GPUExtent3D/width=] must be a multiple of |blockWidth|.
             - |copySize|.[=GPUExtent3D/height=] must be a multiple of |blockHeight|.
 
@@ -543,16 +543,16 @@ are defined by the source type, given by this table:
 
 <div algorithm data-timeline=const>
     The <dfn abstract-op>set of subresources for texture copy</dfn>(|imageCopyTexture|, |copySize|)
-    is the subset of subresources of |texture| = |imageCopyTexture|.{{GPUImageCopyTexture/texture}}
+    is the subset of subresources of |texture| = |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}
     for which each subresource |s| satisfies the following:
 
     - The [=mipmap level=] of |s| equals
-        |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}}.
+        |imageCopyTexture|.{{GPUTexelCopyTextureInfo/mipLevel}}.
     - The [=aspect=] of |s| is in the [=GPUTextureAspect/set of aspects=] of
-        |imageCopyTexture|.{{GPUImageCopyTexture/aspect}}.
+        |imageCopyTexture|.{{GPUTexelCopyTextureInfo/aspect}}.
     - If |texture|.{{GPUTexture/dimension}} is {{GPUTextureDimension/"2d"}}:
         - The [=array layer=] of |s| is &ge;
-            |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/z=] and &lt;
-            |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=GPUOrigin3D/z=] +
+            |imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/z=] and &lt;
+            |imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/z=] +
             |copySize|.[=GPUExtent3D/depthOrArrayLayers=].
 </div>

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -15,7 +15,7 @@ and "immediate" {{GPUQueue}} operations:
 
 ## Image Copies ## {#image-copies}
 
-<dfn dfn>Image copy</dfn> operations operate on texture/"image" data, rather than bytes.
+<dfn dfn>Texel copy</dfn> operations operate on texture/"image" data, rather than bytes.
 
 WebGPU provides "buffered" {{GPUCommandEncoder}} commands:
 
@@ -81,8 +81,8 @@ depth values are tightly packed in an array of the appropriate type ("depth16uno
 <dl dfn-type=dict-member dfn-for=GPUTexelCopyBufferLayout>
     : <dfn>offset</dfn>
     ::
-        The offset, in bytes, from the beginning of the image data source (such as a
-        {{GPUTexelCopyBufferInfo/buffer|GPUTexelCopyBufferInfo.buffer}}) to the start of the image data
+        The offset, in bytes, from the beginning of the texel data source (such as a
+        {{GPUTexelCopyBufferInfo/buffer|GPUTexelCopyBufferInfo.buffer}}) to the start of the texel data
         within that source.
 
     : <dfn>bytesPerRow</dfn>
@@ -107,8 +107,8 @@ depth values are tightly packed in an array of the appropriate type ("depth16uno
 <span id=gpu-image-copy-buffer></span>
 </h4>
 
-In an [=image copy=] operation, {{GPUTexelCopyBufferInfo}} defines a {{GPUBuffer}} and, together with
-the `copySize`, how image data is laid out in the buffer's memory (see {{GPUTexelCopyBufferLayout}}).
+In a [=texel copy=] operation, {{GPUTexelCopyBufferInfo}} defines a {{GPUBuffer}} and, together with
+the `copySize`, how texel data is laid out in the buffer's memory (see {{GPUTexelCopyBufferLayout}}).
 
 <script type=idl>
 dictionary GPUTexelCopyBufferInfo
@@ -120,7 +120,7 @@ dictionary GPUTexelCopyBufferInfo
 <dl dfn-type=dict-member dfn-for=GPUTexelCopyBufferInfo>
     : <dfn>buffer</dfn>
     ::
-        A buffer which either contains image data to be copied or will store the image data being
+        A buffer which either contains texel data to be copied or will store the texel data being
         copied, depending on the method it is being passed to.
 </dl>
 
@@ -147,7 +147,7 @@ dictionary GPUTexelCopyBufferInfo
 <span id=gpu-image-copy-texture></span>
 </h4>
 
-In an [=image copy=] operation, a {{GPUTexelCopyTextureInfo}} defines a {{GPUTexture}} and, together with
+In a [=texel copy=] operation, a {{GPUTexelCopyTextureInfo}} defines a {{GPUTexture}} and, together with
 the `copySize`, the sub-region of the texture (spanning one or more contiguous
 [=texture subresources=] at the same mip-map level).
 
@@ -365,7 +365,7 @@ dictionary GPUCopyExternalImageSourceInfo {
 <dl dfn-type=dict-member dfn-for=GPUCopyExternalImageSourceInfo>
     : <dfn>source</dfn>
     ::
-        The source of the [=image copy=]. The copy source data is captured at the moment that
+        The source of the [=texel copy=]. The copy source data is captured at the moment that
         {{GPUQueue/copyExternalImageToTexture()}} is issued. Source size is determined as described
         by the [=external source dimensions=] table.
 

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -351,10 +351,10 @@ typedef (ImageBitmap or
          HTMLVideoElement or
          VideoFrame or
          HTMLCanvasElement or
-         OffscreenCanvas) GPUImageCopyExternalImageSource;
+         OffscreenCanvas) GPUCopyExternalImageSource;
 
 dictionary GPUCopyExternalImageSourceInfo {
-    required GPUImageCopyExternalImageSource source;
+    required GPUCopyExternalImageSource source;
     GPUOrigin2D origin = {};
     boolean flipY = false;
 };

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -71,8 +71,8 @@ write into a [=texture=] from the {{GPUQueue}}.
 Operations that copy between byte arrays and textures always operate on whole [=texel block=].
 It's not possible to update only a part of a [=texel block=].
 
-[=Texel blocks=] are tightly packed within each [=texel block row=] in the linear memory layout of an
-image copy, with each subsequent [=texel block=] immediately following the previous [=texel block=],
+[=Texel blocks=] are tightly packed within each [=texel block row=] in the linear memory layout of a
+[=texel copy=], with each subsequent [=texel block=] immediately following the previous [=texel block=],
 with no padding.
 This includes [[#copying-depth-stencil|copies]] to/from specific aspects of [=depth-or-stencil format=] textures:
 stencil values are tightly packed in an array of bytes;
@@ -276,10 +276,10 @@ dictionary GPUTexelCopyTextureInfo {
                 1. If |textureUsage| is:
                     <dl class=switch>
                         : {{GPUTextureUsage/COPY_SRC}}
-                        :: That aspect must be a valid image copy source according to [[#depth-formats]].
+                        :: That aspect must be a valid [=texel copy=] source according to [[#depth-formats]].
 
                         : {{GPUTextureUsage/COPY_DST}}
-                        :: That aspect must be a valid image copy destination according to [[#depth-formats]].
+                        :: That aspect must be a valid [=texel copy=] destination according to [[#depth-formats]].
                     </dl>
                 1. Set |aspectSpecificFormat| to the [=aspect-specific format=] according to [[#depth-formats]].
                 1. Set |offsetAlignment| to 4.

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -331,7 +331,7 @@ dictionary GPUCopyExternalImageDestInfo
         Describes whether the data written into the texture should have its RGB channels
         premultiplied by the alpha channel, or not.
 
-        If this option is set to `true` and the {{GPUImageCopyExternalImage/source}} is also
+        If this option is set to `true` and the {{GPUCopyExternalImageSourceInfo/source}} is also
         premultiplied, the source RGB values must be preserved even if they exceed their
         corresponding alpha values.
 
@@ -340,7 +340,7 @@ dictionary GPUCopyExternalImageDestInfo
         conversion may not be necessary. See [[#color-space-conversion-elision]].
 </dl>
 
-<h4 id=gpuimagecopyexternalimage data-dfn-type=dictionary>`GPUImageCopyExternalImage`
+<h4 id=gpuimagecopyexternalimage data-dfn-type=dictionary>`GPUCopyExternalImageSourceInfo`
 <span id=gpu-image-copy-external-image></span>
 </h4>
 
@@ -353,16 +353,16 @@ typedef (ImageBitmap or
          HTMLCanvasElement or
          OffscreenCanvas) GPUImageCopyExternalImageSource;
 
-dictionary GPUImageCopyExternalImage {
+dictionary GPUCopyExternalImageSourceInfo {
     required GPUImageCopyExternalImageSource source;
     GPUOrigin2D origin = {};
     boolean flipY = false;
 };
 </script>
 
-{{GPUImageCopyExternalImage}} has the following members:
+{{GPUCopyExternalImageSourceInfo}} has the following members:
 
-<dl dfn-type=dict-member dfn-for=GPUImageCopyExternalImage>
+<dl dfn-type=dict-member dfn-for=GPUCopyExternalImageSourceInfo>
     : <dfn>source</dfn>
     ::
         The source of the [=image copy=]. The copy source data is captured at the moment that
@@ -380,7 +380,7 @@ dictionary GPUImageCopyExternalImage {
 
         If this option is set to `true`, the copy is flipped vertically: the bottom row of the source
         region is copied into the first row of the destination region, and so on.
-        The {{GPUImageCopyExternalImage/origin}} option is still relative to the top-left corner
+        The {{GPUCopyExternalImageSourceInfo/origin}} option is still relative to the top-left corner
         of the source image, increasing downward.
 </dl>
 

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -42,12 +42,12 @@ Note: Copies may be performed with WGSL shaders, which means that any of the doc
 
 The following definitions are used by these methods:
 
-<h4 id=gpuimagedatalayout data-dfn-type=dictionary>`GPUImageDataLayout`
+<h4 id=gpuimagedatalayout data-dfn-type=dictionary>`GPUTexelCopyBufferLayout`
 <span id=gpu-image-data-layout></span>
 </h4>
 
 <script type=idl>
-dictionary GPUImageDataLayout {
+dictionary GPUTexelCopyBufferLayout {
     GPUSize64 offset = 0;
     GPUSize32 bytesPerRow;
     GPUSize32 rowsPerImage;
@@ -59,7 +59,7 @@ as <dfn dfn>texel block row</dfn>s. Each [=texel block row=] of a [=texel image=
 same number of [=texel blocks=], and all [=texel blocks=] in a [=texel image=] are of the same
 {{GPUTextureFormat}}.
 
-A {{GPUImageDataLayout}} is a layout of [=texel images=] within some linear memory.
+A {{GPUTexelCopyBufferLayout}} is a layout of [=texel images=] within some linear memory.
 It's used when copying data between a [=texture=] and a {{GPUBuffer}}, or when scheduling a
 write into a [=texture=] from the {{GPUQueue}}.
 
@@ -78,7 +78,7 @@ This includes [[#copying-depth-stencil|copies]] to/from specific aspects of [=de
 stencil values are tightly packed in an array of bytes;
 depth values are tightly packed in an array of the appropriate type ("depth16unorm" or "depth32float").
 
-<dl dfn-type=dict-member dfn-for=GPUImageDataLayout>
+<dl dfn-type=dict-member dfn-for=GPUTexelCopyBufferLayout>
     : <dfn>offset</dfn>
     ::
         The offset, in bytes, from the beginning of the image data source (such as a
@@ -96,8 +96,8 @@ depth values are tightly packed in an array of the appropriate type ("depth16uno
     : <dfn>rowsPerImage</dfn>
     ::
         Number of [=texel block rows=] per single [=texel image=] of the [=texture=].
-        {{GPUImageDataLayout/rowsPerImage}} &times;
-        {{GPUImageDataLayout/bytesPerRow}} is the stride, in bytes, between the beginning of each
+        {{GPUTexelCopyBufferLayout/rowsPerImage}} &times;
+        {{GPUTexelCopyBufferLayout/bytesPerRow}} is the stride, in bytes, between the beginning of each
         [=texel image=] of data and the subsequent [=texel image=].
 
         Required if there are multiple [=texel images=] (i.e. the copy depth is more than one).
@@ -108,11 +108,11 @@ depth values are tightly packed in an array of the appropriate type ("depth16uno
 </h4>
 
 In an [=image copy=] operation, {{GPUImageCopyBuffer}} defines a {{GPUBuffer}} and, together with
-the `copySize`, how image data is laid out in the buffer's memory (see {{GPUImageDataLayout}}).
+the `copySize`, how image data is laid out in the buffer's memory (see {{GPUTexelCopyBufferLayout}}).
 
 <script type=idl>
 dictionary GPUImageCopyBuffer
-         : GPUImageDataLayout {
+         : GPUTexelCopyBufferLayout {
     required GPUBuffer buffer;
 };
 </script>
@@ -139,7 +139,7 @@ dictionary GPUImageCopyBuffer
 
         <div class=validusage>
             - |imageCopyBuffer|.{{GPUImageCopyBuffer/buffer}} must be a [=valid=] {{GPUBuffer}}.
-            - |imageCopyBuffer|.{{GPUImageDataLayout/bytesPerRow}} must be a multiple of 256.
+            - |imageCopyBuffer|.{{GPUTexelCopyBufferLayout/bytesPerRow}} must be a multiple of 256.
         </div>
 </div>
 
@@ -201,14 +201,14 @@ dictionary GPUImageCopyTexture {
 </div>
 
 <div algorithm data-timeline=const>
-    The <dfn abstract-op>texel block byte offset</dfn> of data described by {{GPUImageDataLayout}} |dataLayout|
+    The <dfn abstract-op>texel block byte offset</dfn> of data described by {{GPUTexelCopyBufferLayout}} |dataLayout|
     corresponding to [=texel block=] |x|, |y| of depth slice or array layer |z| of a {{GPUTexture}} |texture| is
     determined by running the following steps:
 
         1. Let |blockBytes| be the [=texel block copy footprint=] of |texture|.{{GPUTexture/format}}.
-        1. Let |imageOffset| be (|z| &times; |dataLayout|.{{GPUImageDataLayout/rowsPerImage}} &times;
-            |dataLayout|.{{GPUImageDataLayout/bytesPerRow}}) &plus; |dataLayout|.{{GPUImageDataLayout/offset}}.
-        1. Let |rowOffset| be (|y| &times; |dataLayout|.{{GPUImageDataLayout/bytesPerRow}}) &plus; |imageOffset|.
+        1. Let |imageOffset| be (|z| &times; |dataLayout|.{{GPUTexelCopyBufferLayout/rowsPerImage}} &times;
+            |dataLayout|.{{GPUTexelCopyBufferLayout/bytesPerRow}}) &plus; |dataLayout|.{{GPUTexelCopyBufferLayout/offset}}.
+        1. Let |rowOffset| be (|y| &times; |dataLayout|.{{GPUTexelCopyBufferLayout/bytesPerRow}}) &plus; |imageOffset|.
         1. Let |blockOffset| be (|x| &times; |blockBytes|) &plus; |rowOffset|.
         1. Return |blockOffset|.
 </div>
@@ -250,7 +250,7 @@ dictionary GPUImageCopyTexture {
     **Arguments:**
 
     - {{GPUImageCopyTexture}} |imageCopyTexture|
-    - {{GPUImageDataLayout}} |dataLayout|
+    - {{GPUTexelCopyBufferLayout}} |dataLayout|
     - {{GPUSize64Out}} |dataLength|
     - {{GPUExtent3D}} |copySize|
     - {{GPUTextureUsage}} |textureUsage|
@@ -284,7 +284,7 @@ dictionary GPUImageCopyTexture {
                 1. Set |aspectSpecificFormat| to the [=aspect-specific format=] according to [[#depth-formats]].
                 1. Set |offsetAlignment| to 4.
             1. If |aligned| is `true`:
-                1. |dataLayout|.{{GPUImageDataLayout/offset}} is a multiple of |offsetAlignment|.
+                1. |dataLayout|.{{GPUTexelCopyBufferLayout/offset}} is a multiple of |offsetAlignment|.
             1. [$validating linear texture data$](|dataLayout|,
                 |dataLength|,
                 |aspectSpecificFormat|,
@@ -453,7 +453,7 @@ are defined by the source type, given by this table:
 
     **Arguments:**
 
-    : {{GPUImageDataLayout}} |layout|
+    : {{GPUTexelCopyBufferLayout}} |layout|
     :: Layout of the linear texture data.
     : {{GPUSize64}} |byteSize|
     :: Total size of the linear data, in bytes.
@@ -474,18 +474,18 @@ are defined by the source type, given by this table:
 
         <div class=validusage>
             - If |heightInBlocks| &gt; 1,
-                |layout|.{{GPUImageDataLayout/bytesPerRow}} must be specified.
+                |layout|.{{GPUTexelCopyBufferLayout/bytesPerRow}} must be specified.
             - If |copyExtent|.[=GPUExtent3D/depthOrArrayLayers=] &gt; 1,
-                |layout|.{{GPUImageDataLayout/bytesPerRow}} and
-                |layout|.{{GPUImageDataLayout/rowsPerImage}} must be specified.
-            - If specified, |layout|.{{GPUImageDataLayout/bytesPerRow}}
+                |layout|.{{GPUTexelCopyBufferLayout/bytesPerRow}} and
+                |layout|.{{GPUTexelCopyBufferLayout/rowsPerImage}} must be specified.
+            - If specified, |layout|.{{GPUTexelCopyBufferLayout/bytesPerRow}}
                 must be &ge; |bytesInLastRow|.
-            - If specified, |layout|.{{GPUImageDataLayout/rowsPerImage}}
+            - If specified, |layout|.{{GPUTexelCopyBufferLayout/rowsPerImage}}
                 must be &ge; |heightInBlocks|.
         </div>
     1. Let:
-        - |bytesPerRow| be |layout|.{{GPUImageDataLayout/bytesPerRow}} ?? 0.
-        - |rowsPerImage| be |layout|.{{GPUImageDataLayout/rowsPerImage}} ?? 0.
+        - |bytesPerRow| be |layout|.{{GPUTexelCopyBufferLayout/bytesPerRow}} ?? 0.
+        - |rowsPerImage| be |layout|.{{GPUTexelCopyBufferLayout/rowsPerImage}} ?? 0.
 
         Note: These default values have no effect, as they're always multiplied by 0.
     1. Let |requiredBytesInCopy| be 0.
@@ -499,7 +499,7 @@ are defined by the source type, given by this table:
 
         <div class=validusage>
             - The layout fits inside the linear data:
-                |layout|.{{GPUImageDataLayout/offset}} + |requiredBytesInCopy| &le; |byteSize|.
+                |layout|.{{GPUTexelCopyBufferLayout/offset}} + |requiredBytesInCopy| &le; |byteSize|.
         </div>
 </div>
 

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -242,7 +242,7 @@ dictionary GPUTexelCopyTextureInfo {
                 |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/mipLevelCount}}.
             - |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/x=] must be a multiple of |blockWidth|.
             - |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/y=] must be a multiple of |blockHeight|.
-            - The [=imageCopyTexture physical subresource size=] of |texelCopyTextureInfo| is equal to |copySize| if either of
+            - The [=GPUTexelCopyTextureInfo physical subresource size=] of |texelCopyTextureInfo| is equal to |copySize| if either of
                 the following conditions is true:
                 - |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}} is a depth-stencil format.
                 - |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/sampleCount}} &gt; 1.
@@ -439,8 +439,8 @@ are defined by the source type, given by this table:
 
 ### Subroutines ### {#image-copies-subroutines}
 
-<div algorithm="imageCopyTexture physical subresource size" data-timeline=const>
-    <dfn dfn>imageCopyTexture physical subresource size</dfn>
+<div algorithm="GPUTexelCopyTextureInfo physical subresource size" data-timeline=const>
+    <dfn dfn>GPUTexelCopyTextureInfo physical subresource size</dfn>
 
     **Arguments:**
 
@@ -448,7 +448,7 @@ are defined by the source type, given by this table:
 
     **Returns:** {{GPUExtent3D}}
 
-    The [=imageCopyTexture physical subresource size=] of |texelCopyTextureInfo| is calculated as follows:
+    The [=GPUTexelCopyTextureInfo physical subresource size=] of |texelCopyTextureInfo| is calculated as follows:
 
     Its [=GPUExtent3D/width=], [=GPUExtent3D/height=] and [=GPUExtent3D/depthOrArrayLayers=] are the width, height, and depth, respectively,
     of the [=physical miplevel-specific texture extent=] of |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}} [=subresource=] at [=mipmap level=]
@@ -524,7 +524,7 @@ are defined by the source type, given by this table:
 
     1. Let |blockWidth| be the [=texel block width=] of |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
     1. Let |blockHeight| be the [=texel block height=] of |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
-    1. Let |subresourceSize| be the [=imageCopyTexture physical subresource size=] of |texelCopyTextureInfo|.
+    1. Let |subresourceSize| be the [=GPUTexelCopyTextureInfo physical subresource size=] of |texelCopyTextureInfo|.
     1. Return whether all the conditions below are satisfied:
 
         <div class=validusage>

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -206,14 +206,14 @@ dictionary GPUTexelCopyTextureInfo {
 </div>
 
 <div algorithm data-timeline=const>
-    The <dfn abstract-op>texel block byte offset</dfn> of data described by {{GPUTexelCopyBufferLayout}} |dataLayout|
+    The <dfn abstract-op>texel block byte offset</dfn> of data described by {{GPUTexelCopyBufferLayout}} |bufferLayout|
     corresponding to [=texel block=] |x|, |y| of depth slice or array layer |z| of a {{GPUTexture}} |texture| is
     determined by running the following steps:
 
         1. Let |blockBytes| be the [=texel block copy footprint=] of |texture|.{{GPUTexture/format}}.
-        1. Let |imageOffset| be (|z| &times; |dataLayout|.{{GPUTexelCopyBufferLayout/rowsPerImage}} &times;
-            |dataLayout|.{{GPUTexelCopyBufferLayout/bytesPerRow}}) &plus; |dataLayout|.{{GPUTexelCopyBufferLayout/offset}}.
-        1. Let |rowOffset| be (|y| &times; |dataLayout|.{{GPUTexelCopyBufferLayout/bytesPerRow}}) &plus; |imageOffset|.
+        1. Let |imageOffset| be (|z| &times; |bufferLayout|.{{GPUTexelCopyBufferLayout/rowsPerImage}} &times;
+            |bufferLayout|.{{GPUTexelCopyBufferLayout/bytesPerRow}}) &plus; |bufferLayout|.{{GPUTexelCopyBufferLayout/offset}}.
+        1. Let |rowOffset| be (|y| &times; |bufferLayout|.{{GPUTexelCopyBufferLayout/bytesPerRow}}) &plus; |imageOffset|.
         1. Let |blockOffset| be (|x| &times; |blockBytes|) &plus; |rowOffset|.
         1. Return |blockOffset|.
 </div>
@@ -250,12 +250,12 @@ dictionary GPUTexelCopyTextureInfo {
 </div>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>validating texture buffer copy</dfn>(|texelCopyTextureInfo|, |dataLayout|, |dataLength|, |copySize|, |textureUsage|, |aligned|)
+    <dfn abstract-op>validating texture buffer copy</dfn>(|texelCopyTextureInfo|, |bufferLayout|, |dataLength|, |copySize|, |textureUsage|, |aligned|)
 
     **Arguments:**
 
     - {{GPUTexelCopyTextureInfo}} |texelCopyTextureInfo|
-    - {{GPUTexelCopyBufferLayout}} |dataLayout|
+    - {{GPUTexelCopyBufferLayout}} |bufferLayout|
     - {{GPUSize64Out}} |dataLength|
     - {{GPUExtent3D}} |copySize|
     - {{GPUTextureUsage}} |textureUsage|
@@ -289,8 +289,8 @@ dictionary GPUTexelCopyTextureInfo {
                 1. Set |aspectSpecificFormat| to the [=aspect-specific format=] according to [[#depth-formats]].
                 1. Set |offsetAlignment| to 4.
             1. If |aligned| is `true`:
-                1. |dataLayout|.{{GPUTexelCopyBufferLayout/offset}} is a multiple of |offsetAlignment|.
-            1. [$validating linear texture data$](|dataLayout|,
+                1. |bufferLayout|.{{GPUTexelCopyBufferLayout/offset}} is a multiple of |offsetAlignment|.
+            1. [$validating linear texture data$](|bufferLayout|,
                 |dataLength|,
                 |aspectSpecificFormat|,
                 |copySize|) succeeds.

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -219,42 +219,42 @@ dictionary GPUTexelCopyTextureInfo {
 </div>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>validating GPUTexelCopyTextureInfo</dfn>(|imageCopyTexture|, |copySize|)
+    <dfn abstract-op>validating GPUTexelCopyTextureInfo</dfn>(|texelCopyTextureInfo|, |copySize|)
 
     **Arguments:**
 
-    - {{GPUTexelCopyTextureInfo}} |imageCopyTexture|
+    - {{GPUTexelCopyTextureInfo}} |texelCopyTextureInfo|
     - {{GPUExtent3D}} |copySize|
 
     **Returns:** {{boolean}}
 
     [=Device timeline=] steps:
 
-    1. Let |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
-    1. Let |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
+    1. Let |blockWidth| be the [=texel block width=] of |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
+    1. Let |blockHeight| be the [=texel block height=] of |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
 
     1. Return `true` if and only if all of the following conditions apply:
 
         <div class=validusage>
-            - [$validating texture copy range$](|imageCopyTexture|, |copySize|) returns `true`.
-            - |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}} must be a [=valid=] {{GPUTexture}}.
-            - |imageCopyTexture|.{{GPUTexelCopyTextureInfo/mipLevel}} must be &lt;
-                |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/mipLevelCount}}.
-            - |imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/x=] must be a multiple of |blockWidth|.
-            - |imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/y=] must be a multiple of |blockHeight|.
-            - The [=imageCopyTexture physical subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
+            - [$validating texture copy range$](|texelCopyTextureInfo|, |copySize|) returns `true`.
+            - |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}} must be a [=valid=] {{GPUTexture}}.
+            - |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/mipLevel}} must be &lt;
+                |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/mipLevelCount}}.
+            - |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/x=] must be a multiple of |blockWidth|.
+            - |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/y=] must be a multiple of |blockHeight|.
+            - The [=imageCopyTexture physical subresource size=] of |texelCopyTextureInfo| is equal to |copySize| if either of
                 the following conditions is true:
-                - |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}} is a depth-stencil format.
-                - |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/sampleCount}} &gt; 1.
+                - |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}} is a depth-stencil format.
+                - |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/sampleCount}} &gt; 1.
         </div>
 </div>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>validating texture buffer copy</dfn>(|imageCopyTexture|, |dataLayout|, |dataLength|, |copySize|, |textureUsage|, |aligned|)
+    <dfn abstract-op>validating texture buffer copy</dfn>(|texelCopyTextureInfo|, |dataLayout|, |dataLength|, |copySize|, |textureUsage|, |aligned|)
 
     **Arguments:**
 
-    - {{GPUTexelCopyTextureInfo}} |imageCopyTexture|
+    - {{GPUTexelCopyTextureInfo}} |texelCopyTextureInfo|
     - {{GPUTexelCopyBufferLayout}} |dataLayout|
     - {{GPUSize64Out}} |dataLength|
     - {{GPUExtent3D}} |copySize|
@@ -265,18 +265,18 @@ dictionary GPUTexelCopyTextureInfo {
 
     [=Device timeline=] steps:
 
-    1. Let |texture| be |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}
+    1. Let |texture| be |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}
     1. Let |aspectSpecificFormat| = |texture|.{{GPUTexture/format}}.
     1. Let |offsetAlignment| = [=texel block copy footprint=] of |texture|.{{GPUTexture/format}}.
 
     1. Return `true` if and only if all of the following conditions apply:
 
         <div class=validusage>
-            1. [$validating GPUTexelCopyTextureInfo$](|imageCopyTexture|, |copySize|) returns `true`.
+            1. [$validating GPUTexelCopyTextureInfo$](|texelCopyTextureInfo|, |copySize|) returns `true`.
             1. |texture|.{{GPUTexture/sampleCount}} is 1.
             1. |texture|.{{GPUTexture/usage}} contains |textureUsage|.
             1. If |texture|.{{GPUTexture/format}} is a [=depth-or-stencil format=] format:
-                1. |imageCopyTexture|.{{GPUTexelCopyTextureInfo/aspect}} must refer to a single aspect of
+                1. |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/aspect}} must refer to a single aspect of
                     |texture|.{{GPUTexture/format}}.
                 1. If |textureUsage| is:
                     <dl class=switch>
@@ -444,15 +444,15 @@ are defined by the source type, given by this table:
 
     **Arguments:**
 
-    - {{GPUTexelCopyTextureInfo}} |imageCopyTexture|
+    - {{GPUTexelCopyTextureInfo}} |texelCopyTextureInfo|
 
     **Returns:** {{GPUExtent3D}}
 
-    The [=imageCopyTexture physical subresource size=] of |imageCopyTexture| is calculated as follows:
+    The [=imageCopyTexture physical subresource size=] of |texelCopyTextureInfo| is calculated as follows:
 
     Its [=GPUExtent3D/width=], [=GPUExtent3D/height=] and [=GPUExtent3D/depthOrArrayLayers=] are the width, height, and depth, respectively,
-    of the [=physical miplevel-specific texture extent=] of |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}} [=subresource=] at [=mipmap level=]
-    |imageCopyTexture|.{{GPUTexelCopyTextureInfo/mipLevel}}.
+    of the [=physical miplevel-specific texture extent=] of |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}} [=subresource=] at [=mipmap level=]
+    |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/mipLevel}}.
 </div>
 
 <div algorithm data-timeline=device>
@@ -515,22 +515,22 @@ are defined by the source type, given by this table:
 
     **Arguments:**
 
-    : {{GPUTexelCopyTextureInfo}} |imageCopyTexture|
+    : {{GPUTexelCopyTextureInfo}} |texelCopyTextureInfo|
     :: The texture subresource being copied into and copy origin.
     : {{GPUExtent3D}} |copySize|
     :: The size of the texture.
 
     [=Device timeline=] steps:
 
-    1. Let |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
-    1. Let |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
-    1. Let |subresourceSize| be the [=imageCopyTexture physical subresource size=] of |imageCopyTexture|.
+    1. Let |blockWidth| be the [=texel block width=] of |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
+    1. Let |blockHeight| be the [=texel block height=] of |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}}.
+    1. Let |subresourceSize| be the [=imageCopyTexture physical subresource size=] of |texelCopyTextureInfo|.
     1. Return whether all the conditions below are satisfied:
 
         <div class=validusage>
-            - (|imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/x=] + |copySize|.[=GPUExtent3D/width=]) &le; |subresourceSize|.[=GPUExtent3D/width=]
-            - (|imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/y=] + |copySize|.[=GPUExtent3D/height=]) &le; |subresourceSize|.[=GPUExtent3D/height=]
-            - (|imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/z=] + |copySize|.[=GPUExtent3D/depthOrArrayLayers=]) &le; |subresourceSize|.[=GPUExtent3D/depthOrArrayLayers=]
+            - (|texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/x=] + |copySize|.[=GPUExtent3D/width=]) &le; |subresourceSize|.[=GPUExtent3D/width=]
+            - (|texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/y=] + |copySize|.[=GPUExtent3D/height=]) &le; |subresourceSize|.[=GPUExtent3D/height=]
+            - (|texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/z=] + |copySize|.[=GPUExtent3D/depthOrArrayLayers=]) &le; |subresourceSize|.[=GPUExtent3D/depthOrArrayLayers=]
             - |copySize|.[=GPUExtent3D/width=] must be a multiple of |blockWidth|.
             - |copySize|.[=GPUExtent3D/height=] must be a multiple of |blockHeight|.
 
@@ -549,17 +549,17 @@ are defined by the source type, given by this table:
 </div>
 
 <div algorithm data-timeline=const>
-    The <dfn abstract-op>set of subresources for texture copy</dfn>(|imageCopyTexture|, |copySize|)
-    is the subset of subresources of |texture| = |imageCopyTexture|.{{GPUTexelCopyTextureInfo/texture}}
+    The <dfn abstract-op>set of subresources for texture copy</dfn>(|texelCopyTextureInfo|, |copySize|)
+    is the subset of subresources of |texture| = |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/texture}}
     for which each subresource |s| satisfies the following:
 
     - The [=mipmap level=] of |s| equals
-        |imageCopyTexture|.{{GPUTexelCopyTextureInfo/mipLevel}}.
+        |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/mipLevel}}.
     - The [=aspect=] of |s| is in the [=GPUTextureAspect/set of aspects=] of
-        |imageCopyTexture|.{{GPUTexelCopyTextureInfo/aspect}}.
+        |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/aspect}}.
     - If |texture|.{{GPUTexture/dimension}} is {{GPUTextureDimension/"2d"}}:
         - The [=array layer=] of |s| is &ge;
-            |imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/z=] and &lt;
-            |imageCopyTexture|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/z=] +
+            |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/z=] and &lt;
+            |texelCopyTextureInfo|.{{GPUTexelCopyTextureInfo/origin}}.[=GPUOrigin3D/z=] +
             |copySize|.[=GPUExtent3D/depthOrArrayLayers=].
 </div>

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -13,7 +13,9 @@ and "immediate" {{GPUQueue}} operations:
 
 - {{GPUQueue/writeBuffer()}}, for {{ArrayBuffer}}-to-{{GPUBuffer}} writes
 
-## Image Copies ## {#image-copies}
+<h3 id=texel-copies>Texel Copies
+<span id=image-copies></span>
+</h3>
 
 <dfn dfn>Texel copy</dfn> operations operate on texture/"image" data, rather than bytes.
 
@@ -42,8 +44,9 @@ Note: Copies may be performed with WGSL shaders, which means that any of the doc
 
 The following definitions are used by these methods:
 
-<h4 id=gpuimagedatalayout data-dfn-type=dictionary>`GPUTexelCopyBufferLayout`
+<h4 id=gputexelcopybufferlayout data-dfn-type=dictionary>`GPUTexelCopyBufferLayout`
 <span id=gpu-image-data-layout></span>
+<span id=gpuimagedatalayout></span>
 </h4>
 
 <script type=idl>
@@ -103,8 +106,9 @@ depth values are tightly packed in an array of the appropriate type ("depth16uno
         Required if there are multiple [=texel images=] (i.e. the copy depth is more than one).
 </dl>
 
-<h4 id=gpuimagecopybuffer data-dfn-type=dictionary>`GPUTexelCopyBufferInfo`
+<h4 id=gputexelcopybufferinfo data-dfn-type=dictionary>`GPUTexelCopyBufferInfo`
 <span id=gpu-image-copy-buffer></span>
+<span id=gpuimagecopybuffer></span>
 </h4>
 
 In a [=texel copy=] operation, {{GPUTexelCopyBufferInfo}} defines a {{GPUBuffer}} and, together with
@@ -143,8 +147,9 @@ dictionary GPUTexelCopyBufferInfo
         </div>
 </div>
 
-<h4 id=gpuimagecopytexture data-dfn-type=dictionary>`GPUTexelCopyTextureInfo`
+<h4 id=gputexelcopytextureinfo data-dfn-type=dictionary>`GPUTexelCopyTextureInfo`
 <span id=gpu-image-copy-texture></span>
+<span id=gpuimagecopytexture></span>
 </h4>
 
 In a [=texel copy=] operation, a {{GPUTexelCopyTextureInfo}} defines a {{GPUTexture}} and, together with
@@ -292,8 +297,9 @@ dictionary GPUTexelCopyTextureInfo {
         </div>
 </div>
 
-<h4 id=gpuimagecopytexturetagged data-dfn-type=dictionary>`GPUCopyExternalImageDestInfo`
+<h4 id=gpucopyexternalimagedestinfo data-dfn-type=dictionary>`GPUCopyExternalImageDestInfo`
 <span id=gpu-image-copy-texture-tagged></span>
+<span id=gpuimagecopytexturetagged></span>
 </h4>
 
 WebGPU textures hold raw numeric data, and are not tagged with semantic metadata describing colors.
@@ -340,8 +346,9 @@ dictionary GPUCopyExternalImageDestInfo
         conversion may not be necessary. See [[#color-space-conversion-elision]].
 </dl>
 
-<h4 id=gpuimagecopyexternalimage data-dfn-type=dictionary>`GPUCopyExternalImageSourceInfo`
+<h4 id=gpucopyexternalimagesourceinfo data-dfn-type=dictionary>`GPUCopyExternalImageSourceInfo`
 <span id=gpu-image-copy-external-image></span>
+<span id=gpuimagecopyexternalimage></span>
 </h4>
 
 <script type=idl>

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -292,28 +292,28 @@ dictionary GPUTexelCopyTextureInfo {
         </div>
 </div>
 
-<h4 id=gpuimagecopytexturetagged data-dfn-type=dictionary>`GPUImageCopyTextureTagged`
+<h4 id=gpuimagecopytexturetagged data-dfn-type=dictionary>`GPUCopyExternalImageDestInfo`
 <span id=gpu-image-copy-texture-tagged></span>
 </h4>
 
 WebGPU textures hold raw numeric data, and are not tagged with semantic metadata describing colors.
 However, {{GPUQueue/copyExternalImageToTexture()}} copies from sources that describe colors.
 
-A {{GPUImageCopyTextureTagged}} is a {{GPUTexelCopyTextureInfo}} which is additionally tagged with
+A {{GPUCopyExternalImageDestInfo}} is a {{GPUTexelCopyTextureInfo}} which is additionally tagged with
 color space/encoding and alpha-premultiplication metadata, so that semantic color data may be
 preserved during copies.
 This metadata affects only the semantics of the {{GPUQueue/copyExternalImageToTexture()}}
 operation, not the semantics of the destination texture.
 
 <script type=idl>
-dictionary GPUImageCopyTextureTagged
+dictionary GPUCopyExternalImageDestInfo
          : GPUTexelCopyTextureInfo {
     PredefinedColorSpace colorSpace = "srgb";
     boolean premultipliedAlpha = false;
 };
 </script>
 
-<dl dfn-type=dict-member dfn-for=GPUImageCopyTextureTagged>
+<dl dfn-type=dict-member dfn-for=GPUCopyExternalImageDestInfo>
     : <dfn>colorSpace</dfn>
     ::
         Describes the color space and encoding used to encode data into the destination texture.
@@ -323,7 +323,7 @@ dictionary GPUImageCopyTextureTagged
         Otherwise, the results are clamped to the target texture format's range.
 
         Note:
-        If {{GPUImageCopyTextureTagged/colorSpace}} matches the source image,
+        If {{GPUCopyExternalImageDestInfo/colorSpace}} matches the source image,
         conversion may not be necessary. See [[#color-space-conversion-elision]].
 
     : <dfn>premultipliedAlpha</dfn>
@@ -336,7 +336,7 @@ dictionary GPUImageCopyTextureTagged
         corresponding alpha values.
 
         Note:
-        If {{GPUImageCopyTextureTagged/premultipliedAlpha}} matches the source image,
+        If {{GPUCopyExternalImageDestInfo/premultipliedAlpha}} matches the source image,
         conversion may not be necessary. See [[#color-space-conversion-elision]].
 </dl>
 

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -82,7 +82,7 @@ depth values are tightly packed in an array of the appropriate type ("depth16uno
     : <dfn>offset</dfn>
     ::
         The offset, in bytes, from the beginning of the image data source (such as a
-        {{GPUImageCopyBuffer/buffer|GPUImageCopyBuffer.buffer}}) to the start of the image data
+        {{GPUTexelCopyBufferInfo/buffer|GPUTexelCopyBufferInfo.buffer}}) to the start of the image data
         within that source.
 
     : <dfn>bytesPerRow</dfn>
@@ -103,21 +103,21 @@ depth values are tightly packed in an array of the appropriate type ("depth16uno
         Required if there are multiple [=texel images=] (i.e. the copy depth is more than one).
 </dl>
 
-<h4 id=gpuimagecopybuffer data-dfn-type=dictionary>`GPUImageCopyBuffer`
+<h4 id=gpuimagecopybuffer data-dfn-type=dictionary>`GPUTexelCopyBufferInfo`
 <span id=gpu-image-copy-buffer></span>
 </h4>
 
-In an [=image copy=] operation, {{GPUImageCopyBuffer}} defines a {{GPUBuffer}} and, together with
+In an [=image copy=] operation, {{GPUTexelCopyBufferInfo}} defines a {{GPUBuffer}} and, together with
 the `copySize`, how image data is laid out in the buffer's memory (see {{GPUTexelCopyBufferLayout}}).
 
 <script type=idl>
-dictionary GPUImageCopyBuffer
+dictionary GPUTexelCopyBufferInfo
          : GPUTexelCopyBufferLayout {
     required GPUBuffer buffer;
 };
 </script>
 
-<dl dfn-type=dict-member dfn-for=GPUImageCopyBuffer>
+<dl dfn-type=dict-member dfn-for=GPUTexelCopyBufferInfo>
     : <dfn>buffer</dfn>
     ::
         A buffer which either contains image data to be copied or will store the image data being
@@ -125,11 +125,11 @@ dictionary GPUImageCopyBuffer
 </dl>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>validating GPUImageCopyBuffer</dfn>
+    <dfn abstract-op>validating GPUTexelCopyBufferInfo</dfn>
 
     **Arguments:**
 
-    - {{GPUImageCopyBuffer}} |imageCopyBuffer|
+    - {{GPUTexelCopyBufferInfo}} |imageCopyBuffer|
 
     **Returns:** {{boolean}}
 
@@ -138,7 +138,7 @@ dictionary GPUImageCopyBuffer
     1. Return `true` if and only if all of the following conditions are satisfied:
 
         <div class=validusage>
-            - |imageCopyBuffer|.{{GPUImageCopyBuffer/buffer}} must be a [=valid=] {{GPUBuffer}}.
+            - |imageCopyBuffer|.{{GPUTexelCopyBufferInfo/buffer}} must be a [=valid=] {{GPUBuffer}}.
             - |imageCopyBuffer|.{{GPUTexelCopyBufferLayout/bytesPerRow}} must be a multiple of 256.
         </div>
 </div>

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -356,6 +356,7 @@ dictionary GPUCopyExternalImageDestInfo
 <h4 id=gpucopyexternalimagesourceinfo data-dfn-type=dictionary>`GPUCopyExternalImageSourceInfo`
 <span id=gpu-image-copy-external-image></span>
 <span id=gpuimagecopyexternalimage></span>
+<span id=typedefdef-gpuimagecopyexternalimagesource></span>
 </h4>
 
 "{{GPUCopyExternalImageSourceInfo}}" describes the "**info**" about the "**source**" of a

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -49,6 +49,9 @@ The following definitions are used by these methods:
 <span id=gpuimagedatalayout></span>
 </h4>
 
+"{{GPUTexelCopyBufferLayout}}" describes the "**layout**" of texels in a "**buffer**" of bytes
+({{GPUBuffer}} or {{AllowSharedBufferSource}}) in a "<strong>[=texel copy=]</strong>" operation.
+
 <script type=idl>
 dictionary GPUTexelCopyBufferLayout {
     GPUSize64 offset = 0;
@@ -111,8 +114,9 @@ depth values are tightly packed in an array of the appropriate type ("depth16uno
 <span id=gpuimagecopybuffer></span>
 </h4>
 
-In a [=texel copy=] operation, {{GPUTexelCopyBufferInfo}} defines a {{GPUBuffer}} and, together with
-the `copySize`, how texel data is laid out in the buffer's memory (see {{GPUTexelCopyBufferLayout}}).
+"{{GPUTexelCopyBufferInfo}}" describes the "**info**" ({{GPUBuffer}} and {{GPUTexelCopyBufferLayout}})
+about a "**buffer**" source or destination of a "<strong>[=texel copy=]</strong>" operation.
+Together with the `copySize`, it describes the footprint of a region of texels in a {{GPUBuffer}}.
 
 <script type=idl>
 dictionary GPUTexelCopyBufferInfo
@@ -152,9 +156,10 @@ dictionary GPUTexelCopyBufferInfo
 <span id=gpuimagecopytexture></span>
 </h4>
 
-In a [=texel copy=] operation, a {{GPUTexelCopyTextureInfo}} defines a {{GPUTexture}} and, together with
-the `copySize`, the sub-region of the texture (spanning one or more contiguous
-[=texture subresources=] at the same mip-map level).
+"{{GPUTexelCopyTextureInfo}}" describes the "**info**" ({{GPUTexture}}, etc.)
+about a "**texture**" source or destination of a "<strong>[=texel copy=]</strong>" operation.
+Together with the `copySize`, it describes a sub-region of a texture
+(spanning one or more contiguous [=texture subresources=] at the same mip-map level).
 
 <script type=idl>
 dictionary GPUTexelCopyTextureInfo {
@@ -305,11 +310,13 @@ dictionary GPUTexelCopyTextureInfo {
 WebGPU textures hold raw numeric data, and are not tagged with semantic metadata describing colors.
 However, {{GPUQueue/copyExternalImageToTexture()}} copies from sources that describe colors.
 
-A {{GPUCopyExternalImageDestInfo}} is a {{GPUTexelCopyTextureInfo}} which is additionally tagged with
+"{{GPUCopyExternalImageDestInfo}}" describes the "**info**" about the "<strong>dest</strong>ination" of a
+"<a method for=GPUQueue lt="copyExternalImageToTexture()"><code class=idl><strong>copyExternalImage</strong>ToTexture()</code></a>" operation.
+It is a {{GPUTexelCopyTextureInfo}} which is additionally tagged with
 color space/encoding and alpha-premultiplication metadata, so that semantic color data may be
 preserved during copies.
-This metadata affects only the semantics of the {{GPUQueue/copyExternalImageToTexture()}}
-operation, not the semantics of the destination texture.
+This metadata affects only the semantics of the copy operation
+operation, not the state or semantics of the destination texture object.
 
 <script type=idl>
 dictionary GPUCopyExternalImageDestInfo
@@ -350,6 +357,9 @@ dictionary GPUCopyExternalImageDestInfo
 <span id=gpu-image-copy-external-image></span>
 <span id=gpuimagecopyexternalimage></span>
 </h4>
+
+"{{GPUCopyExternalImageSourceInfo}}" describes the "**info**" about the "**source**" of a
+"<a method for=GPUQueue lt="copyExternalImageToTexture()"><code class=idl><strong>copyExternalImage</strong>ToTexture()</code></a>" operation.
 
 <script type=idl>
 typedef (ImageBitmap or


### PR DESCRIPTION
**Re-done against `main`, with new names, 2024-10-30.**

Commits titled `[subst]` are done by strict (case-sensitive, whole word) find-and-replace.

| Type | Old | New | Used in |
|:- |:- |:- |:- |
| dict | `GPUImageDataLayout`              | `GPUTexelCopyBufferLayout`       | writeTexture,<br>parent type of ↙ |
| dict | `GPUImageCopyBuffer`              | `GPUTexelCopyBufferInfo`<br>extends ↑ | T2B, B2T |
| dict | `GPUImageCopyTexture`             | `GPUTexelCopyTextureInfo`        | T2B, B2T, T2T, writeTexture |
| dict | `GPUImageCopyTextureTagged`       | `GPUCopyExternalImageDestInfo`<br>extends ↑ | copyExternalImageToTexture |
| dict | `GPUImageCopyExternalImage`       | `GPUCopyExternalImageSourceInfo`     | copyExternalImageToTexture |
| union | `GPUImageCopyExternalImageSource` | `GPUCopyExternalImageSource` | member of ↖ |

Fixes #4573