### PR TITLE
Add dynamic offset to "Validate encoder bind groups" validation function

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10689,12 +10689,25 @@ It must only be included by interfaces which also include those mixins.
                 For each pair of ({{GPUIndex32}} |index|, {{GPUBindGroupLayout}} |bindGroupLayout|) in
                 |pipeline|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}:
                 - Let |bindGroup| be |encoder|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|index|].
+                - Let |dynamicOffsets| be |encoder|.{{GPUBindingCommandsMixin/[[dynamic_offsets]]}}[|index|].
                 - |bindGroup| must not be `null`.
                 - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
-                - For each |entry| of |bindGroup|.{{GPUBindGroup/[[entries]]}}:
-                    - If |entry|.{{GPUBindGroupEntry/[[prevalidatedSize]]}} is `false`:
-                        - [$effective buffer binding size$](|entry|.{{GPUBindGroupEntry/resource}}) must be &ge; [=minimum buffer binding size=]
-                            of the binding variable in |pipeline|'s shader that corresponds to |entry|.
+                - Let |dynamicOffsetIndex| be 0.
+                - For each {{GPUBindGroupEntry}} |bindGroupEntry| in |bindGroup|.{{GPUBindGroup/[[entries]]}},
+                    sorted by |bindGroupEntry|.{{GPUBindGroupEntry/binding}}:
+                    - Let |bindGroupLayoutEntry| be
+                        |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[entryMap]]}}[|bindGroupEntry|.{{GPUBindGroupEntry/binding}}].
+                    - If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}} is not
+                        [=map/exists|provided=], **continue**.
+                    - Let |bound| be a copy of |bindGroupEntry|.{{GPUBindGroupEntry/resource}}.
+                    - [=Assert=] |bound| is a {{GPUBufferBinding}}.
+                    - If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}:
+                        - Increment |bound|.{{GPUBufferBinding/offset}} by
+                            |dynamicOffsets|[|dynamicOffsetIndex|].
+                        - Increment |dynamicOffsetIndex| by 1.
+                    - If |bindGroupEntry|.{{GPUBindGroupEntry/[[prevalidatedSize]]}} is `false`:
+                        - [$effective buffer binding size$](|bound|) must be &ge; [=minimum buffer binding size=]
+                            of the binding variable in |pipeline|'s shader that corresponds to |bindGroupEntry|.
             - [$Encoder bind groups alias a writable resource$](|encoder|, |pipeline|) must be `false`.
         </div>
 


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/issues/4811.