### PR TITLE
Add derivatives to accuracy table

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12519,6 +12519,25 @@ the rules in [[#floating-point-overflow]] apply.
      </div>
   <tr><td>`distance(x, y)`<td colspan=2 style="text-align:left;">Inherited from `length(x - y)`
   <tr><td>`dot(x, y)`<td colspan=2 style="text-align:left;">Inherited from sum of `x[i] * y[i]`
+  <tr><td>`dpdx(x)`<br>
+          `dpdxCoarse(x)`<br>
+          `dpdxFine(x)`<br>
+          `dpdy(x)`<br>
+          `dpdyCoarse(x)`<br>
+          `dpdyFine(x)`<br>
+          `fwidth(x)`<br>
+          `fwidthCoarse(x)`<br>
+          `fwidthFine(x)`<br>
+     <td colspan=2 style="text-align:left;">Infinite ULP.
+
+     <div class=note>
+     <span class=marker>Note:</span>WebGPU implementations should provide a pragmatically useful derivative functions.
+
+     Derivatives are implemented as differences (or difference of absolutes in the case of `fwidth`)
+     between values in different invocations on GPUs.
+
+     The lack of a finite error bound for derivatives in WGSL reflects the same lack in underlying implementations.
+     </div>
   <tr><td>`exp(x)`<td>`3 + 2 * |x|` ULP<td>`1 + 2 * |x|` ULP
   <tr><td>`exp2(x)`<td>`3 + 2 * |x|` ULP<td>`1 + 2 * |x|` ULP
   <tr><td class="nowrap">`faceForward(x, y, z)`<td colspan=2 style="text-align:left;">Inherited from `select(-x, x, dot(z, y) < 0.0)`


### PR DESCRIPTION
Fixes #4839

* Adds derivative functions to the accuracy table without error bounds
  * Allows flush to zero behaviour for denorms
  * Reflects underlying APIs' lack of requirements
* Bounds could be tightened in the future without a compatibility issue