### PR TITLE
WGSL: Replace incorrect use of semicolon in struct declaration

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -18015,8 +18015,8 @@ fn atomicCompareExchangeWeak(
       v: T) -> __atomic_compare_exchange_result<T>
 
 struct __atomic_compare_exchange_result<T> {
-  old_value : T; // old value stored in the atomic
-  exchanged : bool; // true if the exchange was done
+  old_value : T,   // old value stored in the atomic
+  exchanged : bool // true if the exchange was done
 }
 ```
 


### PR DESCRIPTION
struct `__atomic_compare_exchange_result` had a `;` member separator instead of `,`.