### PR TITLE
Add "float32-blendable" feature

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2812,6 +2812,7 @@ enum GPUFeatureName {
     "rg11b10ufloat-renderable",
     "bgra8unorm-storage",
     "float32-filterable",
+    "float32-blendable",
     "clip-distances",
     "dual-source-blending",
 };
@@ -16330,6 +16331,12 @@ This feature adds no [=optional API surfaces=].
 Makes textures with formats {{GPUTextureFormat/"r32float"}}, {{GPUTextureFormat/"rg32float"}}, and
 {{GPUTextureFormat/"rgba32float"}} [=filterable=].
 
+<h3 id=float32-blendable data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"float32-blendable"`
+</h3>
+
+Makes textures with formats {{GPUTextureFormat/"r32float"}}, {{GPUTextureFormat/"rg32float"}}, and
+{{GPUTextureFormat/"rgba32float"}} [=blendable=].
+
 <h3 id=dom-gpufeaturename-clip-distances data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"clip-distances"`
 </h3>
 
@@ -16698,7 +16705,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
 
             - {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
@@ -16733,7 +16740,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
 
             - {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
@@ -16768,7 +16775,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
 
             - {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td><!-- Metal -->
         <td>
         <td>&checkmark;


### PR DESCRIPTION
Fixes #3556

Per https://github.com/gpuweb/gpuweb/issues/3556#issuecomment-2334477162 we may not actually need to separate the features for r32float/rg32float blending and rgba32float blending. The only platform that could need that is Metal. ~We need to confirm this is OK.~ Confirmed by Mike!

Motivation: per https://github.com/gpuweb/gpuweb/issues/3556#issuecomment-1763160894 this is a missing feature relative to WebGL (`EXT_float_blend`), and other comments there indicate that people want to use this functionality.
From Chrome's side, we'd like to add this feature because of [a bug in Chrome](https://crbug.com/364987733) that is currently allowing people to use float32 blending with just the `"float32-filterable"` feature, and it would be _nice_ if we provided this alternative before taking that away.