### PR TITLE
[editorial] Use `.[=list/size=]` instead of `.length`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8525,7 +8525,7 @@ dictionary GPUFragmentState
 
         <div class=validusage>
             - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}}, |descriptor|, |layout|, |device|) succeeds.
-            - |descriptor|.{{GPUFragmentState/targets}}.length must be &le;
+            - |descriptor|.{{GPUFragmentState/targets}}.[=list/size=] must be &le;
                 |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
             - Let |entryPoint| be [$get the entry point$]({{GPUShaderStage/FRAGMENT}}, |descriptor|).
             - Let |usesDualSourceBlending| be `false`.
@@ -8577,7 +8577,7 @@ dictionary GPUFragmentState
                     - |entryPoint| must have a [=shader stage output=] with [=location=] equal to |index|
                          and [=blend_src=] omitted or equal to 0.
             - If |usesDualSourceBlending| is `true`:
-                - |descriptor|.{{GPUFragmentState/targets}}.length must be 1.
+                - |descriptor|.{{GPUFragmentState/targets}}.[=list/size=] must be 1.
                 - All the [=shader stage outputs=] with [=location=] in |entryPoint| must be in one
                     struct and [=use dual source blending=].
             - [$Validating GPUFragmentState's color attachment bytes per sample$](|device|, |descriptor|.{{GPUFragmentState/targets}}) succeeds.
@@ -9606,11 +9606,11 @@ dictionary GPUVertexAttribute {
 
         <div class=validusage>
             - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}}, |descriptor|, |layout|, |device|) succeeds.
-            - |descriptor|.{{GPUVertexState/buffers}}.length is &le;
+            - |descriptor|.{{GPUVertexState/buffers}}.[=list/size=] is &le;
                 |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
             - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}
                 passes [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|, |descriptor|)
-            - The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.length,
+            - The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.[=list/size=],
                 over every |vertexBuffer| in |descriptor|.{{GPUVertexState/buffers}},
                 is &le;
                 |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
@@ -10648,7 +10648,7 @@ It must only be included by interfaces which also include those mixins.
                     <div class=validusage>
                         - |index| must be &lt;
                             |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}.
-                        - |dynamicOffsets|.length must equal |dynamicOffsetCount|.
+                        - |dynamicOffsets|.[=list/size=] must equal |dynamicOffsetCount|.
                     </div>
                 1. If |bindGroup| is `null`:
                     1. [=map/Remove=] |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|index|].
@@ -11460,7 +11460,7 @@ dictionary GPURenderPassDescriptor
 
     Given a {{GPUDevice}} |device| and {{GPURenderPassDescriptor}} |this|, the following validation rules apply:
 
-    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be &le;
+    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.[=list/size=] must be &le;
         |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
 
     1. For each non-`null` |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:
@@ -12312,7 +12312,7 @@ It must only be included by interfaces which also include those mixins.
                     <div class=validusage>
                         1. It |must| be [$valid to draw$] with |this|.
                         1. Let |buffers| be |this|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
-                        1. For each {{GPUIndex32}} |slot| from `0` to |buffers|.length (non-inclusive):
+                        1. For each {{GPUIndex32}} |slot| from `0` to |buffers|.[=list/size=] (non-inclusive):
                             1. If |buffers|[|slot|] is `null`, [=iteration/continue=].
                             1. Let |bufferSize| be |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|].
                             1. Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
@@ -12382,7 +12382,7 @@ It must only be included by interfaces which also include those mixins.
                         - |firstIndex| + |indexCount| &le; |this|.{{GPURenderCommandsMixin/[[index_buffer_size]]}}
                             &div; |this|.{{GPURenderCommandsMixin/[[index_format]]}}'s byte size;
                         - Let |buffers| be |this|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
-                        - For each {{GPUIndex32}} |slot| from `0` to |buffers|.length (non-inclusive):
+                        - For each {{GPUIndex32}} |slot| from `0` to |buffers|.[=list/size=] (non-inclusive):
                             - If |buffers|[|slot|] is `null`, [=iteration/continue=].
                             - Let |bufferSize| be |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|].
                             - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
@@ -12589,7 +12589,7 @@ It must only be included by interfaces which also include those mixins.
                 must be `true`.
             - Let |pipelineDescriptor| be |encoder|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.
             - For each {{GPUIndex32}} |slot| `0` to
-                |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.length:
+                |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.[=list/size=]:
                 - If |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}[|slot|] is not `null`,
                     |encoder|.{{GPURenderCommandsMixin/[[vertex_buffers]]}} must [=map/contain=] |slot|.
             - Validate {{supported limits/maxBindGroupsPlusVertexBuffers}}:
@@ -13074,7 +13074,7 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
 
                     <div class=validusage>
                         - |this| must not be [$invalid|lost$].
-                        - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be &le;
+                        - |descriptor|.{{GPURenderPassLayout/colorFormats}}.[=list/size=] must be &le;
                             |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
                         - For each non-`null` |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:
                             - |colorFormat| must be a [=color renderable format=].
@@ -15993,7 +15993,7 @@ integers and single-precision floats.
 
     [=Content timeline=] steps:
 
-    1. Throw a {{TypeError}} if |color| is a sequence and |color|.length &ne; 4.
+    1. Throw a {{TypeError}} if |color| is a sequence and |color|.[=list/size=] &ne; 4.
 </div>
 
 <script type=idl>
@@ -16025,7 +16025,7 @@ typedef (sequence<GPUIntegerCoordinate> or GPUOrigin2DDict) GPUOrigin2D;
 
     [=Content timeline=] steps:
 
-    1. Throw a {{TypeError}} if |origin| is a sequence and |origin|.length &gt; 2.
+    1. Throw a {{TypeError}} if |origin| is a sequence and |origin|.[=list/size=] &gt; 2.
 </div>
 
 <script type=idl>
@@ -16061,7 +16061,7 @@ typedef (sequence<GPUIntegerCoordinate> or GPUOrigin3DDict) GPUOrigin3D;
 
     [=Content timeline=] steps:
 
-    1. Throw a {{TypeError}} if |origin| is a sequence and |origin|.length &gt; 3.
+    1. Throw a {{TypeError}} if |origin| is a sequence and |origin|.[=list/size=] &gt; 3.
 </div>
 
 <script type=idl>
@@ -16117,7 +16117,7 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
     1. Throw a {{TypeError}} if:
 
        - |extent| is a sequence, and
-       - |extent|.length &lt; 1 or |extent|.length &gt; 3.
+       - |extent|.[=list/size=] &lt; 1 or |extent|.[=list/size=] &gt; 3.
 </div>
 
 # Feature Index # {#feature-index}


### PR DESCRIPTION
`.length` would be correct for a JS array, but `sequence`s (and other `list`s) are defined by <https://infra.spec.whatwg.org/#list>.