### PR TITLE
Clarify that filtering sampler_comparison is allowed with depth texture

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -134,6 +134,9 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
             text: f16; url: extension-f16
             text: clip_distances; url: extension-clip_distances
             text: dual_source_blending; url: extension-dual_source_blending
+        for: type
+            text: sampled texture; url: type-sampled-texture
+            text: depth texture; url: type-depth-texture
     type: abstract-op
         text: SizeOf; url: sizeof
 spec: Internationalization Glossary; urlPrefix: https://www.w3.org/TR/i18n-glossary/#
@@ -7513,10 +7516,11 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     1. |entryPoint| |must| not be `null`.
     1. For each |binding| that is [=statically used=] by |entryPoint|:
         - [$validating shader binding$](|binding|, |layout|) |must| return `true`.
-    1. For each texture and sampler used together in a texture builtin function call in any of the
-        [=functions in the shader stage=] rooted at |entryPoint|:
-        1. Let |texture| be the {{GPUBindGroupLayoutEntry}} corresponding to the sampled texture in the call.
-        1. Let |sampler| be the {{GPUBindGroupLayoutEntry}} corresponding to the used sampler in the call.
+    1. For each texture builtin function call in any of the [=functions in the shader stage=] rooted at |entryPoint|,
+        if it uses a |textureBinding| of [=type/sampled texture=] or [=type/depth texture=] type
+        together with a |samplerBinding| of `sampler` type (excluding `sampler_comparison`):
+        1. Let |texture| be the {{GPUBindGroupLayoutEntry}} corresponding to |textureBinding|.
+        1. Let |sampler| be the {{GPUBindGroupLayoutEntry}} corresponding to |samplerBinding|.
         1. If |sampler|.{{GPUSamplerBindingLayout/type}} is {{GPUSamplerBindingType/"filtering"}},
             then |texture|.{{GPUTextureBindingLayout/sampleType}} |must| be
             {{GPUTextureSampleType/"float"}}.


### PR DESCRIPTION
Issue: #4944, https://github.com/gpuweb/gpuweb/pull/4945#issuecomment-2452284224