### PR TITLE
[M0 backport] Allow `featureLevel: "compatibility"`, which does nothing (#4897)

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2290,7 +2290,8 @@ interface GPU {
                 1. All of the requirements in the following steps |must| be met.
 
                     <div class=validusage>
-                        1. |options|.{{GPURequestAdapterOptions/featureLevel}} |must| be `undefined`.
+                        1. |options|.{{GPURequestAdapterOptions/featureLevel}} |must| be
+                            a [=feature level string=].
                     </div>
 
                     If they are met **and** the user agent chooses to return an adapter:
@@ -2433,7 +2434,7 @@ configuration is suitable for the application.
 
 <script type=idl>
 dictionary GPURequestAdapterOptions {
-    DOMString featureLevel;
+    DOMString featureLevel = "core";
     GPUPowerPreference powerPreference;
     boolean forceFallbackAdapter = false;
 };
@@ -2449,6 +2450,23 @@ enum GPUPowerPreference {
 {{GPURequestAdapterOptions}} has the following members:
 
 <dl dfn-type=dict-member dfn-for=GPURequestAdapterOptions>
+    : <dfn>featureLevel</dfn>
+    ::
+        "Feature level" for the adapter request.
+
+        The allowed <dfn dfn for="">feature level string</dfn> values are:
+
+        <dl dfn-type=dfn dfn-for="feature level string">
+            : <dfn noexport>"core"</dfn>
+            :: No effect.
+            : <dfn noexport>"compatibility"</dfn>
+            :: No effect.
+
+                Note:
+                This value is reserved for future use as a way to opt into additional validation restrictions.
+                Applications should not use this value at this time.
+        </dl>
+
     : <dfn>powerPreference</dfn>
     ::
         Optionally provides a hint indicating what class of [=adapter=] should be selected from


### PR DESCRIPTION
Backport to M0 branch.
Main branch PR: #4897

> Issue: #4656, #4266