### PR TITLE
Address the remaining TODO in the WGSL spec for sample footprint

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -16188,8 +16188,8 @@ computing a four-component vector as follows:
         <tr><td>w<td>(*u*<sub>min</sub>,*v*<sub>min</sub>)
         </table>
 
-TODO: The four texels are the "sample footprint" that should be described by the WebGPU spec.
-https://github.com/gpuweb/gpuweb/issues/2343
+The four texels form the sampled area as described in the
+[[WebGPU#GPUSamplerDescriptor|WebGPU sampler descriptor]].
 
 <table class='data'>
   <thead>


### PR DESCRIPTION
There is a TODO in the WGSL spec which mentions issue https://github.com/gpuweb/gpuweb/issues/2343 which was fixed by https://github.com/gpuweb/gpuweb/pull/4683

I tried to use sampled area than sample footprint (which was removed in https://github.com/gpuweb/gpuweb/commit/6df6b39c0716699485748bf7dd2178bf54b37650 commit).

Please let me know if there's a way to change to make it better.

Thanks!