### PR TITLE
wgsl: Tweak wording of array constructor limit

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -920,7 +920,7 @@ shader that goes beyond the specified limits.
             This maps the WebGPU [=supported limits/maxComputeWorkgroupStorageSize=] limit
             into a standalone WGSL limit.
         <td>[=supported limits/maxComputeWorkgroupStorageSize|16384=]
-    <tr><td>Maximum number of elements in [=const-expression=] of [=array=] type<td>2047
+    <tr><td>Maximum number of elements in [[#value-constructor-builtin-function|value constructor]] expression of [=array=] type<td>2047
 </table>
 
 # Textual Structure # {#textual-structure}


### PR DESCRIPTION
The limit needs to cover all array constructors, not just those that are const expressions.