### PR TITLE
wgsl: @align(n) must divide required-align-of, for all structs

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8552,18 +8552,27 @@ path: syntax/align_attr.syntax.bs.include
 
     [=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
-    Note: This attribute influences how a value of the enclosing structure type can appear in memory:
-    at which byte addresses the structure itself and its component members can appear.
-    In particular, the rules in [[#memory-layouts]] combine to imply the following constraint:
+    This attribute influences how a value of the enclosing structure type can appear in memory:
+    it constrains the byte addresses at which the structure itself and its component members can appear.
 
-    <p class="note" algorithm="implied constraint on align attribute">
+    <div algorithm="constraint on align attribute">
     If `align(`|n|`)` is applied to a member of |S|
-    with type |T|, and |S| is the [=store type=]
-    or contained in the store type for a variable in address space |C|,
+    with type |T|,
+    and |S| can be the [=store type=] for variable in address space |AS|,
+    where |AS| is not [=address spaces/uniform=],
     then |n| [=shader-creation error|must=] satisfy:
-    |n|&nbsp;=&nbsp;|k|&nbsp;&times;&nbsp;[=RequiredAlignOf=](|T|,|C|)
+    <blockquote>
+    |n|&nbsp;=&nbsp;|k|&nbsp;&times;&nbsp;[=RequiredAlignOf=](|T|,|AS|)
     for some positive integer |k|.
+    </blockquote>
+    </div>
+
+    <p class="note">The rules for alignment and size are mutually recursive.
+    However, the above constraint is well defined because it depends on the required alignment of a
+    *nested* type, and types have bounded [=nesting depth=].
     </p>
+
+    See [[#memory-layouts]].
 
   <tr>
     <td>Parameters
@@ -10338,37 +10347,37 @@ by [=SizeOfMember=](|S|, |i|) and [=AlignOfMember=](|S|, |i|), respectively.
 The member sizes and alignments are used to calculate each member's byte offset from the start of the structure,
 as described in [[#internal-value-layout]].
 
-<p algorithm="structure member size">
+<blockquote algorithm="structure member size">
   [=SizeOfMember=](|S|, |i|) is |k| if the |i|'th member of |S| has attribute [=attribute/size=](|k|).
   Otherwise, it is [=SizeOf=](|T|) where |T| is the type of the member.
-</p>
+</blockquote>
 
-<p algorithm="structure member alignment">
+<blockquote algorithm="structure member alignment">
   [=AlignOfMember=](|S|, |i|) is |k| if the |i|'th member of |S| has attribute [=attribute/align=](|k|).
   Otherwise, it is [=AlignOf=](|T|) where |T| is the type of the member.
-</p>
+</blockquote>
 
 If a structure member has the [=attribute/size=] attribute applied, the
 value [=shader-creation error|must=] be at least as large as the size of the
 member's type:
 
-<p algorithm="member size constraint">
+<blockquote algorithm="member size constraint">
   [=SizeOfMember=](|S|, |i|) &ge; [=SizeOf=](T)<br>
   Where |T| is the type of the |i|'th member of |S|.
-</p>
+</blockquote>
 
 The first structure member always has a zero byte offset from the start of the
 structure:
-<p algorithm="offset of first structure member">
+<blockquote algorithm="offset of first structure member">
   [=OffsetOfMember=](<var ignore>S</var>, 1) = 0
-</p>
+</blockquote>
 
 Each subsequent member is placed at the lowest offset that satisfies the member type alignment,
 and which avoids overlap with the previous member.
 For each member index |i| > 1:
-<p algorithm="structure member offset">
+<blockquote algorithm="structure member offset">
   [=OffsetOfMember=](|S|, |i|) = [=roundUp=]([=AlignOfMember=](|S|, |i| ), [=OffsetOfMember=](|S|, |i|-1) + [=SizeOfMember=](|S|, |i|-1))<br>
-</p>
+</blockquote>
 
 <div class='example wgsl' heading='Layout of structures using implicit member sizes and alignments'>
   <xmp highlight=wgsl>
@@ -10574,13 +10583,15 @@ used in address space |C|.
 
 <table class='data'>
   <caption>
-    Alignment requirements of a host-shareable or fixed footprint type for
-    [=address spaces/storage=] and [=address spaces/uniform=] address spaces
+    Alignment requirements of host-shareable or fixed footprint types in address space |C|
   </caption>
   <thead>
-    <tr><th>Host-shareable or fixed footprint type |S|
-        <th>[=RequiredAlignOf=](|S|, [=address spaces/storage=])
-        <th>[=RequiredAlignOf=](|S|, [=address spaces/uniform=])
+    <tr><th>Host-shareable or fixed footprint type |S|,
+            assuming |S| can appear in |C|
+        <th>[=RequiredAlignOf=](|S|, |C|),<br/>
+            |C| is not [=address spaces/uniform=]
+        <th>[=RequiredAlignOf=](|S|, |C|),<br/>
+            |C| is [=address spaces/uniform=]
   </thead>
   <tr><td>[=bool=], [=i32=], [=u32=], [=f32=], or [=f16=]
       <td>[=AlignOf=](|S|)
@@ -10602,7 +10613,7 @@ used in address space |C|.
   <tr algorithm="alignment of an runtime-sized array">
       <td>array&lt;T&gt;
       <td>[=AlignOf=](|S|)
-      <td>[=roundUp=](16, [=AlignOf=](|S|))
+      <td>not applicable
   <tr algorithm="alignment of a structure">
       <td>[=structure|struct=] |S|
       <td>[=AlignOf=](|S|)
@@ -10613,25 +10624,27 @@ Structure members of type |T| [=shader-creation error|must=] have a byte offset
 from the start of the structure that is a multiple of the [=RequiredAlignOf=](|T|, |C|)
 for the address space |C|:
 
-<p algorithm="structure member minimum alignment">
+<blockquote algorithm="structure member minimum alignment">
     [=OffsetOfMember=](|S|, |i|) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
     Where |k| is a non-negative integer and the |i|'th member of structure |S| has type |T|
-</p>
+</blockquote>
 
 Arrays of element type |T| [=shader-creation error|must=] have an [=element stride=] that is a
 multiple of the [=RequiredAlignOf=](|T|, |C|) for the address space |C|:
 
-<p algorithm="array element minimum alignment">
+<blockquote algorithm="array element minimum alignment">
     [=StrideOf=](array<|T|, |N|>) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
     [=StrideOf=](array<|T|>) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
     Where |k| is a positive integer
-</p>
+</blockquote>
 
+<!--  Enforcing the rule on @align negates this:
 Note: [=RequiredAlignOf=](|T|, |C|) does not impose any additional restrictions
 on the values permitted for an [=attribute/align=] attribute, nor does it affect the rules
 of [=AlignOf=](|T|). Data is laid out with the rules defined in previous
 sections and then the resulting layout is validated against the
 [=RequiredAlignOf=](|T|, |C|) rules.
+-->
 
 The [=address spaces/uniform=] address space also requires that:
 * Array elements are aligned to 16 byte boundaries.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8558,7 +8558,7 @@ path: syntax/align_attr.syntax.bs.include
     <div algorithm="constraint on align attribute">
     If `align(`|n|`)` is applied to a member of |S|
     with type |T|,
-    and |S| can be the [=store type=] for variable in address space |AS|,
+    and |S| can be the [=store type=] for a variable in address space |AS|,
     where |AS| is not [=address spaces/uniform=],
     then |n| [=shader-creation error|must=] satisfy:
     <blockquote>


### PR DESCRIPTION
Builds on #4974
    
Reverses: #3756
    
    - The previous phrasing was a note that was "implied" by other rules.
      It wasn't actually perfectly implied.
    - Avoids a silly and confusing case with the first element of
      a struct.
    - Brings the spec more in line with Naga and WebKit.
    - More clearly applies the rule for *all* structs, no matter
      if it is actually instantiated by a variable.