### PR TITLE
Loosen Alpha-to-coverage guarantees

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15890,8 +15890,9 @@ It guarantees that:
 
 - if |alpha| &le; 0.0, the result is 0x0
 - if |alpha| &ge; 1.0, the result is 0xFFFFFFFF
-- if |alpha| is greater than some other |alpha1|,
-    then the produced sample mask has at least as many bits set to 1 as the mask for |alpha1|
+- intermediate |alpha| values should result in a proportionate number of bits set to 1 in the mask.
+    Some platforms may not guarantee that the number of bits set to 1 in the mask monotonically
+    increases as alpha increases for a given pixel.
 
 <h4 id=per-sample-shading>Per-Sample Shading
 <span id=sample-frequency-shading></span>


### PR DESCRIPTION
Fixes #4867

I toyed with multiple ways to include the discussion of alpha coverage over a pixel area as discussed in #4867 but ultimately it felt too bogged down in minutia and implementation details. Given that D3D and Vulkan are both pretty loose in their specced behavior it felt appropriate to similarly loosen the language here to describe the intended behavior rather than the acceptable means by which to achieve it.

For the record [Vulkan's text on the subject](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#fragops-covg) is:

> No specific algorithm is specified for converting the alpha value to a temporary coverage mask. It is intended that the number of 1’s in this value be proportional to the alpha value (clamped to [0,1]), with all 1’s corresponding to a value of 1.0 and all 0’s corresponding to 0.0. The algorithm may be different at different framebuffer coordinates.