### PR TITLE
avoid excessive rebuild and install of treesitter WGSL grammar

### DIFF
--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -27,18 +27,21 @@ img/%.mmd.svg: diagrams/%.mmd ../tools/invoke-mermaid.sh ../tools/mermaid.json
 	bash ../tools/invoke-mermaid.sh -i $< -o $@
 
 TREESITTER_GRAMMAR_INPUT := grammar/grammar.js
-TREESITTER_PARSER := grammar/src/scanner.o
+
+# A file used to signal the WGSL parser was successfully installed.
+TREESITTER_PARSER_STAMP := grammar/build.stamp
+
 # Extract WGSL grammar from the spec
 $(TREESITTER_GRAMMAR_INPUT): index.bs ./grammar/src/scanner.c ./tools/extract-grammar.py
 	source ../tools/custom-action/dependency-versions.sh && python3 ./tools/extract-grammar.py --spec index.bs --scanner ./grammar/src/scanner.c --tree-sitter-dir grammar --flow x
 
 # Build a Treesitter parser to validate grammar extract and later examples in spec
-$(TREESITTER_PARSER): $(TREESITTER_GRAMMAR_INPUT)
+$(TREESITTER_PARSER_STAMP): $(TREESITTER_GRAMMAR_INPUT)
 	source ../tools/custom-action/dependency-versions.sh && python3 ./tools/extract-grammar.py --spec index.bs --scanner ./grammar/src/scanner.c --tree-sitter-dir grammar --flow b
 
 .PHONY: validate-examples
 # Use Treesitter to parse many code examples in the spec.
-validate-examples: $(TREESITTER_PARSER)
+validate-examples: $(TREESITTER_PARSER_STAMP)
 	source ../tools/custom-action/dependency-versions.sh && python3 ./tools/extract-grammar.py --flow e
 
 .PHONY: tspath_tests
@@ -47,12 +50,12 @@ tspath_tests: ./tools/TSPath.py
 
 .PHONY: unit_tests
 # Use Treesitter to parse code samples
-unit_tests: $(TREESITTER_PARSER) ./tools/wgsl_unit_tests.py
-	python3 ./tools/wgsl_unit_tests.py --parser $(TREESITTER_PARSER)
+unit_tests: $(TREESITTER_PARSER_STAMP) ./tools/wgsl_unit_tests.py
+	python3 ./tools/wgsl_unit_tests.py
 
 # The grammar in JSON form, emitted by Treesitter.
 WGSL_GRAMMAR=grammar/src/grammar.json
-$(WGSL_GRAMMAR) : $(TREESITTER_PARSER)
+$(WGSL_GRAMMAR) : $(TREESITTER_PARSER_STAMP)
 
 .PHONY: nfkc
 nfkc:

--- a/wgsl/tools/extract-grammar.py
+++ b/wgsl/tools/extract-grammar.py
@@ -1150,12 +1150,9 @@ def flow_build(options):
     scanner_cc_staging = os.path.join(options.grammar_dir, "src", "scanner.c")
 
 
-    if os.path.exists("grammar/src/tree_sitter/parser.h"):
-        print("{}: skipping tree-sitter generate: grammar/src/tree_sitter/parser.h already exists".format(options.script))
-    else:
-        cmd = ["npx", "tree-sitter-cli@" + value_from_dotenv("NPM_TREE_SITTER_CLI_VERSION"), "generate"]
-        print("{}: {}".format(options.script, " ".join(cmd)))
-        subprocess.run(cmd, cwd=options.grammar_dir, check=True)
+    cmd = ["npx", "tree-sitter-cli@" + value_from_dotenv("NPM_TREE_SITTER_CLI_VERSION"), "generate"]
+    print("{}: {}".format(options.script, " ".join(cmd)))
+    subprocess.run(cmd, cwd=options.grammar_dir, check=True)
 
     # Use "npm install" to create the tree-sitter CLI that has WGSL
     # support.  But "npm install" fetches data over the network.

--- a/wgsl/tools/extract-grammar.py
+++ b/wgsl/tools/extract-grammar.py
@@ -1139,12 +1139,16 @@ def flow_build(options):
         print("missing grammar file: {}")
         return False
 
+    # The 'build.stamp' file is touched when the parser is successfully installed.
+    stampfile = os.path.join(options.grammar_dir, 'build.stamp')
+
     # External scanner for nested block comments
     # For the API, see https://tree-sitter.github.io/tree-sitter/creating-parsers#external-scanners
     # See: https://github.com/tree-sitter/tree-sitter-rust/blob/master/src/scanner.c
 
     os.makedirs(os.path.join(options.grammar_dir, "src"), exist_ok=True)
     scanner_cc_staging = os.path.join(options.grammar_dir, "src", "scanner.c")
+
 
     if os.path.exists("grammar/src/tree_sitter/parser.h"):
         print("{}: skipping tree-sitter generate: grammar/src/tree_sitter/parser.h already exists".format(options.script))
@@ -1170,7 +1174,7 @@ def flow_build(options):
     # subprocess.run(["npx", "tree-sitter-cli@" + value_from_dotenv("NPM_TREE_SITTER_CLI_VERSION"), "build-wasm", "--docker"],
     #                cwd=options.grammar_dir, check=True)
 
-    def build_library(output_path, input_files):
+    def build_library(input_files):
         """
         Build and install the tree-sitter language package
         """
@@ -1188,6 +1192,9 @@ def flow_build(options):
                 text=True,
                 cwd=options.grammar_dir
             )
+
+            with open(stampfile, 'w') as f:
+                print("created file:  {}".format(stampfile))
             print("Tree-sitter language package installed successfully.")
         except subprocess.CalledProcessError as e:
             print(f"Error installing tree-sitter language package: {e}")
@@ -1195,11 +1202,11 @@ def flow_build(options):
             print(f"stderr: {e.stderr}")
             return False
 
-    if newer_than(scanner_cc_staging, options.wgsl_shared_lib) or newer_than(options.grammar_filename,options.wgsl_shared_lib):
-        print("{}: ...Building custom scanner: {}".format(options.script,options.wgsl_shared_lib))
-        build_library(options.wgsl_shared_lib,
-                      [scanner_cc_staging,
-                       os.path.join(options.grammar_dir,"src","parser.c")])
+    if newer_than(scanner_cc_staging, stampfile) or newer_than(options.grammar_filename,stampfile):
+        print("{}: ...Building custom scanner".format(options.script))
+        build_library([scanner_cc_staging, os.path.join(options.grammar_dir,"src","parser.c")])
+    else:
+        print("{}: ...Skip building tree_sitter_wgsl: grammar/build.stamp is fresh".format(options.script))
     return True
 
 def flow_examples(options,scan_result):
@@ -1342,7 +1349,7 @@ def main():
             return 1
     if 't' in args.flow:
         import wgsl_unit_tests
-        test_options = wgsl_unit_tests.Options(options.wgsl_shared_lib)
+        test_options = wgsl_unit_tests.Options()
         if not wgsl_unit_tests.run_tests(test_options):
             return 1
     return 0

--- a/wgsl/tools/wgsl_unit_tests.py
+++ b/wgsl/tools/wgsl_unit_tests.py
@@ -92,8 +92,7 @@ def GetCases():
     return cases
 
 class Options:
-    def __init__(self,shared_lib):
-        self.shared_lib = shared_lib
+    def __init__(self):
         self.verbose = False
 
 def run_tests(options):
@@ -131,12 +130,9 @@ def main():
     argparser.add_argument("--verbose","-v",
                            action='store_true',
                            help="be verbose")
-    argparser.add_argument("--parser",
-                           help="path the shared library for the WGSL tree-sitter parser",
-                           default="grammar/build/wgsl.so")
 
     args = argparser.parse_args()
-    options = Options(args.parser)
+    options = Options()
     options.verbose = args.verbose
 
     if not run_tests(options):


### PR DESCRIPTION
This is a followup to #4928

Use a grammar/build.stamp to signal successful install of the package.  Then use that to only rebuild when necessary.


    Avoid excessive rebuild and install of treesitter WGSL grammar
    
    Use a grammar/build.stamp file to mark successful install of the
    package
    
    Update scripts to avoid references to the .so file, since now
    we rely on installing the treesitter parser into the Python
    environment.

