### PR TITLE
Loosen viewport validation requirements

### DIFF
--- a/correspondence/index.bs
+++ b/correspondence/index.bs
@@ -299,12 +299,16 @@ User agents are not required to use these formulas and may expose whatever they 
         <td>`viewportBoundsRange[0]` (= -2 &times; `max(maxViewportDimensions[0..1])`)
         <td><p class=issue>*No documented limit?*
         <td>-32768 = `D3D12_VIEWPORT_BOUNDS_MIN`
+        
+        Note: equal to -2 &times; `maxTextureDimension2D`
     <tr>
         <th>Max Viewport Bounds (implied)
         <td>[#373](https://github.com/gpuweb/gpuweb/issues/373)
         <td>`viewportBoundsRange[1]` (= 2 &times; `max(maxViewportDimensions[0..1])` - 1)
         <td><p class=issue>*No documented limit?*
         <td>32767 = `D3D12_VIEWPORT_BOUNDS_MAX`
+        
+        Note: equal to 2 &times; `maxTextureDimension2D` - 1
 </table>
 
 ## Vulkan `maxFragmentCombinedOutputResources` ## {#vulkan-maxFragmentCombinedOutputResources}

--- a/correspondence/index.bs
+++ b/correspondence/index.bs
@@ -287,6 +287,24 @@ User agents are not required to use these formulas and may expose whatever they 
         <td>`min(maxComputeWorkGroupCount[0..2])`
         <td><p class=issue>*No documented limit?*
         <td>65535 = `D3D12_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION`
+    <tr>
+        <th>Max Viewport Size (implied)
+        <td>[#373](https://github.com/gpuweb/gpuweb/issues/373)
+        <td>`maxViewportDimensions` (&ge; largest framebuffer attachement)
+        <td><p class=issue>*No documented limit?*
+        <td><p class=issue>*No documented limit?*
+    <tr>
+        <th>Min Viewport Bounds (implied)
+        <td>[#373](https://github.com/gpuweb/gpuweb/issues/373)
+        <td>`viewportBoundsRange[0]` (= -2 &times; `max(maxViewportDimensions[0..1])`)
+        <td><p class=issue>*No documented limit?*
+        <td>-32768 = `D3D12_VIEWPORT_BOUNDS_MIN`
+    <tr>
+        <th>Max Viewport Bounds (implied)
+        <td>[#373](https://github.com/gpuweb/gpuweb/issues/373)
+        <td>`viewportBoundsRange[1]` (= 2 &times; `max(maxViewportDimensions[0..1])` - 1)
+        <td><p class=issue>*No documented limit?*
+        <td>32767 = `D3D12_VIEWPORT_BOUNDS_MAX`
 </table>
 
 ## Vulkan `maxFragmentCombinedOutputResources` ## {#vulkan-maxFragmentCombinedOutputResources}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12876,17 +12876,18 @@ attachments used by this encoder.
                 [=Device timeline=] steps:
 
                 1. [$Validate the encoder state$] of |this|. If it returns false, return.
+                1. Let |maxViewportRange| be |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}} &times; `2`.
                 1. If any of the following conditions are unsatisfied, [$invalidate$] |this| and return.
 
                     <div class=validusage>
-                        - |x| &ge; `0`
-                        - |y| &ge; `0`
-                        - |width| &ge; `0`
-                        - |height| &ge; `0`
-                        - |x| + |width| &le; |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width
-                        - |y| + |height| &le; |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height
-                        - 0.0 &le; |minDepth| &le; 1.0
-                        - 0.0 &le; |maxDepth| &le; 1.0
+                        - |x| &ge; -|maxViewportRange|
+                        - |y| &ge; -|maxViewportRange|
+                        - `0` &le; |width| &le; |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}
+                        - `0` &le; |height| &le; |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}
+                        - |x| + |width| &le; |maxViewportRange| &minus; `1`
+                        - |y| + |height| &le; |maxViewportRange| &minus; `1`
+                        - `0.0` &le; |minDepth| &le; `1.0`
+                        - `0.0` &le; |maxDepth| &le; `1.0`
                         - |minDepth| &le; |maxDepth|
                     </div>
 


### PR DESCRIPTION
Fixes #373

Simplifies the Vulkan model a bit by ignoring the fact that the maximum viewport size _may_ be larger than the largest possible 2D texture size. So the logic becomes that the viewports must be no larger than `maxTextureDimension2D` and cannot be extend past `-maxTextureDimension2D * 2` or `(maxTextureDimension2D * 2) - 1` on either axis.

Which should be enough for anybody!*

*There's definitely no way that this statement will come back to haunt us. Nope.