### PR TITLE
Clarify: texture+sampling validation applies to pairs used together in a builtin

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -72,6 +72,7 @@ spec: WEBGL-1; urlPrefix: https://www.khronos.org/registry/webgl/specs/latest/1.
         text: WebGL Drawing Buffer; url: THE_DRAWING_BUFFER
 spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
     type: dfn
+        text: functions in the shader stage; url: functions-in-a-shader-stage
         text: f16; url: f16
         text: location; url: input-output-locations
         text: blend_src; url: input-output-locations
@@ -7507,7 +7508,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     1. |entryPoint| |must| not be `null`.
     1. For each |binding| that is [=statically used=] by |entryPoint|:
         - [$validating shader binding$](|binding|, |layout|) |must| return `true`.
-    1. For each texture and sampler [=statically used=] together by |entryPoint| in texture sampling calls:
+    1. For each texture and sampler used together in a texture builtin function call in any of the
+        [=functions in the shader stage=] rooted at |entryPoint|:
         1. Let |texture| be the {{GPUBindGroupLayoutEntry}} corresponding to the sampled texture in the call.
         1. Let |sampler| be the {{GPUBindGroupLayoutEntry}} corresponding to the used sampler in the call.
         1. If |sampler|.{{GPUSamplerBindingLayout/type}} is {{GPUSamplerBindingType/"filtering"}},


### PR DESCRIPTION


Fixed: #4944