### PR TITLE
Add `texture-compression-astc-sliced-3d`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2805,6 +2805,7 @@ enum GPUFeatureName {
     "texture-compression-bc-sliced-3d",
     "texture-compression-etc2",
     "texture-compression-astc",
+    "texture-compression-astc-sliced-3d",
     "timestamp-query",
     "indirect-first-instance",
     "shader-f16",
@@ -16252,6 +16253,20 @@ This feature adds the following [=optional API surfaces=]:
     - {{GPUTextureFormat/"astc-12x12-unorm"}}
     - {{GPUTextureFormat/"astc-12x12-unorm-srgb"}}
 
+<h3 id=texture-compression-astc-sliced-3d data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-astc-sliced-3d"`
+<span id=dom-gpufeaturename-texture-compression-astc-sliced-3d></span>
+</h3>
+
+Allows the {{GPUTextureDimension/3d}} dimension for textures with ASTC compressed formats.
+
+Note: Adapters which support {{GPUFeatureName/"texture-compression-astc"}} do not
+always support {{GPUFeatureName/"texture-compression-astc-sliced-3d"}}.
+To use {{GPUFeatureName/"texture-compression-astc-sliced-3d"}},
+{{GPUFeatureName/"texture-compression-astc"}} must be enabled explicitly as this feature
+does not enable the ASTC formats.
+
+This feature adds no [=optional API surfaces=].
+
 <h3 id=timestamp-query data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"timestamp-query"`
 <span id=dom-gpufeaturename-timestamp-query></span>
 </h3>
@@ -17040,7 +17055,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td rowspan=2>16
         <td rowspan=28>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td rowspan=2>4 &times; 4
-        <td rowspan=28>
+        <td rowspan=14>If {{GPUFeatureName/"texture-compression-astc-sliced-3d"}} is enabled
         <td rowspan=28>{{GPUFeatureName/texture-compression-astc}}
     <tr>
         <td>{{GPUTextureFormat/astc-4x4-unorm-srgb}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17055,7 +17055,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td rowspan=2>16
         <td rowspan=28>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td rowspan=2>4 &times; 4
-        <td rowspan=14>If {{GPUFeatureName/"texture-compression-astc-sliced-3d"}} is enabled
+        <td rowspan=28>If {{GPUFeatureName/"texture-compression-astc-sliced-3d"}} is enabled
         <td rowspan=28>{{GPUFeatureName/texture-compression-astc}}
     <tr>
         <td>{{GPUTextureFormat/astc-4x4-unorm-srgb}}


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/issues/4701

This PR adds the astc-sliced-3d extension to allow 3D dimension for ASTC textures as sliced 3D, as previously agreed: https://github.com/gpuweb/gpuweb/issues/4701#issuecomment-2231761896

This extension requires base ASTC extension similar to the BC extension, so I tried to phrase it in a succinct way. Please let me know if that would benefit from any improvement.

Thank you!