### PR TITLE
Additional cases for non-exact texel copies

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -100,8 +100,10 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: language extension; url: language-extension
         text: runtime-sized; url: runtime-sized
         text: WGSL floating point conversion; url: floating-point-conversion
+        text: WGSL floating point behaviors; url: differences-from-ieee754
         text: WGSL identifier comparison; url: identifier-comparison
         text: WGSL scalar type; url: scalar-types
+        text: indeterminate value; url: indeterminate-values
         text: @binding; url: attribute-binding
         text: @group; url: attribute-group
         text: @interpolate; url: interpolate-attr

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -29,9 +29,16 @@ and "immediate" {{GPUQueue}} operations:
 - {{GPUQueue/copyExternalImageToTexture()}}, for copies from Web Platform image sources to textures
 
 Some texel values have <dfn dfn lt='equivalent texel representation'>multiple possible representations</dfn>
-of some values, e.g. as `r8snorm`, -1.0 can be represented as either -127 or -128. Additionally NaN,
-zero, and subnormal float values may also have multiple equivalent representations. Copy commands
-are not guaranteed to preserve the source's bit-representation.
+of some values. As a result copy commands are not guaranteed to preserve the source's bit-representation.
+Examples include:
+
+ - snorm values may represent -1.0 as either -127 or -128.
+ - Any NaN or Infinity may be represented by an indeterminant, non-signaling NaN.
+ - Any subnormal value, -0.0, or +0.0 may be represented by either -0.0 or +0.0.
+
+Note: Copies may be performed with WGSL shaders, which means that any of the documented
+[WGSL IEEE-754 behaviors](https://gpuweb.github.io/gpuweb/wgsl/#differences-from-ieee754) may be
+observed.
 
 The following definitions are used by these methods:
 

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -29,8 +29,9 @@ and "immediate" {{GPUQueue}} operations:
 - {{GPUQueue/copyExternalImageToTexture()}}, for copies from Web Platform image sources to textures
 
 Some texel values have <dfn dfn lt='equivalent texel representation'>multiple possible representations</dfn>
-of some values, e.g. as `r8snorm`, -1.0 can be represented as either -127 or -128.
-Copy commands are not guaranteed to preserve the source's bit-representation.
+of some values, e.g. as `r8snorm`, -1.0 can be represented as either -127 or -128. Additionally NaN,
+zero, and subnormal float values may also have multiple equivalent representations. Copy commands
+are not guaranteed to preserve the source's bit-representation.
 
 The following definitions are used by these methods:
 

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -28,17 +28,18 @@ and "immediate" {{GPUQueue}} operations:
 - {{GPUQueue/writeTexture()}}, for {{ArrayBuffer}}-to-{{GPUTexture}} writes
 - {{GPUQueue/copyExternalImageToTexture()}}, for copies from Web Platform image sources to textures
 
-Some texel values have <dfn dfn lt='equivalent texel representation'>multiple possible representations</dfn>
-of some values. As a result copy commands are not guaranteed to preserve the source's bit-representation.
-Examples include:
+During a texel copy texels are copied over with an <dfn dfn>equivalent texel representation</dfn>.
+Texel copies only guarantee that valid, normal numeric values in the source have the same numeric
+value in the destination, and may not preserve the bit-representations of the the following values:
 
- - snorm values may represent -1.0 as either -127 or -128.
- - Any NaN or Infinity may be represented by an indeterminant, non-signaling NaN.
- - Any subnormal value, -0.0, or +0.0 may be represented by either -0.0 or +0.0.
+- snorm values may represent -1.0 as either -127 or -128.
+- The signs of zero values may not be preserved.
+- Subnormal floating-point values may be replaced by either -0.0 or +0.0.
+- Any NaN or Infinity is an invalid value and may be replace by an [=indeterminate value=].
+
 
 Note: Copies may be performed with WGSL shaders, which means that any of the documented
-[WGSL IEEE-754 behaviors](https://gpuweb.github.io/gpuweb/wgsl/#differences-from-ieee754) may be
-observed.
+[=WGSL floating point behaviors=] may be observed.
 
 The following definitions are used by these methods:
 

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -37,7 +37,6 @@ value in the destination, and may not preserve the bit-representations of the th
 - Subnormal floating-point values may be replaced by either -0.0 or +0.0.
 - Any NaN or Infinity is an invalid value and may be replace by an [=indeterminate value=].
 
-
 Note: Copies may be performed with WGSL shaders, which means that any of the documented
 [=WGSL floating point behaviors=] may be observed.
 


### PR DESCRIPTION
Fixes #2558

Explicitly lists NaN, zero, and subnormal float values as cases which may not guarantee bit-exact texel copies.

@kainino0x: Did you want to include anything more than this?