### PR TITLE
Change GLSL loop examples to WGSL examples.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7377,7 +7377,7 @@ allows them to naturally use values defined in the loop body.
     var a: i32 = 2;
     let step: i32 = 1;
     for (var i: i32 = 0; i < 4; i += step) {
-      if (i % 2 == 0) { continue };
+      if (i % 2 == 0) { continue; }
       a *= 2;
     }
   </xmp>


### PR DESCRIPTION
I believe these examples are left over from before WGSL had `for` loops. Now that WGSL has for loops these examples showing a `for` loop expressed with `loop` can directly reference `for` in WGSL.

Fixed: #4996