### PR TITLE
Add API surface for feature levels

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2289,7 +2289,7 @@ interface GPU {
                 1. All of the requirements in the following steps |must| be met.
 
                     <div class=validusage>
-                        1. |options|.{{GPURequestAdapterOptions/capabilityLevel}} |must| be `undefined`.
+                        1. |options|.{{GPURequestAdapterOptions/featureLevel}} |must| be `undefined`.
                     </div>
 
                     If they are met **and** the user agent chooses to return an adapter:
@@ -2432,7 +2432,7 @@ configuration is suitable for the application.
 
 <script type=idl>
 dictionary GPURequestAdapterOptions {
-    any capabilityLevel;
+    any featureLevel;
     GPUPowerPreference powerPreference;
     boolean forceFallbackAdapter = false;
 };

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2286,18 +2286,26 @@ interface GPU {
             <div data-timeline=device>
                 [=Device timeline=] |initialization steps|:
 
-                1. Let |adapter| be `null`.
-                1. If the user agent chooses to return an adapter:
+                1. All of the requirements in the following steps |must| be met.
+
+                    <div class=validusage>
+                        1. |options|.{{GPURequestAdapterOptions/featureLevel}} |must| be `undefined`.
+                    </div>
+
+                    If they are met **and** the user agent chooses to return an adapter:
+
                     1. Set |adapter| to an [=adapter=] chosen according to
                         the rules in [[#adapter-selection]] and the criteria in |options|,
                         adhering to [[#adapter-capability-guarantees]].
 
                         The [=supported limits=] of the adapter must adhere to the requirements
                         defined in [[#limits]].
-
                     1. If |adapter| meets the criteria of a [=fallback adapter=] set
                         |adapter|.{{adapter/[[fallback]]}} to `true`.
 
+                    Otherwise:
+
+                    1. Let |adapter| be `null`.
                 1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
             <div data-timeline=content>
@@ -2424,6 +2432,7 @@ configuration is suitable for the application.
 
 <script type=idl>
 dictionary GPURequestAdapterOptions {
+    any featureLevel;
     GPUPowerPreference powerPreference;
     boolean forceFallbackAdapter = false;
 };

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2289,7 +2289,7 @@ interface GPU {
                 1. All of the requirements in the following steps |must| be met.
 
                     <div class=validusage>
-                        1. |options|.{{GPURequestAdapterOptions/featureLevel}} |must| be `undefined`.
+                        1. |options|.{{GPURequestAdapterOptions/capabilityLevel}} |must| be `undefined`.
                     </div>
 
                     If they are met **and** the user agent chooses to return an adapter:
@@ -2432,7 +2432,7 @@ configuration is suitable for the application.
 
 <script type=idl>
 dictionary GPURequestAdapterOptions {
-    any featureLevel;
+    any capabilityLevel;
     GPUPowerPreference powerPreference;
     boolean forceFallbackAdapter = false;
 };


### PR DESCRIPTION
This provides a dictionary member that can be used for feature level requests in the future. It currently does not accept any value; the only thing it does is make sure that _if_ anything is passed to `featureLevel`, we know not to ignore it. This is the appropriate behavior for a browser to have before it adds support for any other feature levels.

Proposing this for M0 to set up the API surface.

It has type `any` so that it `requestAdapter()` can return `null` (rather than rejecting) regardless of what types we end up using to describe feature levels in the future. This is to make it consistent with the future case where the browser _does_ understand the feature level but the hardware doesn't support it (which probably should return `null` - the request was OK but there was no adapter to return).

This is planned to be used for Compat mode, likely simply by accepting a string value, e.g. `"compat"` (% bikeshedding).

Issue: #4656