### PR TITLE
[editorial] Fix fencepost error in maxBindGroupsPlusVertexBuffers validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8040,19 +8040,21 @@ dictionary GPURenderPipelineDescriptor
                 1. Let |layout| be a new [$default pipeline layout$] for |pipeline| if
                     |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
                     and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
-                1. If any of the following conditions are unsatisfied:
-                    [$generate a validation error$], [$invalidate$] |pipeline|, and stop.
+                1. All of the requirements in the following steps |must| be met.
+                    If any are unmet, [$invalidate$] |pipeline| and return.
 
                     <div class=validusage>
-                        - |layout| is [$valid to use with$] |this|.
-                        - [$validating GPURenderPipelineDescriptor$](|descriptor|, |layout|, |this|) succeeds.
-                        - |layout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}.length + |vertexBufferCount| is &le;
-                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}},
-                            where |vertexBufferCount| is the maximum index in |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}} that is not `undefined`.
+                        1. |layout| |must| be [$valid to use with$] |this|.
+                        1. [$validating GPURenderPipelineDescriptor$](|descriptor|, |layout|, |this|) must succeed.
+                        1. Let |vertexBufferCount| be the index of the last non-null entry in
+                            |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}},
+                            plus 1; or 0 if there are none.
+                        1. |layout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}.[=list/size=] + |vertexBufferCount| must be &le;
+                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}.
                     </div>
                 1. If any [=pipeline-creation error|pipeline-creation=] [=uncategorized errors=]
                     result from the implementation of pipeline creation,
-                    [$generate an internal error$], [$invalidate$] |pipeline|, and stop.
+                    [$generate an internal error$], [$invalidate$] |pipeline| and return.
 
                     Note:
                     Even if the implementation detected [=uncategorized errors=] in shader module


### PR DESCRIPTION
Randomly noticed this fencepost error in the validation for maxBindGroupsPlusVertexBuffers. It said "vertexBufferCount" was the "maximum index" in the array, which is off by one. It also didn't handle 0 vertex buffers.

Uses the newer `|must|` style for these requirements so I could write them as algorithm steps.