### PR TITLE
wgsl: Remove [INF] macro and its uses

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -19,7 +19,6 @@ Text Macro: ALLINTEGRALDECL S is AbstractInt, i32, or u32<br>T is S or vecN&lt;S
 Text Macro: ALLFLOATINGDECL S is AbstractFloat, f32, or f16<br>T is S or vecN&lt;S&gt;
 Text Macro: ALLNUMERICDECL S is AbstractInt, AbstractFloat, i32, u32, f32, or f16<br>T is S, or vecN&lt;S&gt;
 Text Macro: ALLSIGNEDNUMERICDECL S is AbstractInt, AbstractFloat, i32, f32, or f16<br>T is S, or vecN&lt;S&gt;
-Text Macro: INF &infin;
 Text Macro: PINF &plus;&infin;
 Text Macro: NINF &minus;&infin;
 Ignored Vars: i, c0, e, e1, e2, e3, edge, eN, p, s1, s2, sn, AS, AM, N, newbits, M, C, R, v, Stride, Offset, Align, Extent, T, T1, E, S, F, x, y, a, b
@@ -500,7 +499,7 @@ sense. Specifically:
 Then the area |a| is a hyperbolic angle such that |x| is the hyperbolic cosine of |a|, and
 |y| is the hyperbolic sine of |a|.
 
-<dfn noexport>Positive infinity</dfn>, denoted by &infin; or [PINF], is a unique value strictly greater than all real numbers.
+<dfn noexport>Positive infinity</dfn>, denoted by [PINF], is a unique value strictly greater than all real numbers.
 
 <dfn noexport>Negative infinity</dfn>, denoted by [NINF], is a unique value strictly lower than all real numbers.
 
@@ -12324,7 +12323,7 @@ IEEE-754 defines five kinds of <dfn dfn-for="ieee754">exceptions</dfn>:
 * <dfn dfn-for="ieee754">Invalid operation</dfn>.
     This occurs when an operation is evaluated on [=extended real=] inputs outside its [=domain=].
     Such operations yield a NaN.
-    Examples of invalid operations are 0 &times; [INF], and `sqrt`(&minus;1).
+    Examples of invalid operations are 0 &times; [PINF], and `sqrt`(&minus;1).
 * <dfn dfn-for="ieee754">Division by zero</dfn>.
     This occurs when an operation on finite operands is defined as having an exact infinite result.
     Examples are 1 &divide; 0, and log(0).
@@ -14135,7 +14134,7 @@ fn num_point_lights() -> u32 {
   <tr>
     <td>Description
     <td>Returns the inverse hyperbolic cosine (cosh<sup>-1</sup>) of `x`, as a [=hyperbolic angle=].<br>
-    That is, approximates `a` with 0 &le; a &le; [INF], such that `cosh`(`a`) = `x`.
+    That is, approximates `a` with 0 &le; a &le; [PINF], such that `cosh`(`a`) = `x`.
 
     [=Component-wise=] when `T` is a vector.
   <tr>


### PR DESCRIPTION
The IEEE spec uses &infin; by itself to indicate either positive or negative infinity.  The WGSL spec was using it to mean positive infinity; replace those uses by [PINF].