### PR TITLE
Subgroups: clarify subgroups operations using f16

### DIFF
--- a/proposals/subgroups.md
+++ b/proposals/subgroups.md
@@ -86,7 +86,7 @@ Note: HLSL does not expose a subgroup_id or num_subgroups equivalent.
 ## Built-in Functions
 
 All built-in function can only be used in `compute` or `fragment` shader stages.
-Using f16 as a parameter in any of these functions requires `subgroups_f16` to be enabled.
+Using f16 as a parameter in any of these functions is valid if and only if ~subgroups_f16~ `f16` enabled.
 
 | Function | Preconditions | Description |
 | --- | --- | --- |
@@ -181,6 +181,9 @@ New GPU features:
 | --- | --- |
 | **subgroups** | Allows the WGSL feature and adds new limits |
 | ~subgroups-f16~ | Allows WGSL feature. Requires **subgroups** and **shader-f16** |
+
+Note: An adapter supporting both `shader-f16` and `subgroups` GPU features must support using
+f16 in subgroups operations if and only if `subgroups` and `f16` WGSL extensions enabled.
 
 **TODO**: Can we expose a feature to require a specific subgroup size?
 No facility exists in Metal so it would have to be a separate feature.

--- a/proposals/subgroups.md
+++ b/proposals/subgroups.md
@@ -2,7 +2,7 @@
 
 Status: **Draft**
 
-Last modified: 2024-12-02
+Last modified: 2024-12-04
 
 Issue: [#4306](https://github.com/gpuweb/gpuweb/issues/4306)
 


### PR DESCRIPTION
This PR clarify that using f16 in subgroups operation only requires `f16` WGSL extension enabled together with `subgroups` (since `subgroups_f16` is deprecated), and an adapter that support `shader-f16` GPU feature must support using f16 in subgroups operations to declare supporting `subgroups` GPU feature (in other words, the criteria for an adapter to support `subgroups` is tightened to also supporting deprecated `subgroups-f16`).