### PR TITLE
Update toneMapping mode in configure

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13996,6 +13996,13 @@ interface GPUCanvasContext {
                 1. Let |descriptor| be the
                     [$GPUTextureDescriptor for the canvas and configuration$](|this|.{{GPUCanvasContext/canvas}}, |configuration|).
                 1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.
+                1. Set |this|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/toneMapping}}.{{GPUCanvasToneMapping/mode}}
+                    to {{GPUCanvasToneMappingMode/"standard"}} if either of the following conditions is true:
+                    - If |configuration|.{{GPUCanvasConfiguration/toneMapping}} is not provided.
+                    - If |configuration|.{{GPUCanvasConfiguration/toneMapping}}.{{GPUCanvasToneMapping/mode}}
+                        is {{GPUCanvasToneMappingMode/"extended"}} and the user agent does not
+                        support displaying color values in the extended dynamic range of the screen
+                        in a canvas.
                 1. Set |this|.{{GPUCanvasContext/[[textureDescriptor]]}} to |descriptor|.
                 1. [$Replace the drawing buffer$] of |this|.
                 1. Issue the subsequent steps on the [=Device timeline=] of |device|.


### PR DESCRIPTION
This PR addresses https://github.com/gpuweb/gpuweb/issues/4828#issuecomment-2387328301 by explicitly setting `toneMapping` `mode` to `"standard"` in the `configure()` section under certain circumstances.