### PR TITLE
Clarify uniqueness of nearest enclosing diagnostic

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -862,6 +862,8 @@ Two [=diagnostic filters=] *DF*(*AR1*,*NS1*,*TR1*) and *DF*(*AR2*,*NS2*,*TR2*) <
 
 [=Diagnostic filters=] [=shader-creation error|must=] not [=diagnostic/conflict=].
 
+Note: Multiple [=global diagnostic filters=] are permitted when they do not [=diagnostic/conflict=].
+
 WGSL's diagnostic filters are designed so their affected ranges nest perfectly.
 If the affected range of DF1 overlaps with the affected range of DF2, then
 either DF1's affected range is fully contained in DF2's affected range, or the other way around.
@@ -871,7 +873,10 @@ if one exists, is the diagnostic filter *DF(AR,NS,TR)* where:
 * *L* falls in the affected range *AR*, and
 * If there is another filter *DF'(AR',NS',TR)* where *L* falls in *AR'*, then *AR* is contained in *AR'*.
 
-Because affected ranges nest, the nearest enclosing diagnostic is unique, or does not exist.
+Because affected ranges nest, the nearest enclosing diagnostic:
+* is a unique [=range diagnostic filter=],
+* otherwise is one of a set of duplicate (non-[=diagnostic/conflict|conflicting=]) [=global diagnostic filters=],
+* otherwise does not exist.
 
 ## Limits ## {#limits}
 


### PR DESCRIPTION
Also add a note saying multiple non-conflicting global diagnostic filters are permitted.

Issue: #4976