### PR TITLE
wgsl: dynamically infinite loops are dynamic errors

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -270,6 +270,7 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
         text: binding member; url: binding-member
         text: binding resource type; url: binding-resource-type
         text: binding type; url: binding-type
+        text: device loss; url: lose-the-device
         text: GPU error scope; url: gpu-error-scope
         text: front-facing; url: front-facing
         text: shader-output mask; url: shader-output-mask
@@ -7317,7 +7318,7 @@ creating a new instance of the [=variable declaration|variable=] or [=value decl
 path: syntax/loop_statement.syntax.bs.include
 </pre>
 
-A <dfn noexport dfn-for="statement">loop</dfn> statement repeatedly executes a <dfn noexport>loop body</dfn>;
+A <dfn dfn-for="statement">loop</dfn> statement repeatedly executes a <dfn noexport>loop body</dfn>;
 the loop body is specified as a [=compound statement=].
 Each execution of the loop body is called an <dfn noexport>iteration</dfn>.
 
@@ -7326,6 +7327,9 @@ This repetition can be interrupted by a [=statement/break=], or
 
 Optionally, the last statement in the loop body may be a
 [=statement/continuing=] statement.
+
+A [=dynamic error=] occurs if the [=statement/loop=] would execute an unbounded number of [=iterations=].
+This may result in early termination of the loop, other non-local effects, or even [=device loss=].
 
 When one of the statements in the loop body is a [=declaration=],
 it follows the normal [=scope=] and [=lifetime=] rules of a declaration in a [=compound statement=].
@@ -7491,6 +7495,9 @@ Converts to:
   </xmp>
 </div>
 
+A [=dynamic error=] occurs if the [=statement/for=] loop would execute an unbounded number of [=iterations=].
+This may result in early termination of the loop, other non-local effects, or even [=device loss=].
+
 ### While Statement ### {#while-statement}
 
 <pre class=include>
@@ -7509,6 +7516,9 @@ The following statement forms are equivalent:
 * `while`  *condition*  `{` *body_statements* `}`
 * `loop { if !` *condition* `{break;}` *body_statements* `}`
 * `for (;`  *condition* `;) {` *body_statements*  `}`
+
+A [=dynamic error=] occurs if the [=statement/while=] loop would execute an unbounded number of [=iterations=].
+This may result in early termination of the loop, other non-local effects, or even [=device loss=].
 
 ### Break Statement ### {#break-statement}
 


### PR DESCRIPTION
Device loss is not the only possibility.
The loop may be terminated early, skipped, etc.

Issue: #1987