### PR TITLE
Compat mode: make f16 and f32 rendering optional.

### DIFF
--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -238,6 +238,18 @@ for each stage of the pipeline:
 
 **Justification**: In OpenGL ES 3.1 does not support more combinations. Sampler units and texture units are bound together. Texture unit X uses sampler unit X.
 
+## 21. Introduce new `float16-renderable` and `float32-renderable` features.
+
+When supported, `float16-renderable` allows the `RENDER_ATTACHMENT` usage on textures with format `"r16float"`, `"rg16float"`, and `"rgba16float"`.
+
+When supported, `float32-renderable` allows the `RENDER_ATTACHMENT` usage on textures with format `"r32float"`, `"rg32float"`, and `"rgba32float"`.
+
+Without support, an error will occur at texture creation time as described in section 6.1.3.
+
+Support for both features is mandatory in core WebGPU.
+
+**Justification**: OpenGL ES 3.1 does not require the relevant f16- or f32-based texture formats (`R16F`, `RG16F`, `RGBA16F`, `R32F`, `RG32F`, and `RGBA32F`) to be color-renderable. While there exist OpenGL ES extensions to enable renderability (`GL_EXT_COLOR_BUFFER_HALF_FLOAT` and `GL_EXT_COLOR_BUFFER_FLOAT`), there are a significant number of devices which lack support for these extensions.
+
 ## Issues
 
 Q: OpenGL ES does not have "coarse" and "fine" variants of the derivative instructions (`dFdx()`, `dFdy()`, `fwidth()`). Should WGSL's "fine" derivatives (`dpdxFine()`, `dpdyFine()`, and `fwidthFine()`) be required to deliver high precision results? See [Issue 4325](https://github.com/gpuweb/gpuweb/issues/4325).


### PR DESCRIPTION
Introduce `float16-renderable` and `float32-renderable` as optional features in Compatibility mode, and required in Core.

Closes https://github.com/gpuweb/gpuweb/issues/4417.