### PR TITLE
Compatibility Mode: add vertex storage buffer and texture limits 

### DIFF
--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -197,15 +197,15 @@ generate a validation error.
 other APIs only support the first vertex so only `@interpolation(flat, either)` is supported in
 compatibility mode.
 
-## 18. Introduce new `maxVertexStageStorageBuffers` and `maxVertexStageStorageTextures` limits.
+## 18. Introduce new `maxStorageBuffersInVertexStage` and `maxStorageTexturesInVertexStage` limits.
 
-If the number of shader variables of type `storage_buffer` in a vertex shader exceeds the `maxVertexStageStorageBuffers` limit, a validation error will occur at pipeline creation time.
+If the number of shader variables of type `storage_buffer` in a vertex shader exceeds the `maxStorageBuffersInVertexStage` limit, a validation error will occur at pipeline creation time.
 
-If the number of shader variables of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` in a vertex shader exceeds the `maxVertexStageStorageTextures` limit, a validation error will occur at pipeline creation time.
+If the number of shader variables of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` in a vertex shader exceeds the `maxStorageTexturesInVertexStage` limit, a validation error will occur at pipeline creation time.
 
-In Compatibility mode, these new limits will have a default of zero. In Core mode, they will default to the same values as the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage`, respectively.
+In Compatibility mode, these new limits will have a default of zero. In Core mode, they will default to the maximum value of a GPUSize32.
 
-In Compatibility mode, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limit will apply to the Compute stage only.
+In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limits continue to apply to all stages. E.g., the effective storage buffer limit in the vertex stage is `min(maxStorageBuffersPerShaderStage, maxStorageBuffersInVertexStage)`.
 
 **Justification**: OpenGL ES 3.1 allows `MAX_VERTEX_SHADER_STORAGE_BLOCKS` and `MAX_VERTEX_IMAGE_UNIFORMS` to be zero, and there are a significant number of devices in the field with that value.
 

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -197,6 +197,18 @@ generate a validation error.
 other APIs only support the first vertex so only `@interpolation(flat, either)` is supported in
 compatibility mode.
 
+## 18. Introduce new `maxVertexStageStorageBuffers` and `maxVertexStageStorageTextures` limits.
+
+If the number of shader variables of type `storage_buffer` in a vertex shader exceeds the `maxVertexStageStorageBuffers` limit, a validation error will occur at pipeline creation time.
+
+If the number of shader variables of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` in a vertex shader exceeds the `maxVertexStageStorageTextures` limit, a validation error will occur at pipeline creation time.
+
+In Compatibility mode, these new limits will have a default of zero. In Core mode, they will default to the same values as the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage`, respectively.
+
+In Compatibility mode, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limit will apply to the Compute stage only.
+
+**Justification**: OpenGL ES 3.1 allows `MAX_VERTEX_SHADER_STORAGE_BLOCKS` and `MAX_VERTEX_IMAGE_UNIFORMS` to be zero, and there are a significant number of devices in the field with that value.
+
 ## Issues
 
 Q: OpenGL ES does not have "coarse" and "fine" variants of the derivative instructions (`dFdx()`, `dFdy()`, `fwidth()`). Should WGSL's "fine" derivatives (`dpdxFine()`, `dpdyFine()`, and `fwidthFine()`) be required to deliver high precision results? See [Issue 4325](https://github.com/gpuweb/gpuweb/issues/4325).


### PR DESCRIPTION
Compatibility proposal: add separate limits for the minimum number of storage buffers and storage textures in the vertex stage.

Allow them to be zero, to accommodate OpenGL devices in the field with such a limit.

Issue: https://github.com/gpuweb/gpuweb/issues/4721