### PR TITLE
Clarify that atomic `and` and `or` are bitwise operations, slightly restructure, and fix missing prepositions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -17998,6 +17998,21 @@ Returns a two member structure, where the first member, `old_value`, is the
 original value of the atomic object before the operation and the second member, `exchanged`, is
 whether or not the comparison succeeded.
 
+<div class='example wgsl global-scope' heading='Operation of `atomicCompareExhcangeWeak` as a function'>
+  <xmp highlight=wgsl>
+// All operation performed atomically
+fn atomicCompareExchangeWeak(atomic_ptr: ptr<AS, atomic<T>, read_write>, cmp : T, v : T) ->
+  _atomic_compare_exchange_result<T> {
+  let old = *atomic_ptr;
+  // This comparison may spuriously fail.
+  let comparison = old == cmp;
+  if comparison {
+    *atomic_ptr = v;
+  }
+  return _atomic_compare_exchange_result<T>(old, comparison);  
+}
+  </xmp>
+
 Note: The equality comparison may spuriously fail on some implementations. That
 is, the second component of the result vector may be `false` even if the first
 component of the result vector equals `cmp`.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -17817,7 +17817,7 @@ fn atomicStore(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T)
 
 Atomically stores the value `v` in the atomic object pointed to by `atomic_ptr`.
 
-### Atomic Read-modify-write Functions ### {#atomic-rmw}
+### Atomic Read-modify-write Arithmetic and Logical Functions ### {#atomic-rmw}
 
 Each function performs the following steps atomically:
 
@@ -17837,6 +17837,17 @@ fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically performs an addition operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
 
+<div class='example wgsl global-scope' heading='Operation of `atomicAdd` as a function'>
+  <xmp highlight=wgsl>
+// All operation performed atomically
+fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
+  let old = *atomic_ptr;
+  *atomic_ptr = old + v;
+  return old;
+}
+  </xmp>
+</div>
+
 #### `atomicSub` #### {#atomic-sub}
 
 ```wgsl
@@ -17845,6 +17856,17 @@ fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 
 Atomically performs a subtraction operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
+
+<div class='example wgsl global-scope' heading='Operation of `atomicSub` as a function'>
+  <xmp highlight=wgsl>
+// All operation performed atomically
+fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
+  let old = *atomic_ptr;
+  *atomic_ptr = old - v;
+  return old;
+}
+  </xmp>
+</div>
 
 #### `atomicMax` #### {#atomic-max}
 
@@ -17855,6 +17877,17 @@ fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically performs a maximum operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
 
+<div class='example wgsl global-scope' heading='Operation of `atomicMax` as a function'>
+  <xmp highlight=wgsl>
+// All operation performed atomically
+fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
+  let old = *atomic_ptr;
+  *atomic_ptr = max(old, v);
+  return old;
+}
+  </xmp>
+</div>
+
 #### `atomicMin` #### {#atomic-min}
 
 ```wgsl
@@ -17863,6 +17896,17 @@ fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 
 Atomically performs a minimum operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
+
+<div class='example wgsl global-scope' heading='Operation of `atomicMin` as a function'>
+  <xmp highlight=wgsl>
+// All operation performed atomically
+fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
+  let old = *atomic_ptr;
+  *atomic_ptr = min(old, v);
+  return old;
+}
+  </xmp>
+</div>
 
 #### `atomicAnd` #### {#atomic-and}
 
@@ -17873,6 +17917,17 @@ fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically performs a bitwise AND operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
 
+<div class='example wgsl global-scope' heading='Operation of `atomicAnd` as a function'>
+  <xmp highlight=wgsl>
+// All operation performed atomically
+fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
+  let old = *atomic_ptr;
+  *atomic_ptr = old & v;
+  return old;
+}
+  </xmp>
+</div>
+
 #### `atomicOr` #### {#atomic-or}
 
 ```wgsl
@@ -17881,6 +17936,17 @@ fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 
 Atomically performs a bitwise OR operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
+
+<div class='example wgsl global-scope' heading='Operation of `atomicOr` as a function'>
+  <xmp highlight=wgsl>
+// All operation performed atomically
+fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
+  let old = *atomic_ptr;
+  *atomic_ptr = old | v;
+  return old;
+}
+  </xmp>
+</div>
 
 #### `atomicXor` #### {#atomic-xor}
 
@@ -17891,7 +17957,18 @@ fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically performs a bitwise XOR operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
 
-#### `atomicExchange` #### {#atomic-exchange}
+<div class='example wgsl global-scope' heading='Operation of `atomicXor` as a function'>
+  <xmp highlight=wgsl>
+// All operation performed atomically
+fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
+  let old = *atomic_ptr;
+  *atomic_ptr = old ^ v;
+  return old;
+}
+  </xmp>
+</div>
+
+### `atomicExchange` #### {#atomic-exchange}
 
 ```wgsl
 fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
@@ -17900,7 +17977,7 @@ fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically stores the value `v` in the atomic object pointed to by
 `atomic_ptr` and returns the original value stored in the atomic object before the operation.
 
-#### `atomicCompareExchangeWeak` #### {#atomic-compare-exchange-weak}
+### `atomicCompareExchangeWeak` #### {#atomic-compare-exchange-weak}
 
 ```wgsl
 fn atomicCompareExchangeWeak(

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -17962,7 +17962,15 @@ fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 
 Atomically stores the value `v` in the atomic object pointed to by
 `atomic_ptr` and returns the original value stored in the atomic object before the operation.
-
+<div class='example wgsl global-scope' heading='Operation of `atomicExchange` as a function'>
+  <xmp highlight=wgsl>
+// All operation performed atomically
+fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
+  let old = *atomic_ptr;
+  *atomic_ptr = v;
+  return old;
+}
+  </xmp>
 ### `atomicCompareExchangeWeak` ### {#atomic-compare-exchange-weak}
 
 ```wgsl

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -17963,7 +17963,7 @@ fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically stores the value `v` in the atomic object pointed to by
 `atomic_ptr` and returns the original value stored in the atomic object before the operation.
 
-### `atomicCompareExchangeWeak` #### {#atomic-compare-exchange-weak}
+### `atomicCompareExchangeWeak` ### {#atomic-compare-exchange-weak}
 
 ```wgsl
 fn atomicCompareExchangeWeak(

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -17823,7 +17823,7 @@ fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically performs an addition operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
 
-<div class='example wgsl global-scope' heading='Operation of `atomicAdd` as a function'>
+<div class='example wgsl global-scope' heading='Operation of atomic addition as a function'>
   <xmp highlight=wgsl>
 // All operation performed atomically
 fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
@@ -17843,7 +17843,7 @@ fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically performs a subtraction operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
 
-<div class='example wgsl global-scope' heading='Operation of `atomicSub` as a function'>
+<div class='example wgsl global-scope' heading='Operation of atomic subtraction as a function'>
   <xmp highlight=wgsl>
 // All operation performed atomically
 fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
@@ -17863,7 +17863,7 @@ fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically performs a maximum operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
 
-<div class='example wgsl global-scope' heading='Operation of `atomicMax` as a function'>
+<div class='example wgsl global-scope' heading='Operation of atomic maximum as a function'>
   <xmp highlight=wgsl>
 // All operation performed atomically
 fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
@@ -17883,7 +17883,7 @@ fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically performs a minimum operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
 
-<div class='example wgsl global-scope' heading='Operation of `atomicMin` as a function'>
+<div class='example wgsl global-scope' heading='Operation of atomic minimum as a function'>
   <xmp highlight=wgsl>
 // All operation performed atomically
 fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
@@ -17903,7 +17903,7 @@ fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically performs a bitwise AND operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
 
-<div class='example wgsl global-scope' heading='Operation of `atomicAnd` as a function'>
+<div class='example wgsl global-scope' heading='Operation of atomic bitwise and as a function'>
   <xmp highlight=wgsl>
 // All operation performed atomically
 fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
@@ -17923,7 +17923,7 @@ fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically performs a bitwise OR operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
 
-<div class='example wgsl global-scope' heading='Operation of `atomicOr` as a function'>
+<div class='example wgsl global-scope' heading='Operation of atomic bitwise or as a function'>
   <xmp highlight=wgsl>
 // All operation performed atomically
 fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
@@ -17943,7 +17943,7 @@ fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically performs a bitwise XOR operation on the atomic object pointed to by `atomic_ptr`
 with the value `v`, and returns the original value stored in the atomic object before the operation.
 
-<div class='example wgsl global-scope' heading='Operation of `atomicXor` as a function'>
+<div class='example wgsl global-scope' heading='Operation of atomic bitwise xor as a function'>
   <xmp highlight=wgsl>
 // All operation performed atomically
 fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
@@ -17963,7 +17963,7 @@ fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 Atomically stores the value `v` in the atomic object pointed to by
 `atomic_ptr` and returns the original value stored in the atomic object before the operation.
 
-<div class='example wgsl global-scope' heading='Operation of `atomicExchange` as a function'>
+<div class='example wgsl global-scope' heading='Operation of atomic exchange as a function'>
   <xmp highlight=wgsl>
 // All operation performed atomically
 fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
@@ -17972,6 +17972,8 @@ fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
   return old;
 }
   </xmp>
+</div>
+
 ### `atomicCompareExchangeWeak` ### {#atomic-compare-exchange-weak}
 
 ```wgsl
@@ -17999,7 +18001,7 @@ Returns a two member structure, where the first member, `old_value`, is the
 original value of the atomic object before the operation and the second member, `exchanged`, is
 whether or not the comparison succeeded.
 
-<div class='example wgsl global-scope' heading='Operation of `atomicCompareExchangeWeak` as a function'>
+<div class='example wgsl global-scope' heading='Operation of atomic compare exchange as a function'>
   <xmp highlight=wgsl>
 // All operation performed atomically
 fn atomicCompareExchangeWeak(atomic_ptr: ptr<AS, atomic<T>, read_write>, cmp : T, v : T) ->

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -17800,7 +17800,7 @@ functions [=shader-creation error|must=] be either [=address spaces/storage=] or
 
 |T| [=shader-creation error|must=] be either [=u32=] or [=i32=]
 
-### Atomic Load ### {#atomic-load}
+### `atomicLoad` ### {#atomic-load}
 
 ```wgsl
 fn atomicLoad(atomic_ptr: ptr<AS, atomic<T>, read_write>) -> T
@@ -17809,7 +17809,7 @@ fn atomicLoad(atomic_ptr: ptr<AS, atomic<T>, read_write>) -> T
 Returns the atomically loaded the value pointed to by `atomic_ptr`.
 It does not [=atomic modification|modify=] the object.
 
-### Atomic Store ### {#atomic-store}
+### `atomicStore` ### {#atomic-store}
 
 ```wgsl
 fn atomicStore(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T)
@@ -17817,17 +17817,8 @@ fn atomicStore(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T)
 
 Atomically stores the value `v` in the atomic object pointed to by `atomic_ptr`.
 
-### Atomic Read-modify-write ### {#atomic-rmw}
+### Atomic Read-modify-write Functions ### {#atomic-rmw}
 
-```wgsl
-fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-```
 Each function performs the following steps atomically:
 
 1. Load the original value pointed to by `atomic_ptr`.
@@ -17835,14 +17826,81 @@ Each function performs the following steps atomically:
     name with the value |v|.
 3. Store the new value using `atomic_ptr`.
 
-Each function returns the original value stored in the atomic object.
+Each function returns the original value stored in the atomic object before the operation.
+
+#### `atomicAdd` #### {#atomic-add}
+
+```wgsl
+fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+```
+
+Atomically performs an addition operation on the atomic object pointed to by `atomic_ptr`
+with the value `v`, and returns the original value stored in the atomic object before the operation.
+
+#### `atomicSub` #### {#atomic-sub}
+
+```wgsl
+fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+```
+
+Atomically performs a subtraction operation on the atomic object pointed to by `atomic_ptr`
+with the value `v`, and returns the original value stored in the atomic object before the operation.
+
+#### `atomicMax` #### {#atomic-max}
+
+```wgsl
+fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+```
+
+Atomically performs a maximum operation on the atomic object pointed to by `atomic_ptr`
+with the value `v`, and returns the original value stored in the atomic object before the operation.
+
+#### `atomicMin` #### {#atomic-min}
+
+```wgsl
+fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+```
+
+Atomically performs a minimum operation on the atomic object pointed to by `atomic_ptr`
+with the value `v`, and returns the original value stored in the atomic object before the operation.
+
+#### `atomicAnd` #### {#atomic-and}
+
+```wgsl
+fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+```
+
+Atomically performs a bitwise AND operation on the atomic object pointed to by `atomic_ptr`
+with the value `v`, and returns the original value stored in the atomic object before the operation.
+
+#### `atomicOr` #### {#atomic-or}
+
+```wgsl
+fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+```
+
+Atomically performs a bitwise OR operation on the atomic object pointed to by `atomic_ptr`
+with the value `v`, and returns the original value stored in the atomic object before the operation.
+
+#### `atomicXor` #### {#atomic-xor}
+
+```wgsl
+fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+```
+
+Atomically performs a bitwise XOR operation on the atomic object pointed to by `atomic_ptr`
+with the value `v`, and returns the original value stored in the atomic object before the operation.
+
+#### `atomicExchange` #### {#atomic-exchange}
 
 ```wgsl
 fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 ```
 
-Atomically stores the value `v` in the atomic object pointed to
-`atomic_ptr` and returns the original value stored in the atomic object.
+Atomically stores the value `v` in the atomic object pointed to by
+`atomic_ptr` and returns the original value stored in the atomic object before the operation.
+
+#### `atomicCompareExchangeWeak` #### {#atomic-compare-exchange-weak}
 
 ```wgsl
 fn atomicCompareExchangeWeak(
@@ -17866,7 +17924,7 @@ Performs the following steps atomically:
 3. Store the value `v` `only if` the result of the equality comparison was `true`.
 
 Returns a two member structure, where the first member, `old_value`, is the
-original value of the atomic object and the second member, `exchanged`, is
+original value of the atomic object before the operation and the second member, `exchanged`, is
 whether or not the comparison succeeded.
 
 Note: The equality comparison may spuriously fail on some implementations. That

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -17954,7 +17954,7 @@ fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v : T) -> T {
   </xmp>
 </div>
 
-### `atomicExchange` #### {#atomic-exchange}
+### `atomicExchange` ### {#atomic-exchange}
 
 ```wgsl
 fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -17962,6 +17962,7 @@ fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 
 Atomically stores the value `v` in the atomic object pointed to by
 `atomic_ptr` and returns the original value stored in the atomic object before the operation.
+
 <div class='example wgsl global-scope' heading='Operation of `atomicExchange` as a function'>
   <xmp highlight=wgsl>
 // All operation performed atomically
@@ -17998,7 +17999,7 @@ Returns a two member structure, where the first member, `old_value`, is the
 original value of the atomic object before the operation and the second member, `exchanged`, is
 whether or not the comparison succeeded.
 
-<div class='example wgsl global-scope' heading='Operation of `atomicCompareExhcangeWeak` as a function'>
+<div class='example wgsl global-scope' heading='Operation of `atomicCompareExchangeWeak` as a function'>
   <xmp highlight=wgsl>
 // All operation performed atomically
 fn atomicCompareExchangeWeak(atomic_ptr: ptr<AS, atomic<T>, read_write>, cmp : T, v : T) ->
@@ -18012,6 +18013,7 @@ fn atomicCompareExchangeWeak(atomic_ptr: ptr<AS, atomic<T>, read_write>, cmp : T
   return _atomic_compare_exchange_result<T>(old, comparison);  
 }
   </xmp>
+</div>
 
 Note: The equality comparison may spuriously fail on some implementations. That
 is, the second component of the result vector may be `false` even if the first


### PR DESCRIPTION
Although we intended to just probably add a note to say that these two operations are bitwise versions, I found it slightly unfortunate that atomic operations were not sectioned, relying on reader intuition to locate them. They were the only such in the built-in functions section, so I also monospaced load and store operations. At this moment, this helps us clarify the bitwise nature of these two operations, but sectioning them helps in the case that adding an example might clarify things.