### PR TITLE
Compat: fix GL computation of storage limits

### DIFF
--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -107,7 +107,6 @@ During `createRenderPipeline()` and `createRenderPipelineAsync()`, `GPUDepthSten
 The differences in limits between compatibility mode and standard WebGPU
 are as follows
 
-
 | limit                               | compat  | standard  | gl limit                                     |
 | :---------------------------------- | ------: | --------: | :------------------------------------------- |
 | `maxColorAttachments`               |       4 |         8 | min(MAX_COLOR_ATTACHMENTS, MAX_DRAW_BUFFERS) |
@@ -115,7 +114,11 @@ are as follows
 | `maxComputeWorkgroupSizeX`          |     128 |       256 | MAX_COMPUTE_WORK_GROUP_SIZE                  |
 | `maxComputeWorkgroupSizeY`          |     128 |       256 | MAX_COMPUTE_WORK_GROUP_SIZE                  |
 | `maxInterStageShaderVariables`      |      15 |        16 | MAX_VARYING_VECTORS                          |
-| `maxStorageBuffersPerShaderStage`   |       4 |         8 | min(GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS, GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS, GL_MAX_FRAGMENT_SHADER_STORAGE_BLOCKS, GL_MAX_COMPUTE_SHADER_STORAGE_BLOCKS) |
+| `maxStorageBuffersPerShaderStage`   |       4 |         8 | min(MAX_SHADER_STORAGE_BUFFER_BINDINGS, MAX_COMPUTE_SHADER_STORAGE_BLOCKS) |
+| `maxStorageBuffersInVertexStage`    |       0 | (ignored) | min(MAX_SHADER_STORAGE_BUFFER_BINDINGS, MAX_VERTEX_SHADER_STORAGE_BLOCKS) (see restriction 18) |
+| `maxStorageBuffersInFragmentStage`  |       0 | (ignored) | min(MAX_SHADER_STORAGE_BUFFER_BINDINGS, MAX_FRAGMENT_SHADER_STORAGE_BLOCKS) (see restriction 19) |
+| `maxStorageTexturesInVertexStage`   |       0 | (ignored) | TODO (see restriction 18) |
+| `maxStorageTexturesInFragmentStage` |       0 | (ignored) | TODO (see restriction 19) |
 | `maxTextureDimension1D`             |    4096 |      8192 | MAX_TEXTURE_SIZE                             |
 | `maxTextureDimension2D`             |    4096 |      8192 | MAX_TEXTURE_SIZE                             |
 | `maxUniformBufferBindingSize`       |   16384 |     65536 | MAX_UNIFORM_BLOCK_SIZE                       |

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -117,8 +117,8 @@ are as follows
 | `maxStorageBuffersPerShaderStage`   |       4 |         8 | min(MAX_SHADER_STORAGE_BUFFER_BINDINGS, MAX_COMPUTE_SHADER_STORAGE_BLOCKS) |
 | `maxStorageBuffersInVertexStage`    |       0 | (ignored) | min(MAX_SHADER_STORAGE_BUFFER_BINDINGS, MAX_VERTEX_SHADER_STORAGE_BLOCKS) (see restriction 18) |
 | `maxStorageBuffersInFragmentStage`  |       0 | (ignored) | min(MAX_SHADER_STORAGE_BUFFER_BINDINGS, MAX_FRAGMENT_SHADER_STORAGE_BLOCKS) (see restriction 19) |
-| `maxStorageTexturesInVertexStage`   |       0 | (ignored) | TODO (see restriction 18) |
-| `maxStorageTexturesInFragmentStage` |       0 | (ignored) | TODO (see restriction 19) |
+| `maxStorageTexturesInVertexStage`   |       0 | (ignored) | MAX_VERTEX_IMAGE_UNIFORMS (see restriction 18) |
+| `maxStorageTexturesInFragmentStage` |       0 | (ignored) | MAX_FRAGMENT_IMAGE_UNIFORMS (see restriction 19) |
 | `maxTextureDimension1D`             |    4096 |      8192 | MAX_TEXTURE_SIZE                             |
 | `maxTextureDimension2D`             |    4096 |      8192 | MAX_TEXTURE_SIZE                             |
 | `maxUniformBufferBindingSize`       |   16384 |     65536 | MAX_UNIFORM_BLOCK_SIZE                       |


### PR DESCRIPTION
I noticed the formula for `maxStorageBuffersPerShaderStage` was outdated. I also wanted to add the formula for the new limits, but I'm not sure what they all are.