### PR TITLE
Add column `Extension` in `Built-in input and output values`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9182,7 +9182,7 @@ Each is described in detail in subsequent sections.
 <table class='data'>
   <caption>Built-in input and output values</caption>
   <thead>
-    <tr><th>Name<th>Stage<th>Direction<th>Type
+    <tr><th>Name<th>Stage<th>Direction<th>Type<th>[=Extension=]
   </thead>
 
   <tr><td>[=built-in values/vertex_index=]
@@ -9199,6 +9199,7 @@ Each is described in detail in subsequent sections.
       <td>vertex
       <td>output
       <td>array&lt;f32, N&gt; (`N` &le; `8`)
+      <td>[=extension/clip_distances=]
 
   <tr><td rowspan=2>[=built-in values/position=]
       <td>vertex

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9189,6 +9189,7 @@ Each is described in detail in subsequent sections.
       <td>vertex
       <td>input
       <td>u32
+      <td rowspan=2>
 
   <tr><td>[=built-in values/instance_index=]
       <td>vertex
@@ -9205,6 +9206,7 @@ Each is described in detail in subsequent sections.
       <td>vertex
       <td>output
       <td>vec4&lt;f32&gt;
+      <td rowspan=12>
 
   <tr>
       <td>fragment


### PR DESCRIPTION
This patch adds a new column `Extension` in the table `Built-in input and output values` and set the related WGSL extension for the optional built-in value `clip_distances`.