### PR TITLE
Fix default pipeline layout determination of sampling type for f32 textures

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7284,7 +7284,7 @@ run the following [=device timeline=] steps:
                     Else if the sampled type of |resource| is:
 
                     <dl class=switch>
-                        : `f32` and there exists a [=static use=] of |resource| by |stageDesc| with a `textureSample*` builtin
+                        : `f32` and there exists a [=static use=] of |resource| by |stageDesc| in a texture builtin function call that also uses a sampler
                         :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"float"}}
                         : `f32` otherwise
                         :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"unfilterable-float"}}


### PR DESCRIPTION


Instead of the condition being:
 - used in a textureSample* call. the condition should be:
 - used in a texture builtin call that also uses a sampler

Because the latter is textureSample* but also adds textureGather* calls.

Issue: #4944