### PR TITLE
Check bindGroupLayout entries are empty

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6567,7 +6567,9 @@ pipeline, and have the following members:
                 1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                 1. Let |bindGroupLayouts| be a copy of |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
                 1. For each |i| in the [=list/get the indices|indices=] of |bindGroupLayouts|:
-                    1. If |bindGroupLayouts|[|i|] is `undefined` or [=list/empty=], set |bindGroupLayouts|[|i|] to `null`.
+                    1. If |bindGroupLayouts|[|i|] is `undefined` or
+                        |bindGroupLayouts|[|i|].{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
+                        is [=list/empty=], set |bindGroupLayouts|[|i|] to `null`.
                 1. Let |allEntries| be the result of concatenating
                     |bgl|.{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
                     for all non-`null` |bgl| in |bindGroupLayouts|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6565,9 +6565,9 @@ pipeline, and have the following members:
                 [=Device timeline=] |initialization steps|:
 
                 1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
-                1. Let |bindGroupLayouts| be a copy of |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+                1. Let |bindGroupLayouts| be a copy of |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
                 1. For each |i| in the [=list/get the indices|indices=] of |bindGroupLayouts|:
-                    1. If |bindGroupLayouts|[|i|] is `undefined` or
+                    1. If |bindGroupLayouts|[|i|] is not `null` and
                         |bindGroupLayouts|[|i|].{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
                         is [=list/empty=], set |bindGroupLayouts|[|i|] to `null`.
                 1. Let |allEntries| be the result of concatenating


### PR DESCRIPTION
Following https://github.com/gpuweb/gpuweb/pull/4946#discussion_r1831824362, this PR makes sure we check bindGroupLayout entries are empty, not just bindGroupLayout.

@kainino0x Please review