### PR TITLE
Remove the [[destroy started]] state, go straight to 'lost'

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1353,20 +1353,6 @@ implicitly [$valid to use with|unusable$].
         The [=Content timeline=] {{GPUDevice}} interface which this device is associated with.
 </dl>
 
-[=device=] has the following [=device timeline properties=]:
-
-<dl dfn-type=attribute dfn-for=device data-timeline=device>
-    : <dfn>[[destroy started]]</dfn>, of type `boolean`, initially `false`
-    ::
-        Becomes true when a {{GPUDevice/destroy()}} operation is started,
-        and remains true once it is finished.
-
-        Note:
-        Once destruction starts, ongoing operations can complete and send messages back to the
-        [=content timeline=], but no new operations can start which do so.
-        See also [[#errors-and-debugging]].
-</dl>
-
 <div algorithm data-timeline=device>
     To create <dfn dfn>a new device</dfn> from [=adapter=] |adapter|
     with {{GPUDeviceDescriptor}} |descriptor|, run the following [=device timeline=] steps:
@@ -1416,7 +1402,7 @@ no validation errors are raised, most promises resolve normally, etc.
 
     1. Complete any outstanding steps that are waiting until |device| <dfn dfn>becomes lost</dfn>.
 
-    Note: No errors are generated from a device which is lost or pending destruction.
+    Note: No errors are generated from a device which is lost.
     See [[#errors-and-debugging]].
 </div>
 
@@ -1425,7 +1411,6 @@ no validation errors are raised, most promises resolve normally, etc.
     |event| on [=device=] |device|, handled by |steps| on timeline |timeline|:
 
     - If or when the [=device timeline=] has been informed of the completion of |event|, or
-    - If |device|.{{device/[[destroy started]]}} is already `true`, or
     - If |device| is [$invalid|lost$] already, or when it [=becomes lost=]:
 
     Then issue |steps| on |timeline|.
@@ -2912,19 +2897,6 @@ to.
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.
             </div>
             <div data-timeline=device>
-                [=Device timeline=] steps:
-
-                1. Set |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} to `true`.
-                1. Once:
-                    - All <span data-timeline=queue>currently-enqueued operations on any queue on this device</span> have completed, and
-                    - Any [=device timeline=] steps that were listening for completion of
-                        queue operations have completed
-                        ([=asserting=] that no new listeners were added after {{device/[[destroy started]]}} was set):
-
-                    Then issue the subsequent steps on the
-                    <span data-timeline=device>current timeline</span>.
-            </div>
-            <div data-timeline=device>
                 1. [=Lose the device=](|this|.{{GPUObjectBase/[[device]]}},
                     {{GPUDeviceLostReason/"destroyed"}}).
             </div>
@@ -3614,16 +3586,6 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 1. Set |this|.{{GPUBuffer/[[internal state]]}} to "[=GPUBuffer/[[internal state]]/unavailable=]".
 
                     Note: Since the buffer is mapped, its contents cannot change between this step and {{GPUBuffer/unmap()}}.
-
-                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`:
-                    1. Return.
-
-                    Note:
-                    The map promise will already have been aborted, because
-                    {{GPUDevice/destroy()|GPUDevice.destroy()}}
-                    aborts it, so there is no need to do so here.
-                    <!-- POSTV1(multithreading): this will no longer be true; instead,
-                    issue the map failure steps before returning -->
 
                 1. When either of the following events occur (whichever comes first),
                     or if either has already occurred:
@@ -7869,9 +7831,7 @@ dictionary GPUComputePipelineDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. If |pipeline| is [$valid$],
-                    |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`,
-                    or |this| is [$invalid|lost$]:
+                1. If |pipeline| is [$valid$] or |this| is [$invalid|lost$]:
 
                     1. Issue the following steps on |contentTimeline|:
 
@@ -7883,7 +7843,7 @@ dictionary GPUComputePipelineDescriptor
 
                     1. Return.
 
-                    Note: No errors are generated from a device which is lost or pending destruction.
+                    Note: No errors are generated from a device which is lost.
                     See [[#errors-and-debugging]].
 
                 1. If |pipeline| is [$invalid$] and |error| is an [$internal error$],
@@ -8147,9 +8107,7 @@ dictionary GPURenderPipelineDescriptor
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
-                1. If |pipeline| is [$valid$],
-                    |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`,
-                    or |this| is [$invalid|lost$]:
+                1. If |pipeline| is [$valid$] or |this| is [$invalid|lost$]:
 
                     1. Issue the following steps on |contentTimeline|:
 
@@ -8161,7 +8119,7 @@ dictionary GPURenderPipelineDescriptor
 
                     1. Return.
 
-                    Note: No errors are generated from a device which is lost or pending destruction.
+                    Note: No errors are generated from a device which is lost.
                     See [[#errors-and-debugging]].
 
                 1. If |pipeline| is [$invalid$] and |error| is an [$internal error$],
@@ -14564,8 +14522,7 @@ is being composited into (e.g. an HTML page rendering, or a 2D canvas).
 
 During the normal course of operation of WebGPU, errors are raised via [$dispatch error$].
 
-After a device is {{device/[[destroy started]]}} or [=lose the device|lost=],
-errors are no longer surfaced, where possible.
+After a device is [=lose the device|lost=], errors are no longer surfaced, where possible.
 After this point, implementations do not need to run validation or error tracking:
 
 - The validity of objects on the device becomes unobservable.
@@ -14626,7 +14583,7 @@ and the {{GPUDevice/uncapturederror}} event.
 Errors must only be generated for operations that explicitly state the conditions one may
 be generated under in their respective algorithms, and the subtype of error that is generated.
 
-No errors are generated from a device which is lost or pending destruction.
+No errors are generated from a device which is lost.
 See [[#errors-and-debugging]].
 
 Note: {{GPUError}} may gain new subtypes in future versions of this spec. Applications should handle
@@ -14815,10 +14772,9 @@ partial interface GPUDevice {
     <div data-timeline=device>
         [=Device timeline=] steps:
 
-        Note: No errors are generated from a device which is lost or pending destruction.
+        Note: No errors are generated from a device which is lost.
         If this algorithm is called while
-        |device|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} is `true`
-        or |device| is [$invalid|lost$], it will not be observable to the application.
+        |device| is [$invalid|lost$], it will not be observable to the application.
         See [[#errors-and-debugging]].
 
         1. Let |scope| be the [$current error scope$] for |error| and |device|.
@@ -14902,8 +14858,7 @@ partial interface GPUDevice {
             <div data-timeline=device>
                 [=Device timeline=] |check steps|:
 
-                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[destroy started]]}} or
-                    |this| is [$invalid|lost$]:
+                1. If |this| is [$invalid|lost$]:
 
                     1. Issue the following steps on
                         <var data-timeline=content>contentTimeline</var>:
@@ -14916,7 +14871,7 @@ partial interface GPUDevice {
 
                     1. Return.
 
-                    Note: No errors are generated from a device which is lost or pending destruction.
+                    Note: No errors are generated from a device which is lost.
                     See [[#errors-and-debugging]].
                 1. If any of the following requirements are unmet:
 


### PR DESCRIPTION
~**Draft, depends on #4902**~

Non-functional change - just a simplification of the spec.

This state is no longer necessary because canvas outputs will revert or disappear on all types of device loss, so it doesn't matter if device.destroy() completes outstanding work before losing the device - it's unobservable.

Reverts most of what was in #4788.

Issue: 4859