### PR TITLE
wgsl: vertex position.w = 0 is a dynamic error

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9453,6 +9453,8 @@ Each is described in detail in subsequent sections.
       WebGPU [=normalized device coordinates=].
 
       See [[WebGPU#coordinate-systems]] and [[WebGPU#primitive-clipping]].
+
+      A [=dynamic error=] occurs if the *w* coordinate is zero.
 </table>
 
 <table class='data'>


### PR DESCRIPTION
Fixed: #4845