### PR TITLE
[M0 backport] Fix typos in refs to adapter capability guarantees section (#5015)

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1462,7 +1462,7 @@ A <dfn dfn>feature</dfn> is a set of optional WebGPU functionality that is not s
 on all implementations, typically due to hardware or system software constraints.
 
 All [=features=] are optional, but [=adapters=] make some guarantees about their availability
-(see [[#adapter capability guarantees]].
+(see [[#adapter-capability-guarantees]]).
 
 A [=device=] supports the exact set of features determined at creation (see [[#optional-capabilities]]).
 API calls perform validation according to these features (not the [=adapter=]'s features):
@@ -1500,7 +1500,7 @@ generally only request better limits if they may actually require them.
 Each limit has a <dfn dfn for=limit>default</dfn> value.
 
 [=Adapters=] are always guaranteed to support the defaults or [=limit/better=]
-(see [[#adapter capability guarantees]].
+(see [[#adapter-capability-guarantees]]).
 
 A [=device=] supports the exact set of limits determined at creation (see [[#optional-capabilities]]).
 API calls perform validation according to these limits (not the [=adapter=]'s limits),


### PR DESCRIPTION
From #5015