### PR TITLE
[editorial] remove assertion from "dot" syntax

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -536,10 +536,7 @@ In this specification, the following syntactic shorthands are used:
 : The `.` ("dot") syntax, common in programming languages.
 ::
     The phrasing "`Foo.Bar`" means "the `Bar` member of the value (or interface) `Foo`."
-    If `Foo` is an [=ordered map=], [=asserts=] that the key `Bar` exists.
-
-    <p class="note editorial"><span class=marker>Editorial note:</span>
-    Some phrasing in this spec may currently assume this resolves to `undefined` if `Bar` doesn't exist.
+    If `Foo` is an [=ordered map=] and `Bar` does not [=map/exist=] in `Foo`, returns `undefined`.
 
     The phrasing "`Foo.Bar` is [=map/exist|provided=]" means
     "the `Bar` member [=map/exists=] in the [=map=] value `Foo`"
@@ -555,7 +552,7 @@ In this specification, the following syntactic shorthands are used:
 
 : The `??` ("nullish coalescing") syntax, adopted from JavaScript.
 ::
-    The phrasing "`x` ?? `y`" means "`x`, if `x` is not null/undefined, and `y` otherwise".
+    The phrasing "`x` ?? `y`" means "`x`, if `x` is not null or undefined, and `y` otherwise".
 
 : <dfn dfn>slot-backed attribute</dfn>
 ::
@@ -6075,10 +6072,11 @@ A {{GPUBindGroupLayout}} object has the following [=device timeline properties=]
 
                             - If |entry|.{{GPUBindGroupLayoutEntry/visibility}} includes
                                 {{GPUShaderStage/VERTEX}}:
-                                - |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
-                                    must not be {{GPUBufferBindingType/"storage"}}.
-                                    Note that {{GPUBufferBindingType/"read-only-storage"}} is allowed.
-                                - |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}?.{{GPUStorageTextureBindingLayout/access}}
+                                - If |entry|.{{GPUBindGroupLayoutEntry/buffer}} is [=map/exists|provided=],
+                                    |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}}
+                                    must be {{GPUBufferBindingType/"uniform"}} or {{GPUBufferBindingType/"read-only-storage"}}.
+                                - If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is [=map/exists|provided=],
+                                    |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}}
                                     must be {{GPUStorageTextureAccess/"read-only"}}.
 
                             - If |entry|.{{GPUBindGroupLayoutEntry/texture}}?.{{GPUTextureBindingLayout/multisampled}} is `true`:
@@ -6309,7 +6307,7 @@ following members:
                                 such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
                                 |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
 
-                            - If the defined [=binding member=] for |layoutBinding| is
+                            - If the defined [=binding member=] for |layoutBinding| is:
 
                                 <dl class=switch>
                                     : {{GPUBindGroupLayoutEntry/sampler}}
@@ -8540,15 +8538,15 @@ dictionary GPUFragmentState
                         must be a [=valid GPUBlendComponent=].
                     - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}
                         must be a [=valid GPUBlendComponent=].
-                - If |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}.{{GPUBlendComponent/srcFactor}} or
-                    |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}.{{GPUBlendComponent/dstFactor}} or
-                    |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}.{{GPUBlendComponent/srcFactor}} or
-                    |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}.{{GPUBlendComponent/dstFactor}}
-                    uses the second input of the corresponding blending unit (is any of
-                        {{GPUBlendFactor/"src1"}}, {{GPUBlendFactor/"one-minus-src1"}},
-                        {{GPUBlendFactor/"src1-alpha"}}, {{GPUBlendFactor/"one-minus-src1-alpha"}}), then:
+                    - If |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}.{{GPUBlendComponent/srcFactor}} or
+                        |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}.{{GPUBlendComponent/dstFactor}} or
+                        |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}.{{GPUBlendComponent/srcFactor}} or
+                        |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}.{{GPUBlendComponent/dstFactor}}
+                        uses the second input of the corresponding blending unit (is any of
+                            {{GPUBlendFactor/"src1"}}, {{GPUBlendFactor/"one-minus-src1"}},
+                            {{GPUBlendFactor/"src1-alpha"}}, {{GPUBlendFactor/"one-minus-src1-alpha"}}), then:
 
-                    - Set |usesDualSourceBlending| to `true`.
+                        - Set |usesDualSourceBlending| to `true`.
                 - For each [=shader stage output=] value |output| with [=location=] attribute equal to |index|
                     in |entryPoint|:
                     - For each component in |colorState|.{{GPUColorTargetState/format}}, there must be a
@@ -9871,7 +9869,7 @@ dictionary GPUCommandEncoderDescriptor
                 [=Content timeline=] steps:
 
                 1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-                    1. If |colorAttachment|.{{GPURenderPassColorAttachment/clearValue}} is not `null`.
+                    1. If |colorAttachment|.{{GPURenderPassColorAttachment/clearValue}} is [=map/exists|provided=]:
                         1. [=?=] [$validate GPUColor shape$](|colorAttachment|.{{GPURenderPassColorAttachment/clearValue}}).
                 1. Let |pass| be a new {{GPURenderPassEncoder}} object.
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
@@ -9888,7 +9886,7 @@ dictionary GPUCommandEncoderDescriptor
                     includes a single depth slice for {{GPUTextureViewDimension/"3d"}} textures only.
                 1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
                     1. Add [|colorAttachment|.{{GPURenderPassColorAttachment/view}},
-                        |colorAttachment|.{{GPURenderPassColorAttachment/depthSlice}}] to |attachmentRegions|.
+                        |colorAttachment|.{{GPURenderPassColorAttachment/depthSlice}} ?? `null`] to |attachmentRegions|.
                     1. If |colorAttachment|.{{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
                         1. Add [|colorAttachment|.{{GPURenderPassColorAttachment/resolveTarget}},
                             `undefined`] to |attachmentRegions|.
@@ -9902,8 +9900,7 @@ dictionary GPUCommandEncoderDescriptor
                 1. [$usage scope/Add$] each [=texture subresource=] in |attachmentRegions|
                     to |pass|.{{GPURenderCommandsMixin/[[usage scope]]}}
                     with usage [=internal usage/attachment=].
-                1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}},
-                    or `null` if not [=map/exist|provided=].
+                1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
                 1. If |depthStencilAttachment| is not `null`:
                     1. Let |depthStencilView| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
                     1. [$usage scope/Add$] the [=aspect/depth=] [=subresource=] of |depthStencilView|, if any,
@@ -10262,7 +10259,7 @@ dictionary GPUCommandEncoderDescriptor
                 1. Let |blockWidth| be the [=texel block width=] of |destination|.{{GPUImageCopyTexture/texture}}.
                 1. Let |blockHeight| be the [=texel block height=] of |destination|.{{GPUImageCopyTexture/texture}}.
 
-                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}};
+                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}}.
                 1. Let |dstBlockOriginX| be (|dstOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
                 1. Let |dstBlockOriginY| be (|dstOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
 
@@ -10335,7 +10332,7 @@ dictionary GPUCommandEncoderDescriptor
                 1. Let |blockWidth| be the [=texel block width=] of |source|.{{GPUImageCopyTexture/texture}}.
                 1. Let |blockHeight| be the [=texel block height=] of |source|.{{GPUImageCopyTexture/texture}}.
 
-                1. Let |srcOrigin| be |source|.{{GPUImageCopyTexture/origin}};
+                1. Let |srcOrigin| be |source|.{{GPUImageCopyTexture/origin}}.
                 1. Let |srcBlockOriginX| be (|srcOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
                 1. Let |srcBlockOriginY| be (|srcOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
 
@@ -10419,11 +10416,11 @@ dictionary GPUCommandEncoderDescriptor
                 1. Let |blockWidth| be the [=texel block width=] of |source|.{{GPUImageCopyTexture/texture}}.
                 1. Let |blockHeight| be the [=texel block height=] of |source|.{{GPUImageCopyTexture/texture}}.
 
-                1. Let |srcOrigin| be |source|.{{GPUImageCopyTexture/origin}};
+                1. Let |srcOrigin| be |source|.{{GPUImageCopyTexture/origin}}.
                 1. Let |srcBlockOriginX| be (|srcOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
                 1. Let |srcBlockOriginY| be (|srcOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
 
-                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}};
+                1. Let |dstOrigin| be |destination|.{{GPUImageCopyTexture/origin}}.
                 1. Let |dstBlockOriginX| be (|dstOrigin|.[=GPUOrigin3D/x=] &div; |blockWidth|).
                 1. Let |dstBlockOriginY| be (|dstOrigin|.[=GPUOrigin3D/y=] &div; |blockHeight|).
 
@@ -10828,10 +10825,10 @@ It must only be included by interfaces which also include those mixins.
                 |bindGroupLayoutEntries|, and corresponding {{GPUTextureView}} |resource|
                 in |bindGroup|, in which
                 |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/visibility}} contains |stage|:
+                1. If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not [=map/exist|provided=], **continue**.
                 1. Let |resourceWritable| be whether
                     |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}}
                     is a writable access mode.
-                1. If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not [=map/exist|provided=], **continue**.
                 1. For each pair ({{GPUTextureView}} |pastResource|, {{boolean}} |pastResourceWritable|) in |textureViews|,
                     1. If (|resourceWritable| or |pastResourceWritable|) is true, and
                         |pastResource| and |resource| is [=texture-view-aliasing=], return `true`.
@@ -11491,7 +11488,7 @@ dictionary GPURenderPassDescriptor
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
         if present, the {{GPUTextureView/[[renderExtent]]}} must match.
 
-    1. If |this|.{{GPURenderPassDescriptor/occlusionQuerySet}} is not `null`:
+    1. If |this|.{{GPURenderPassDescriptor/occlusionQuerySet}} is [=map/exists|provided=]:
 
         1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}} must be [$valid to use with$] |device|.
         1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/type}}
@@ -11573,47 +11570,46 @@ dictionary GPURenderPassColorAttachment {
         after executing the render pass.
 </dl>
 
-<div dfn-for=GPURenderPassColorAttachment data-timeline=device>
+<div algorithm dfn-for=GPURenderPassColorAttachment data-timeline=device>
     <dfn abstract-op>GPURenderPassColorAttachment Valid Usage</dfn>
 
     Given a {{GPURenderPassColorAttachment}} |this|:
 
     1. Let |renderViewDescriptor| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.
-    1. Let |resolveViewDescriptor| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[descriptor]]}}.
     1. Let |renderTexture| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.
-    1. Let |resolveTexture| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.
-
-    1. The following validation rules apply:
+    1. All of the requirements in the following steps |must| be met.
         <div class=validusage>
-            - |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}} must be a [=color renderable format=].
-            - |this|.{{GPURenderPassColorAttachment/view}} must be a [$renderable texture view$].
-            - If |renderViewDescriptor|.{{GPUTextureViewDescriptor/dimension}} is {{GPUTextureViewDimension/"3d"}}:
-                - |this|.{{GPURenderPassColorAttachment/depthSlice}} must [=map/exist|be provided=] and must
+            1. |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}} |must| be a [=color renderable format=].
+            1. |this|.{{GPURenderPassColorAttachment/view}} |must| be a [$renderable texture view$].
+            1. If |renderViewDescriptor|.{{GPUTextureViewDescriptor/dimension}} is {{GPUTextureViewDimension/"3d"}}:
+                1. |this|.{{GPURenderPassColorAttachment/depthSlice}} |must| [=map/exist|be provided=] and |must|
                     be &lt; the [=GPUExtent3D/depthOrArrayLayers=] of the [=logical miplevel-specific texture extent=]
                     of the |renderTexture| [=subresource=] at [=mipmap level=] |renderViewDescriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}.
 
                 Otherwise:
 
-                - |this|.{{GPURenderPassColorAttachment/depthSlice}} must not [=map/exist|be provided=].
+                1. |this|.{{GPURenderPassColorAttachment/depthSlice}} |must| not [=map/exist|be provided=].
 
-            - If |this|.{{GPURenderPassColorAttachment/loadOp}} is {{GPULoadOp/"clear"}}:
-                - Converting the IDL value |this|.{{GPURenderPassColorAttachment/clearValue}}
+            1. If |this|.{{GPURenderPassColorAttachment/loadOp}} is {{GPULoadOp/"clear"}}:
+                1. Converting the IDL value |this|.{{GPURenderPassColorAttachment/clearValue}}
                     [$to a texel value of texture format$] |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}}
-                    must not throw a {{TypeError}}.
+                    |must| not throw a {{TypeError}}.
 
                     Note: An error is not thrown if the value is out-of-range for the format but in-range for
                     the corresponding WGSL primitive type (`f32`, `i32`, or `u32`).
-            - If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is [=map/exist|provided=]:
-                - |renderTexture|.{{GPUTexture/sampleCount}} must be &gt; 1.
-                - |resolveTexture|.{{GPUTexture/sampleCount}} must be 1.
-                - |this|.{{GPURenderPassColorAttachment/resolveTarget}} must be a non-3d [$renderable texture view$].
-                - |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[renderExtent]]}} and
-                    |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[renderExtent]]}} must match.
-                - |resolveViewDescriptor|.{{GPUTextureViewDescriptor/format}} must equal
+            1. If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is [=map/exist|provided=]:
+                1. Let |resolveViewDescriptor| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[descriptor]]}}.
+                1. Let |resolveTexture| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.
+                1. |renderTexture|.{{GPUTexture/sampleCount}} |must| be &gt; 1.
+                1. |resolveTexture|.{{GPUTexture/sampleCount}} |must| be 1.
+                1. |this|.{{GPURenderPassColorAttachment/resolveTarget}} |must| be a non-3d [$renderable texture view$].
+                1. |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[renderExtent]]}} and
+                    |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[renderExtent]]}} |must| match.
+                1. |resolveViewDescriptor|.{{GPUTextureViewDescriptor/format}} |must| equal
                     |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}}.
-                - |resolveTexture|.{{GPUTextureDescriptor/format}} must equal
+                1. |resolveTexture|.{{GPUTextureDescriptor/format}} |must| equal
                     |renderTexture|.{{GPUTextureDescriptor/format}}.
-                - |resolveViewDescriptor|.{{GPUTextureViewDescriptor/format}} must support resolve according to [[#plain-color-formats]].
+                1. |resolveViewDescriptor|.{{GPUTextureViewDescriptor/format}} |must| support resolve according to [[#plain-color-formats]].
         </div>
 </div>
 
@@ -11868,8 +11864,7 @@ dictionary GPURenderPassLayout
             1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}.
         1. Otherwise:
             1. Append `null` to |layout|.{{GPURenderPassLayout/colorFormats}}.
-    1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}},
-        or `null` if not [=map/exist|provided=].
+    1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
     1. If |depthStencilAttachment| is not `null`:
         1. Let |view| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
         1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}.
@@ -12407,8 +12402,9 @@ It must only be included by interfaces which also include those mixins.
                     with the states from |bindingState| and |renderState|.
             </div>
 
-            Note: a valid program should also never use vertex indices with
-            {{GPUVertexStepMode/"vertex"|GPUVertexStepMode."vertex"}} that are out of bounds.
+            Note:
+            WebGPU applications should never use index data with indices out of bounds of any
+            bound vertex buffer that has {{GPUVertexStepMode}} {{GPUVertexStepMode/"vertex"}}.
             WebGPU implementations have different ways of handling this,
             and therefore a range of behaviors is allowed.
             Either the whole draw call is discarded, or the access to those attributes
@@ -13060,8 +13056,9 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
 
                 1. [=?=] [$Validate texture format required features$] of each non-`null` element of
                     |descriptor|.{{GPURenderPassLayout/colorFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
-                1. [=?=] [$Validate texture format required features$] of
-                    |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} with |this|.{{GPUObjectBase/[[device]]}}.
+                1. If |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} is [=map/exists|provided=]:
+                    1. [=?=] [$Validate texture format required features$] of
+                        |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} with |this|.{{GPUObjectBase/[[device]]}}.
                 1. Let |e| be [=!=] [$create a new WebGPU object$](|this|, {{GPURenderBundleEncoder}}, |descriptor|).
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |e|.
@@ -14998,9 +14995,10 @@ Issue: This section is incomplete.
 ## Computing ## {#computing-operations}
 
 Computing operations provide direct access to GPU's programmable hardware.
-Compute shaders do not have shader stage inputs or outputs, their results are
-side effects from writing data into storage bindings bound as
-{{GPUBufferBindingType/"storage"|GPUBufferBindingType."storage"}} and {{GPUStorageTextureBindingLayout}}.
+Compute shaders do not have shader stage inputs or outputs; their results are
+side effects from writing data into storage bindings bound either as
+{{GPUBufferBindingLayout}} with {{GPUBufferBindingType}} {{GPUBufferBindingType/"storage"}}
+or as {{GPUStorageTextureBindingLayout}}.
 These operations are encoded within {{GPUComputePassEncoder}} as:
 
 - {{GPUComputePassEncoder/dispatchWorkgroups()}}
@@ -15212,7 +15210,7 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
     in each instance of index |rawInstanceIndex|, is processed independently.
     The |rawInstanceIndex| is in range from 0 to |drawCall|.instanceCount - 1, inclusive.
     This processing happens in parallel, and any side effects, such as
-    writes into {{GPUBufferBindingType/"storage"|GPUBufferBindingType."storage"}} bindings,
+    writes into {{GPUBufferBindingType}} {{GPUBufferBindingType/"storage"}} bindings,
     may happen in any order.
 
     1. Let |instanceIndex| be |rawInstanceIndex| + |drawCall|.firstInstance.
@@ -15793,7 +15791,7 @@ This stage produces a <dfn dfn>Fragment</dfn> for each [=RasterizationPoint=]:
 </div>
 
 Processing of fragments happens in parallel, while any side effects,
-such as writes into {{GPUBufferBindingType/"storage"|GPUBufferBindingType."storage"}} bindings,
+such as writes into {{GPUBufferBindingType}} {{GPUBufferBindingType/"storage"}} bindings,
 may happen in any order.
 
 ### Output Merging ### {#output-merging}


### PR DESCRIPTION
Audited ~all of the usages of the x.y "dot" syntax and things that look like it.

- Determined that the assertion was not really useful, so instead defined missing optional members to return 'undefined', like JS.
- Fixed several places where the assert _would_ have failed.
- Replaced weird EnumName."enum-value" style.
- Assorted copyediting.

Fixes an "editorial note".