### PR TITLE
Allow only strings in `featureLevel`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2429,7 +2429,7 @@ configuration is suitable for the application.
 
 <script type=idl>
 dictionary GPURequestAdapterOptions {
-    any featureLevel;
+    DOMString featureLevel;
     GPUPowerPreference powerPreference;
     boolean forceFallbackAdapter = false;
 };


### PR DESCRIPTION
The initial landing of GPURequestAdapterOptions.featureLevel allowed `any` because we don't know what the shape of future feature level requests will be.

Brandon pointed out that we don't need to use `any` to achieve this. Instead, we can add sibling members such that you request something like:
`{ featureLevel: 'foo', featureLevelFooOptions: { /* ... */ } }`

There was a similar change in WebXR's history; discussion on that seems to start roughly here:
https://github.com/immersive-web/webxr/issues/1205#issuecomment-868869651

(It is a DOMString rather than an enum so that we can return `null` meaning "cannot fulfill adapter request" rather than rejecting. This makes it consistent between older browsers, and newer browsers on older hardware.)

EDIT: This additionally makes representing the value in an implementation much simpler: since featureLevel will (presumably) only ever allow strings from some fixed set, it can be converted to an enum (e.g. C++ enum) internally.

Issue #4656. Milestone 1, because while it's technically possible for an application to exist which this PR changes from getting `null` to getting a rejection, we don't need to consider that a breaking change because `featureLevel` is currently useless. (It's almost exactly like adding a member to a dictionary, except that the dictionary member name isn't new.)