### PR TITLE
[editorial] Use the word "return" instead of "stop"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3361,7 +3361,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following requirements are unmet,
-                    [$generate a validation error$], [$invalidate$] |b|, and stop.
+                    [$generate a validation error$], [$invalidate$] |b| and return.
 
                     <div class=validusage>
                         - |this| must not be [$invalid|lost$].
@@ -3726,7 +3726,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                     Otherwise, let |rangeSize| be |size|.
 
-                1. If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
+                1. If any of the following conditions are unsatisfied, throw an {{OperationError}} and return.
 
                     <div class=validusage>
                         - |this|.{{GPUBuffer/[[mapping]]}} is not `null`.
@@ -4258,7 +4258,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], [$invalidate$] |t|, and stop.
+                    [$generate a validation error$], [$invalidate$] |t| and return.
 
                     <div class=validusage>
                         - [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns `true`.
@@ -4679,7 +4679,7 @@ enum GPUTextureAspect {
                 1. Set |descriptor| to the result of [$resolving GPUTextureViewDescriptor defaults$]
                     for |this| with |descriptor|.
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], [$invalidate$] |view|, and stop.
+                    [$generate a validation error$], [$invalidate$] |view| and return.
 
                     <div class=validusage>
                         - |this| is [$valid to use with$] |this|.{{GPUObjectBase/[[device]]}}.
@@ -5218,7 +5218,7 @@ dictionary GPUExternalTextureDescriptor
                     Otherwise:
 
                     1. If |source| <l spec=html>[=is not origin-clean=]</l>,
-                        throw a {{SecurityError}} and stop.
+                        throw a {{SecurityError}} and return.
 
                     1. Let |usability| be [=?=] [=check the usability of the image argument=](|source|).
 
@@ -5579,7 +5579,7 @@ enum GPUCompareFunction {
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], [$invalidate$] |s|, and stop.
+                    [$generate a validation error$], [$invalidate$] |s| and return.
 
                     <div class=validusage>
                         - |this| must not be [$invalid|lost$].
@@ -6054,7 +6054,7 @@ A {{GPUBindGroupLayout}} object has the following [=device timeline properties=]
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], [$invalidate$] |layout|, and stop.
+                    [$generate a validation error$], [$invalidate$] |layout| and return.
 
                     <div class=validusage>
                         - |this| must not be [$invalid|lost$].
@@ -6293,7 +6293,7 @@ following members:
 
                 1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], [$invalidate$] |bindGroup|, and stop.
+                    [$generate a validation error$], [$invalidate$] |bindGroup| and return.
 
                     <div class=validusage>
                         - |descriptor|.{{GPUBindGroupDescriptor/layout}} is [$valid to use with$] |this|.
@@ -6545,7 +6545,7 @@ pipeline, and have the following members:
                     |bgl|.{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
                     for all |bgl| in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], [$invalidate$] |pl|, and stop.
+                    [$generate a validation error$], [$invalidate$] |pl| and return.
 
                     <div class=validusage>
                         - Every {{GPUBindGroupLayout}} in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -7173,7 +7173,7 @@ interface mixin GPUPipelineBase {
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], [$invalidate$] |layout|, and stop.
+                    [$generate a validation error$], [$invalidate$] |layout| and return.
 
                     <div class=validusage>
                         - |this| must be [$valid$].
@@ -7767,7 +7767,7 @@ dictionary GPUComputePipelineDescriptor
                     and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
 
                 1. All of the requirements in the following steps |must| be met.
-                    If any are unmet, [$generate a validation error$], [$invalidate$] |pipeline|, and stop.
+                    If any are unmet, [$generate a validation error$], [$invalidate$] |pipeline| and return.
 
                     <div class=validusage>
                         1. |layout| |must| be [$valid to use with$] |this|.
@@ -7794,7 +7794,7 @@ dictionary GPUComputePipelineDescriptor
 
                 1. If any [=pipeline-creation error|pipeline-creation=] [=uncategorized errors=]
                     result from the implementation of pipeline creation,
-                    [$generate an internal error$], [$invalidate$] |pipeline|, and stop.
+                    [$generate an internal error$], [$invalidate$] |pipeline| and return.
 
                     Note:
                     Even if the implementation detected [=uncategorized errors=] in shader module
@@ -8041,7 +8041,7 @@ dictionary GPURenderPipelineDescriptor
                     |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
                     and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
                 1. If any of the following conditions are unsatisfied:
-                    [$generate a validation error$], [$invalidate$] |pipeline|, and stop.
+                    [$generate a validation error$], [$invalidate$] |pipeline| and return.
 
                     <div class=validusage>
                         - |layout| is [$valid to use with$] |this|.
@@ -8052,7 +8052,7 @@ dictionary GPURenderPipelineDescriptor
                     </div>
                 1. If any [=pipeline-creation error|pipeline-creation=] [=uncategorized errors=]
                     result from the implementation of pipeline creation,
-                    [$generate an internal error$], [$invalidate$] |pipeline|, and stop.
+                    [$generate an internal error$], [$invalidate$] |pipeline| and return.
 
                     Note:
                     Even if the implementation detected [=uncategorized errors=] in shader module
@@ -9828,7 +9828,7 @@ dictionary GPUCommandEncoderDescriptor
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], [$invalidate$] |e|, and stop.
+                    [$generate a validation error$], [$invalidate$] |e| and return.
 
                     <div class=validusage>
                         - |this| must not be [$invalid|lost$].
@@ -10132,8 +10132,8 @@ dictionary GPUCommandEncoderDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied [$invalidate$] |this| and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |source| is [$valid to use with$] |this|.
@@ -10186,9 +10186,9 @@ dictionary GPUCommandEncoderDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. If |size| is missing, set |size| to <code>max(0, |buffer|.{{GPUBuffer/size}} - |offset|)</code>.
-                1. If any of the following conditions are unsatisfied [$invalidate$] |this| and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
@@ -10241,10 +10241,10 @@ dictionary GPUCommandEncoderDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. Let |aligned| be `true`.
                 1. Let |dataLength| be |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}}.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
@@ -10314,10 +10314,10 @@ dictionary GPUCommandEncoderDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. Let |aligned| be `true`.
                 1. Let |dataLength| be |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}}.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
@@ -10389,8 +10389,8 @@ dictionary GPUCommandEncoderDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - Let |srcTexture| be |source|.{{GPUImageCopyTexture/texture}}.
@@ -10478,8 +10478,8 @@ dictionary GPUCommandEncoderDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |querySet| is [$valid to use with$] |this|.
@@ -10640,10 +10640,10 @@ It must only be included by interfaces which also include those mixins.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. Let |dynamicOffsetCount| be 0 if `bindGroup` is `null`, or
                     |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}} if not.
-                1. If any of the following requirements are unmet, [$invalidate$] |this| and stop.
+                1. If any of the following requirements are unmet, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |index| must be &lt;
@@ -10656,7 +10656,7 @@ It must only be included by interfaces which also include those mixins.
 
                     Otherwise:
 
-                    1. If any of the following requirements are unmet, [$invalidate$] |this| and stop.
+                    1. If any of the following requirements are unmet, [$invalidate$] |this| and return.
 
                         <div class=validusage>
                             - |bindGroup| must be [$valid to use with$] |this|.
@@ -10708,7 +10708,7 @@ It must only be included by interfaces which also include those mixins.
 
                 [=Content timeline=] steps:
 
-                1. If any of the following requirements are unmet, throw a {{RangeError}} and stop.
+                1. If any of the following requirements are unmet, throw a {{RangeError}} and return.
 
                     <div class=validusage>
                         - |dynamicOffsetsDataStart| must be &ge; 0.
@@ -10899,7 +10899,7 @@ It must only be included by interfaces which also include those mixins.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. [=stack/Push=] |groupLabel| onto |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}}.
             </div>
         </div>
@@ -10922,8 +10922,8 @@ It must only be included by interfaces which also include those mixins.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following requirements are unmet, [$invalidate$] |this|, and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following requirements are unmet, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must not [=list/is empty|be empty=].
@@ -10956,7 +10956,7 @@ It must only be included by interfaces which also include those mixins.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
             </div>
         </div>
 </dl>
@@ -11068,8 +11068,8 @@ dictionary GPUComputePassDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |pipeline| is [$valid to use with$] |this|.
@@ -11119,12 +11119,12 @@ dictionary GPUComputePassDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. Let |usageScope| be an empty [=usage scope=].
                 1. For each |bindGroup| in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}},
                     [$usage scope/merge$] |bindGroup|.{{GPUBindGroup/[[usedResources]]}}
                     into |this|.{{GPURenderCommandsMixin/[[usage scope]]}}
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |usageScope| must satisfy [=usage scope validation=].
@@ -11186,14 +11186,14 @@ dictionary GPUComputePassDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. Let |usageScope| be an empty [=usage scope=].
                 1. For each |bindGroup| in |this|.{{GPUBindingCommandsMixin/[[bind_groups]]}},
                     [$usage scope/merge$] |bindGroup|.{{GPUBindGroup/[[usedResources]]}}
                     into |this|.{{GPURenderCommandsMixin/[[usage scope]]}}
                 1. [$usage scope/Add$] |indirectBuffer| to |usageScope|
                     with usage [=internal usage/input=].
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |usageScope| must satisfy [=usage scope validation=].
@@ -11220,7 +11220,7 @@ dictionary GPUComputePassDescriptor
                     (|indirectOffset| + 8) bytes.
                 1. If |workgroupCountX|, |workgroupCountY|, or |workgroupCountZ| is greater than
                     |this|.device.limits.{{supported limits/maxComputeWorkgroupsPerDimension}},
-                    stop.
+                    return.
                 1. Execute a grid of workgroups with dimensions [|workgroupCountX|, |workgroupCountY|,
                     |workgroupCountZ|] with |bindingState|.{{GPUComputePassEncoder/[[pipeline]]}} using
                     |bindingState|.{{GPUBindingCommandsMixin/[[bind_groups]]}}.
@@ -11255,7 +11255,7 @@ called the compute pass encoder can no longer be used.
 
                 1. Let |parentEncoder| be |this|.{{GPURenderPassEncoder/[[command_encoder]]}}.
                 1. If any of the following requirements are unmet,
-                    [$generate a validation error$] and stop.
+                    [$generate a validation error$] and return.
 
                     <div class=validusage>
                         - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
@@ -11263,7 +11263,7 @@ called the compute pass encoder can no longer be used.
                     </div>
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
                 1. Set |parentEncoder|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
-                1. If any of the following requirements are unmet, [$invalidate$] |parentEncoder| and stop.
+                1. If any of the following requirements are unmet, [$invalidate$] |parentEncoder| and return.
 
                     <div class=validusage>
                         - |this| must be [$valid$].
@@ -11926,7 +11926,7 @@ called the render pass encoder can no longer be used.
 
                 1. Let |parentEncoder| be |this|.{{GPURenderPassEncoder/[[command_encoder]]}}.
                 1. If any of the following requirements are unmet,
-                    [$generate a validation error$] and stop.
+                    [$generate a validation error$] and return.
 
                     <div class=validusage>
                         - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
@@ -11934,7 +11934,7 @@ called the render pass encoder can no longer be used.
                     </div>
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
                 1. Set |parentEncoder|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
-                1. If any of the following requirements are unmet, [$invalidate$] |parentEncoder| and stop.
+                1. If any of the following requirements are unmet, [$invalidate$] |parentEncoder| and return.
 
                     <div class=validusage>
                         - |this| must be [$valid$].
@@ -12159,9 +12159,9 @@ It must only be included by interfaces which also include those mixins.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. Let |pipelineTargetsLayout| be [$derive render targets layout from pipeline$](|pipeline|.{{GPURenderPipeline/[[descriptor]]}}).
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |pipeline| is [$valid to use with$] |this|.
@@ -12202,9 +12202,9 @@ It must only be included by interfaces which also include those mixins.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
@@ -12248,10 +12248,10 @@ It must only be included by interfaces which also include those mixins.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. Let |bufferSize| be 0 if |buffer| is `null`, or |buffer|.{{GPUBuffer/size}} if not.
                 1. If |size| is missing, set |size| to max(0, |bufferSize| - |offset|).
-                1. If any of the following requirements are unmet, [$invalidate$] |this| and stop.
+                1. If any of the following requirements are unmet, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |slot| must be &lt;
@@ -12265,7 +12265,7 @@ It must only be included by interfaces which also include those mixins.
 
                     Otherwise:
 
-                    1. If any of the following requirements are unmet, [$invalidate$] |this| and stop.
+                    1. If any of the following requirements are unmet, [$invalidate$] |this| and return.
 
                         <div class=validusage>
                             - |buffer| must be [$valid to use with$] |this|.
@@ -12305,9 +12305,9 @@ It must only be included by interfaces which also include those mixins.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. All of the requirements in the following steps |must| be met.
-                    If any are unmet, [$invalidate$] |this| and stop.
+                    If any are unmet, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         1. It |must| be [$valid to draw$] with |this|.
@@ -12374,8 +12374,8 @@ It must only be included by interfaces which also include those mixins.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - It is [$valid to draw indexed$] with |this|.
@@ -12456,8 +12456,8 @@ It must only be included by interfaces which also include those mixins.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - It is [$valid to draw$] with |this|.
@@ -12538,8 +12538,8 @@ It must only be included by interfaces which also include those mixins.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - It is [$valid to draw indexed$] with |this|.
@@ -12656,8 +12656,8 @@ attachments used by this encoder.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |x| &ge; `0`
@@ -12711,8 +12711,8 @@ attachments used by this encoder.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |x|+|width| &le;
@@ -12757,7 +12757,7 @@ attachments used by this encoder.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. [$Enqueue a render command$] on |this| which issues the subsequent steps on the
                     [=Queue timeline=] with |renderState| when executed.
             </div>
@@ -12793,7 +12793,7 @@ attachments used by this encoder.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
                 1. [$Enqueue a render command$] on |this| which issues the subsequent steps on the
                     [=Queue timeline=] with |renderState| when executed.
             </div>
@@ -12830,8 +12830,8 @@ attachments used by this encoder.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is not `null`.
@@ -12867,8 +12867,8 @@ attachments used by this encoder.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `true`.
@@ -12929,8 +12929,8 @@ attachments used by this encoder.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
                         - For each |bundle| in |bundles|:
@@ -13070,7 +13070,7 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following conditions are unsatisfied
-                    [$generate a validation error$], [$invalidate$] |e|, and stop.
+                    [$generate a validation error$], [$invalidate$] |e| and return.
 
                     <div class=validusage>
                         - |this| must not be [$invalid|lost$].
@@ -13256,10 +13256,7 @@ GPUQueue includes GPUObjectBase;
                     let |contentsSize| be |dataSize| &minus; |dataOffset|.
                     Otherwise, let |contentsSize| be |size|.
                 1. If any of the following conditions are unsatisfied,
-                    throw {{OperationError}} and stop.
-
-                    <!-- Note: it's easiest to write the valid usage rules inline
-                        here, because they depend on contentsSize above. -->
+                    throw an {{OperationError}} and return.
 
                     <div class=validusage>
                         - |contentsSize| &ge; 0.
@@ -13275,7 +13272,7 @@ GPUQueue includes GPUObjectBase;
                 [=Device timeline=] steps:
 
                 1. If any of the following conditions are unsatisfied,
-                    [$generate a validation error$] and stop.
+                    [$generate a validation error$] and return.
 
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
@@ -13329,7 +13326,7 @@ GPUQueue includes GPUObjectBase;
                 1. Let |aligned| be `false`.
                 1. Let |dataLength| be |dataBytes|.[=byte sequence/length=].
                 1. If any of the following conditions are unsatisfied,
-                    [$generate a validation error$] and stop.
+                    [$generate a validation error$] and return.
 
                     <div class=validusage>
                         - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[destroyed]]}} is `false`.
@@ -13423,8 +13420,8 @@ GPUQueue includes GPUObjectBase;
                 1. [=?=] [$validate GPUExtent3D shape$](|copySize|).
                 1. Let |sourceImage| be |source|.{{GPUImageCopyExternalImage/source}}
                 1. If |sourceImage| <l spec=html>[=is not origin-clean=]</l>,
-                    throw a {{SecurityError}} and stop.
-                1. If any of the following requirements are unmet, throw an {{OperationError}} and stop.
+                    throw a {{SecurityError}} and return.
+                1. If any of the following requirements are unmet, throw an {{OperationError}} and return.
 
                     <div class=validusage>
                         - |source|.|origin|.[=GPUOrigin2D/x=] + |copySize|.[=GPUExtent3D/width=]
@@ -13441,7 +13438,7 @@ GPUQueue includes GPUObjectBase;
                 [=Device timeline=] steps:
 
                 1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
-                1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
+                1. If any of the following requirements are unmet, [$generate a validation error$] and return.
 
                     <div class=validusage>
                         - |usability| must be `good`.
@@ -13524,7 +13521,7 @@ GPUQueue includes GPUObjectBase;
                 [=Device timeline=] steps:
 
                 1. If any of the following requirements are unmet, [$generate a validation error$],
-                    [$invalidate$] each {{GPUCommandBuffer}} in |commandBuffers| and stop.
+                    [$invalidate$] each {{GPUCommandBuffer}} in |commandBuffers| and return.
 
                     <div class=validusage>
                         - Every {{GPUCommandBuffer}} in |commandBuffers| must be [$valid to use with$] |this|.
@@ -13695,7 +13692,7 @@ dictionary GPUQuerySetDescriptor
                 [=Device timeline=] |initialization steps|:
 
                 1. If any of the following requirements are unmet, [$generate a validation error$],
-                    [$invalidate$] |q|, and stop.
+                    [$invalidate$] |q| and return.
 
                     <div class=validusage>
                         - |this| must not be [$invalid|lost$].
@@ -13985,7 +13982,7 @@ interface GPUCanvasContext {
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
+                1. If any of the following requirements are unmet, [$generate a validation error$] and return.
 
                     <div class=validusage>
                         - [$validating GPUTextureDescriptor$](|device|, |descriptor|)
@@ -14047,8 +14044,8 @@ interface GPUCanvasContext {
 
                 [=Content timeline=] steps:
 
-                1. If |this|.{{GPUCanvasContext/[[configuration]]}} is `null`:
-                    1. Throw an {{InvalidStateError}} and stop.
+                1. If |this|.{{GPUCanvasContext/[[configuration]]}} is `null`,
+                    throw an {{InvalidStateError}} and return.
                 1. [=Assert=] |this|.{{GPUCanvasContext/[[textureDescriptor]]}} is not `null`.
                 1. Let |device| be |this|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/device}}.
                 1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is `null`:
@@ -15150,7 +15147,7 @@ a list of vertices to process for each instance.
             1. Let |relativeVertexIndex| be [$fetch index$](|i| + |drawCall|.`firstIndex`,
                 |state|.{{GPURenderCommandsMixin/[[index_buffer]]}}).
             1. If |relativeVertexIndex| has the special value `"out of bounds"`,
-                stop and return the empty list.
+                return the empty list.
 
                 Note: Implementations may choose to display a warning when this occurs,
                 especially when it is easy to detect (like in non-indirect indexed draw calls).
@@ -15236,8 +15233,8 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
             1. If |attributeOffset| + sizeof(|attributeDesc|.{{GPUVertexAttribute/format}}) &gt;
                 |vertexBufferOffset| + |vertexBufferBindingSize|:
                 1. Set |drawCallOutOfBounds| to `true`.
-                1. **Optionally ([=implementation-defined=])**,
-                    [=list/empty=] |vertexIndexList| and stop, cancelling the draw call.
+                1. <strong>Optionally ([=implementation-defined=])</strong>,
+                    [=list/empty=] |vertexIndexList| and return, cancelling the draw call.
 
                     Note: This allows implementations to detect out-of-bounds values in the index buffer
                     before issuing a draw call, instead of using [=invalid memory reference=] behavior.


### PR DESCRIPTION
"Return" is standard terminology:
<https://infra.spec.whatwg.org/#algorithm-control-flow>
(Unfortunately it's not linkable, unless we want to make our own `anchors` entry for it.)