### PR TITLE
Remove GPUShaderModuleDescriptor.sourceMap

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6563,7 +6563,6 @@ GPUShaderModule includes GPUObjectBase;
 dictionary GPUShaderModuleDescriptor
          : GPUObjectDescriptorBase {
     required USVString code;
-    object sourceMap;
     sequence<GPUShaderModuleCompilationHint> compilationHints = [];
 };
 </script>
@@ -6573,21 +6572,6 @@ dictionary GPUShaderModuleDescriptor
     ::
         The <a href="https://gpuweb.github.io/gpuweb/wgsl/">WGSL</a> source code for the shader
         module.
-
-    : <dfn>sourceMap</dfn>
-    ::
-        If defined, **may** be interpreted in the [[!SourceMap]] v3 format.
-
-        If an implementation supports this option but is unable to process the provided value,
-        it should show a developer-visible warning but must not produce any application-observable
-        error.
-
-        Note:
-        Source map support is optional, but serves as a semi-standardized way to support dev-tool
-        integration such as source-language debugging.
-
-        WGSL names (identifiers) in source maps follow the rules defined in [=WGSL identifier
-        comparison=].
 
     : <dfn>compilationHints</dfn>
     ::


### PR DESCRIPTION
TBD exactly how we will support source maps in the future, but we realized this isn't the correct way.

If there are any applications out there setting this member, this is a non-breaking change because browsers will just ignore the key. (No browsers were implementing this anyway, so at best we were just type-checking it.)

History: added in #645

Fixes #4808