### PR TITLE
[editorial] default GPUProgrammableStage.constants to {}

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7364,7 +7364,7 @@ Entry point names follow the rules defined in [=WGSL identifier comparison=].
 dictionary GPUProgrammableStage {
     required GPUShaderModule module;
     USVString entryPoint;
-    record<USVString, GPUPipelineConstantValue> constants;
+    record<USVString, GPUPipelineConstantValue> constants = {};
 };
 
 typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32, u32, and f16 if enabled.


### PR DESCRIPTION
This lets us assume it's defined when we refer to it in algorithms. (Currently we ignore the possibility of it being undefined.)