### PR TITLE
Remove superfluous exposed on GPUDevice onuncapturederror

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15040,7 +15040,6 @@ dictionary GPUUncapturedErrorEventInit : EventInit {
 
 <script type=idl>
 partial interface GPUDevice {
-    [Exposed=(Window, Worker)]
     attribute EventHandler onuncapturederror;
 };
 </script>


### PR DESCRIPTION
This simple PR removes `[Exposed=(Window, Worker)]` for GPUDevice `onuncapturederror` as it's already the case for GPUDevice. This is similar to the following:

```webidl
partial interface GPUDevice {
    readonly attribute Promise<GPUDeviceLostInfo> lost;
};
```