### PR TITLE
Fix attribute validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9722,20 +9722,20 @@ dictionary GPUVertexAttribute {
 
     [=Device timeline=] steps:
 
-    1. Return `true`, if and only if, all of the following conditions are satisfied:
+    1. All of the requirements in the following steps |must| be met.
 
         <div class=validusage>
-            - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}}, |descriptor|, |layout|, |device|) succeeds.
-            - |descriptor|.{{GPUVertexState/buffers}}.[=list/size=] is &le;
+            1. [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}}, |descriptor|, |layout|, |device|) |must| succeed.
+            1. |descriptor|.{{GPUVertexState/buffers}}.[=list/size=] |must| be &le;
                 |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
-            - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}
-                passes [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|, |descriptor|)
-            - The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.[=list/size=],
+            1. Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}
+                |must| pass [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|, |descriptor|)
+            1. The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.[=list/size=],
                 over every |vertexBuffer| in |descriptor|.{{GPUVertexState/buffers}},
-                is &le;
+                |must| be &le;
                 |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
-            - Each |attrib| in the union of all {{GPUVertexAttribute}}
-                across |descriptor|.{{GPUVertexState/buffers}} has a distinct
+            1. Each |attrib| in the union of all {{GPUVertexAttribute}}
+                across |descriptor|.{{GPUVertexState/buffers}} |must| have a distinct
                 |attrib|.{{GPUVertexAttribute/shaderLocation}} value.
         </div>
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9664,13 +9664,12 @@ dictionary GPUVertexAttribute {
 </dl>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>validating GPUVertexBufferLayout</dfn>(device, descriptor, vertexStage)
+    <dfn abstract-op>validating GPUVertexBufferLayout</dfn>(device, descriptor)
 
     **Arguments:**
 
     - {{GPUDevice}} |device|
     - {{GPUVertexBufferLayout}} |descriptor|
-    - {{GPUProgrammableStage}} |vertexStage|
 
     [=Device timeline=] steps:
 
@@ -9693,21 +9692,6 @@ dictionary GPUVertexAttribute {
                     [$GPUVertexFormat/byteSize$](|attrib|.{{GPUVertexAttribute/format}}).
                 - |attrib|.{{GPUVertexAttribute/shaderLocation}} is &lt;
                     |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
-            - Let |entryPoint| be [$get the entry point$]({{GPUShaderStage/VERTEX}}, |vertexStage|). [=Assert=] it is not `null`.
-                For every vertex attribute |var| [=statically used=] by |entryPoint|,
-                there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayout/attributes}} for which
-                all of the following are true:
-                - The type |T| of |var| is compatible with |attrib|.{{GPUVertexAttribute/format}}'s [=vertex data type=]:
-
-                    <dl class=switch>
-                        : "unorm", "snorm", or "float"
-                        :: |T| must be `f32` or `vecN<f32>`.
-                        : "uint"
-                        :: |T| must be `u32` or `vecN<u32>`.
-                        : "sint"
-                        :: |T| must be `i32` or `vecN<i32>`.
-                    </dl>
-                - The shader location is |attrib|.{{GPUVertexAttribute/shaderLocation}}.
         </div>
 </div>
 
@@ -9722,6 +9706,8 @@ dictionary GPUVertexAttribute {
 
     [=Device timeline=] steps:
 
+    1. Let |entryPoint| be [$get the entry point$]({{GPUShaderStage/VERTEX}}, |descriptor|).
+    1. [=Assert=] |entryPoint| is not `null`.
     1. All of the requirements in the following steps |must| be met.
 
         <div class=validusage>
@@ -9729,14 +9715,25 @@ dictionary GPUVertexAttribute {
             1. |descriptor|.{{GPUVertexState/buffers}}.[=list/size=] |must| be &le;
                 |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
             1. Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}
-                |must| pass [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|, |descriptor|)
+                |must| pass [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|).
             1. The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.[=list/size=],
                 over every |vertexBuffer| in |descriptor|.{{GPUVertexState/buffers}},
                 |must| be &le;
                 |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
-            1. Each |attrib| in the union of all {{GPUVertexAttribute}}
-                across |descriptor|.{{GPUVertexState/buffers}} |must| have a distinct
-                |attrib|.{{GPUVertexAttribute/shaderLocation}} value.
+            1. For every vertex attribute declaration (at location |location| with type |T|) that is
+                [=statically used=] by |entryPoint|, there |must| be exactly one pair (|i|, |j|) for which
+                |descriptor|.{{GPUVertexState/buffers}}[|i|]?.{{GPUVertexBufferLayout/attributes}}[|j|].{{GPUVertexAttribute/shaderLocation}} == |location|.
+
+                Let |attrib| be that {{GPUVertexAttribute}}.
+            1. |T| |must| be compatible with |attrib|.{{GPUVertexAttribute/format}}'s [=vertex data type=]:
+                <dl class=switch>
+                    : "unorm", "snorm", or "float"
+                    :: |T| must be `f32` or `vecN<f32>`.
+                    : "uint"
+                    :: |T| must be `u32` or `vecN<u32>`.
+                    : "sint"
+                    :: |T| must be `i32` or `vecN<i32>`.
+                </dl>
         </div>
 </div>
 


### PR DESCRIPTION
**I suggest reviewing commits separately**

Note the previous (nonsensical) validation required each shader attribute to have one `GPUVertexAttribute` matching BOTH its location and type. The new validation requires each shader attribute to have one `GPUVertexAttribute` matching its location, _then_ that attribute must match in type. This should be the same because we _also_ had validation that said each `shaderLocation` in the pipeline was unique.

Fixes #4994