### PR TITLE
Add missing validation rule about |maxFragmentShaderInputVariables|

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8232,6 +8232,8 @@ dictionary GPURenderPipelineDescriptor
 
                 Note: Vertex-only pipelines **can** have user-defined outputs in the vertex stage;
                 their values will be discarded.
+            - There must be no more than |maxFragmentShaderInputVariables| user-defined inputs for
+                |descriptor|.{{GPURenderPipelineDescriptor/Fragment}}.
         1. [=Assert=] that the [=location=] of each user-defined input of
             |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is less
             than |device|.limits.{{supported limits/maxInterStageShaderVariables}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8233,7 +8233,7 @@ dictionary GPURenderPipelineDescriptor
                 Note: Vertex-only pipelines **can** have user-defined outputs in the vertex stage;
                 their values will be discarded.
             - There must be no more than |maxFragmentShaderInputVariables| user-defined inputs for
-                |descriptor|.{{GPURenderPipelineDescriptor/Fragment}}.
+                |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
         1. [=Assert=] that the [=location=] of each user-defined input of
             |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is less
             than |device|.limits.{{supported limits/maxInterStageShaderVariables}}.


### PR DESCRIPTION
This patch adds the missing validation rule about the maximum number of fragment shader input variables. The total number of user-defined fragment shader input variables must be less than or equal to |maxFragmentShaderInputVariables|.

Issue: #4688