### PR TITLE
wgsl: clarify inherited-from accuracy applies after fp rules and shortcuts

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12423,10 +12423,18 @@ possibilities:
 * An expression that the accuracy is <dfn noexport>inherited from</dfn>.
     That is, the accuracy of the operation is defined as the accuracy of evaluating the given WGSL expression.
     The given expression is only one valid implementation of the function.
+
+    When evaluating the inherited-from expression, subexpression evaluations
+    are subject to other rules for floating-point evaluation, including those regarding
+    [=rounding=],
+    [=ieee754/overflow=],
+    [=reassociation=],
+    [[#reassociation-and-fusion|fusion]],
+    and [=flush to zero|flush-to-zero=].
+
     A WebGPU implementation may implement the operation differently, with better accuracy
     or with greater tolerance for extreme inputs.
-    Additionally, an implementation may treat [=intermediate result=] as subject to the rules for
-    floating-point evaluation (e.g. they may be [=rounding|rounded=] and/or [=flush to zero|flushed-to-zero=]).
+
 
 When the accuracy for an operation is specified over an input range,
 the accuracy is undefined for input values outside that range.


### PR DESCRIPTION


This is an editorial fix.