### PR TITLE
Check for supported context formats in `configure()` on content timeline

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13992,7 +13992,9 @@ interface GPUCanvasContext {
                 1. [=?=] [$Validate texture format required features$] of
                     |configuration|.{{GPUCanvasConfiguration/format}} with |device|.{{GPUObjectBase/[[device]]}}.
                 1. [=?=] [$Validate texture format required features$] of each element of
-                    |configuration|.{{GPUTextureDescriptor/viewFormats}} with |device|.{{GPUObjectBase/[[device]]}}.
+                    |configuration|.{{GPUCanvasConfiguration/viewFormats}} with |device|.{{GPUObjectBase/[[device]]}}.
+                1. If [=Supported context formats=] does not [=set/contain=]
+                            |configuration|.{{GPUCanvasConfiguration/format}} throw an {{TypeError}}.
                 1. Let |descriptor| be the
                     [$GPUTextureDescriptor for the canvas and configuration$](|this|.{{GPUCanvasContext/canvas}}, |configuration|).
                 1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.
@@ -14008,8 +14010,6 @@ interface GPUCanvasContext {
                     <div class=validusage>
                         - [$validating GPUTextureDescriptor$](|device|, |descriptor|)
                             must return true.
-                        - [=Supported context formats=] must [=set/contain=]
-                            |configuration|.{{GPUCanvasConfiguration/format}}.
                     </div>
 
                     Note: This early validation remains valid until the next

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13994,7 +13994,7 @@ interface GPUCanvasContext {
                 1. [=?=] [$Validate texture format required features$] of each element of
                     |configuration|.{{GPUCanvasConfiguration/viewFormats}} with |device|.{{GPUObjectBase/[[device]]}}.
                 1. If [=Supported context formats=] does not [=set/contain=]
-                            |configuration|.{{GPUCanvasConfiguration/format}} throw an {{TypeError}}.
+                            |configuration|.{{GPUCanvasConfiguration/format}}, throw a {{TypeError}}.
                 1. Let |descriptor| be the
                     [$GPUTextureDescriptor for the canvas and configuration$](|this|.{{GPUCanvasContext/canvas}}, |configuration|).
                 1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.


### PR DESCRIPTION
Currently if you configure with invalid format (valid per device but not one of supported context formats), canvas still gets configured and validation error is raised. Because context is configured, `getCurrentTexture` returns valid texture, but given that it hasn't got supported context formats it's not defined how to present it.

Instead of adding additional check to `getCurrentTexture`  (https://github.com/gpuweb/gpuweb/pull/4907), we can move check for [`supported context formats`](https://www.w3.org/TR/webgpu/#supported-context-formats) in content timeline, so that context does not get configured (hence no problem in `getCurrentTexture`).

This fixes https://github.com/gpuweb/gpuweb/issues/4906