### PR TITLE
Add GPUCanvasContext getConfiguration() method

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14041,8 +14041,16 @@ interface GPUCanvasContext {
 
                 [=Content timeline=] steps:
 
-                1. Return |this|.{{GPUCanvasContext/[[configuration]]}}.
+                1. Let |configuration| be a copy of |this|.{{GPUCanvasContext/[[configuration]]}}.
+                1. Return |configuration|.
             </div>
+        </div>
+
+        <div class=note heading>
+            In scenarios where {{GPUCanvasContext/getConfiguration()}} shows that
+            {{GPUCanvasConfiguration/toneMapping}} is implemented and the `'dynamic-range'` media
+            query indicates HDR support, then WebGPU canvas should render content using the full
+            HDR range instead of clamping values to the SDR range of the HDR display.
         </div>
 
     : <dfn>getCurrentTexture()</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13887,6 +13887,7 @@ interface GPUCanvasContext {
     undefined configure(GPUCanvasConfiguration configuration);
     undefined unconfigure();
 
+    GPUCanvasConfiguration? getConfiguration();
     GPUTexture getCurrentTexture();
 };
 </script>
@@ -14025,6 +14026,22 @@ interface GPUCanvasContext {
                 1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to `null`.
                 1. Set |this|.{{GPUCanvasContext/[[textureDescriptor]]}} to `null`.
                 1. [$Replace the drawing buffer$] of |this|.
+            </div>
+        </div>
+
+    : <dfn>getConfiguration()</dfn>
+    ::
+        Returns the context configuration.
+
+        <div algorithm=GPUCanvasContext.getConfiguration>
+            <div data-timeline=content>
+                **Called on:** {{GPUCanvasContext}} |this|.
+
+                **Returns:** {{GPUCanvasConfiguration}} or `null`
+
+                [=Content timeline=] steps:
+
+                1. Return |this|.{{GPUCanvasContext/[[configuration]]}}.
             </div>
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14048,8 +14048,8 @@ interface GPUCanvasContext {
 
         <div class=note heading>
             In scenarios where {{GPUCanvasContext/getConfiguration()}} shows that
-            {{GPUCanvasConfiguration/toneMapping}} is implemented and the `'dynamic-range'` media
-            query indicates HDR support, then WebGPU canvas should render content using the full
+            {{GPUCanvasConfiguration/toneMapping}} is implemented and the `dynamic-range` media
+            query indicates HDR support, then WebGPU canvas **should** render content using the full
             HDR range instead of clamping values to the SDR range of the HDR display.
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14048,7 +14048,7 @@ interface GPUCanvasContext {
 
         <div class=note heading>
             In scenarios where {{GPUCanvasContext/getConfiguration()}} shows that
-            {{GPUCanvasConfiguration/toneMapping}} is implemented and the `dynamic-range` media
+            {{GPUCanvasConfiguration/toneMapping}} is implemented and the <l>'@media/dynamic-range'</l> media
             query indicates HDR support, then WebGPU canvas **should** render content using the full
             HDR range instead of clamping values to the SDR range of the HDR display.
         </div>


### PR DESCRIPTION
As discussed in https://github.com/gpuweb/gpuweb/issues/4828, this PR exposes a way for web apps to feature-detect whether WebGPU can do HDR canvas. It does so by exposing a new GPUCanvasContext `getConfiguration()` method that returns the context configuration which includes device, format, usage, viewFormats, colorSpace, toneMapping, and alphaMode members.


 