### PR TITLE
Add xrCompatible adapter flag

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2535,6 +2535,11 @@ enum GPUPowerPreference {
         When set to `true` indicates that the best [=adapter=] for rendering to a [=WebXR session=]
         must be returned. If the user agent or system does not support [=WebXR sessions=] then
         adapter selection may ignore this value.
+
+        Note:
+        If {{GPURequestAdapterOptions/xrCompatible}} is not set to `true` when the adapter is
+        requested, {{GPUDevice}}s created from the adapter cannot be used to render for
+        [=WebXR sessions=].
 </dl>
 
 <div class=example>
@@ -2563,7 +2568,6 @@ interface GPUAdapter {
     [SameObject] readonly attribute GPUSupportedLimits limits;
     [SameObject] readonly attribute GPUAdapterInfo info;
     readonly attribute boolean isFallbackAdapter;
-    readonly attribute boolean isXrCompatible;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
@@ -2603,10 +2607,6 @@ interface GPUAdapter {
     : <dfn>isFallbackAdapter</dfn>
     ::
         Returns the value of {{GPUAdapter/[[adapter]]}}.{{adapter/[[fallback]]}}.
-
-    : <dfn>isXrCompatible</dfn>
-    ::
-        Returns the value of {{GPUAdapter/[[adapter]]}}.{{adapter/[[xrCompatible]]}}.
 
     : <dfn>\[[adapter]]</dfn>, of type [=adapter=], readonly
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -145,6 +145,9 @@ spec: Internationalization Glossary; urlPrefix: https://www.w3.org/TR/i18n-gloss
 spec: Strings on the Web; urlPrefix: https://w3c.github.io/string-meta/#
     type: dfn
         text: best practices for language and direction information; url: bp_and-reco
+spec: WebXR; urlPrefix: https://www.w3.org/TR/webxr/
+    type: dfn
+        text: WebXR session; url: #session
 </pre>
 
 <pre class=biblio>
@@ -1287,6 +1290,11 @@ improved privacy. It is not required that a [=fallback adapter=] is available on
     : <dfn>\[[fallback]]</dfn>, of type {{boolean}}, readonly
     ::
         If set to `true` indicates that the adapter is a [=fallback adapter=].
+
+    : <dfn>\[[xrCompatible]]</dfn>, of type boolean
+    ::
+        If set to `true` indicates that the adapter was requested with compatibility with
+        [=WebXR sessions=].
 </dl>
 
 [=adapter=] has the following [=device timeline properties=]:
@@ -2291,6 +2299,8 @@ interface GPU {
                         defined in [[#limits]].
                     1. If |adapter| meets the criteria of a [=fallback adapter=] set
                         |adapter|.{{adapter/[[fallback]]}} to `true`.
+                    1. Set |adapter|.{{adapter/[[xrCompatible]]}} to
+                        |options|.{{GPURequestAdapterOptions/xrCompatible}}.
 
                     Otherwise:
 
@@ -2424,6 +2434,7 @@ dictionary GPURequestAdapterOptions {
     DOMString featureLevel = "core";
     GPUPowerPreference powerPreference;
     boolean forceFallbackAdapter = false;
+    boolean xrCompatible = false;
 };
 </script>
 
@@ -2518,6 +2529,12 @@ enum GPUPowerPreference {
         [=fallback adapter=]. Developers that wish to prevent their applications from running on
         [=fallback adapters=] should check the {{GPUAdapter}}.{{GPUAdapter/isFallbackAdapter}}
         attribute prior to requesting a {{GPUDevice}}.
+
+    : <dfn>xrCompatible</dfn>
+    ::
+        When set to `true` indicates that the best [=adapter=] for rendering to a [=WebXR session=]
+        must be returned. If the user agent or system does not support [=WebXR sessions=] then
+        adapter selection may ignore this value.
 </dl>
 
 <div class=example>
@@ -2546,6 +2563,7 @@ interface GPUAdapter {
     [SameObject] readonly attribute GPUSupportedLimits limits;
     [SameObject] readonly attribute GPUAdapterInfo info;
     readonly attribute boolean isFallbackAdapter;
+    readonly attribute boolean isXrCompatible;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
@@ -2585,6 +2603,10 @@ interface GPUAdapter {
     : <dfn>isFallbackAdapter</dfn>
     ::
         Returns the value of {{GPUAdapter/[[adapter]]}}.{{adapter/[[fallback]]}}.
+
+    : <dfn>isXrCompatible</dfn>
+    ::
+        Returns the value of {{GPUAdapter/[[adapter]]}}.{{adapter/[[xrCompatible]]}}.
 
     : <dfn>\[[adapter]]</dfn>, of type [=adapter=], readonly
     ::


### PR DESCRIPTION
As discussed at the Oct. F2F, this adds the flags to indicate WebXR compatibility of an adapter. This should be the only WebGPU spec change required for WebXR support, with all other necessary changes happening within the Immersive Web working group.