### PR TITLE
[editorial] Make a definition for vertex format sizes

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4211,7 +4211,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                 :: Let |m| = max(|size|.[=GPUExtent3D/width=], |size|.[=GPUExtent3D/height=]).
 
                 : {{GPUTextureDimension/"3d"}}
-                :: Let |m| = max(max(|size|.[=GPUExtent3D/width=], |size|.[=GPUExtent3D/height=]), |size|.[=GPUExtent3D/depthOrArrayLayer=]).
+                :: Let |m| = max(max(|size|.[=GPUExtent3D/width=], |size|.[=GPUExtent3D/height=]), |size|.[=GPUExtent3D/depthOrArrayLayers=]).
             </dl>
     1. Return floor(log<sub>2</sub>(|m|)) + 1.
 </div>
@@ -9255,7 +9255,7 @@ enum GPUVertexFormat {
             <th>Vertex format
             <th>Data type
             <th>Components
-            <th>Byte size
+            <th><dfn abstract-op for=GPUVertexFormat>byteSize</dfn>
             <th>Example WGSL type
     </thead>
     <tbody dfn-type=enum-value dfn-for=GPUVertexFormat>
@@ -9562,15 +9562,15 @@ dictionary GPUVertexAttribute {
             - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is a multiple of 4.
             - For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferLayout/attributes}}:
                 - If |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is zero:
-                    - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
+                    - |attrib|.{{GPUVertexAttribute/offset}} + [$GPUVertexFormat/byteSize$](|attrib|.{{GPUVertexAttribute/format}}) &le;
                         |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
 
                     Otherwise:
 
-                    - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
+                    - |attrib|.{{GPUVertexAttribute/offset}} + [$GPUVertexFormat/byteSize$](|attrib|.{{GPUVertexAttribute/format}}) &le;
                         |descriptor|.{{GPUVertexBufferLayout/arrayStride}}.
                 - |attrib|.{{GPUVertexAttribute/offset}} is a multiple of the minimum of 4 and
-                    sizeof(|attrib|.{{GPUVertexAttribute/format}}).
+                    [$GPUVertexFormat/byteSize$](|attrib|.{{GPUVertexAttribute/format}}).
                 - |attrib|.{{GPUVertexAttribute/shaderLocation}} is &lt;
                     |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
             - Let |entryPoint| be [$get the entry point$]({{GPUShaderStage/VERTEX}}, |vertexStage|). [=Assert=] it is not `null`.
@@ -12318,7 +12318,7 @@ It must only be included by interfaces which also include those mixins.
                             1. Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
                             1. Let |attributes| be |buffers|[|slot|].{{GPUVertexBufferLayout/attributes}}
                             1. Let |lastStride| be the maximum value of
-                                (|attribute|.{{GPUVertexAttribute/offset}} &plus; sizeof(|attribute|.{{GPUVertexAttribute/format}}))
+                                (|attribute|.{{GPUVertexAttribute/offset}} &plus; [$GPUVertexFormat/byteSize$](|attribute|.{{GPUVertexAttribute/format}}))
                                 over each |attribute| in |attributes|, or 0 if |attributes| is [=list/empty=].
                             1. Let |strideCount| be computed based on |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}}:
 
@@ -12386,7 +12386,7 @@ It must only be included by interfaces which also include those mixins.
                             - If |buffers|[|slot|] is `null`, [=iteration/continue=].
                             - Let |bufferSize| be |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|].
                             - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
-                            - Let |lastStride| be max(|attribute|.{{GPUVertexAttribute/offset}} &plus; sizeof(|attribute|.{{GPUVertexAttribute/format}}))
+                            - Let |lastStride| be max(|attribute|.{{GPUVertexAttribute/offset}} &plus; [$GPUVertexFormat/byteSize$](|attribute|.{{GPUVertexAttribute/format}}))
                                 for each |attribute| in |buffers|[|slot|].{{GPUVertexBufferLayout/attributes}}.
                             - Let |strideCount| be |firstInstance| &plus; |instanceCount|.
                             - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is {{GPUVertexStepMode/"instance"}} and |strideCount| &ne; `0`:
@@ -15233,7 +15233,7 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
             1. Let |attributeOffset| be |vertexBufferOffset| +
                 |vertexElementIndex| * |vertexBufferLayout|.{{GPUVertexBufferLayout/arrayStride}} +
                 |attributeDesc|.{{GPUVertexAttribute/offset}}.
-            1. If |attributeOffset| + sizeof(|attributeDesc|.{{GPUVertexAttribute/format}}) &gt;
+            1. If |attributeOffset| + [$GPUVertexFormat/byteSize$](|attributeDesc|.{{GPUVertexAttribute/format}}) &gt;
                 |vertexBufferOffset| + |vertexBufferBindingSize|:
                 1. Set |drawCallOutOfBounds| to `true`.
                 1. **Optionally ([=implementation-defined=])**,


### PR DESCRIPTION
`sizeof` was kind of confusing (in C syntax, that would give you the size of the type `GPUVertexFormat`).