### PR TITLE
Similarity of variable and value declarations is a non-normative note

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4617,7 +4617,13 @@ declaration until the end of the brace-delimited list of statements immediately
 enclosing the declaration.
 A function-scope declaration is a [=dynamic context=].
 
-Variable and value declarations have a similar overall syntax:
+<div class=note heading>
+Variable and value declarations have a similar overall syntax. The following non-normative
+illustration shows the general form of variable and value declarations, where `[...]` denotes
+optional parts, `...*` denotes zero or more repetitions of the preceding, and `...+` denotes one or
+more repetitions of the preceding. For specific syntactic rules, see the respective sections for
+the elements.
+
 <xmp highlight=wgsl>
   // Specific value declarations.
                const    name [: type]  = initializer ;
@@ -4639,6 +4645,7 @@ Variable and value declarations have a similar overall syntax:
   [attribute]+ var             name : sampler_type;
   [attribute]+ var<storage[, access_mode]> name : type;
 </xmp>
+</div>
 
 Each such declaration [=shader-creation error|must=] have an explicitly
 specified type or an initializer.


### PR DESCRIPTION
This PR moves the example that uses an unintroduced syntax into a note with a small explanation of the syntax. Although I am still a bit not very clear on the importance of having this illustration just to demonstrate it is similar or whether adding concrete examples is not sufficient to make the point, it should at least be explicitly noted as non-normative, which this PR does.

PTAL, TYVM!