### PR TITLE
wgsl: allow OffsetOfMember to be 0

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10600,8 +10600,8 @@ from the start of the structure that is a multiple of the [=RequiredAlignOf=](|T
 for the address space |C|:
 
 <p algorithm="structure member minimum alignment">
-    [=OffsetOfMember=](|S|, |M|) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
-    Where |k| is a positive integer and |M| is a member of structure |S| with type |T|
+    [=OffsetOfMember=](|S|, |i|) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
+    Where |k| is a non-negative integer and the |i|'th member of structure |S| has type |T|
 </p>
 
 Arrays of element type |T| [=shader-creation error|must=] have an [=element stride=] that is a


### PR DESCRIPTION
The first member of a struct has offset 0, so that must be allowed by the rule.

Fixed: #4959