### PR TITLE
Call out `texture_multisampled_2d` parameterization

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4318,7 +4318,7 @@ WebGPU [$validating shader binding|validates$] compatibility between the
 texture, the {{GPUTextureBindingLayout/sampleType}} of the bind group layout,
 and the [=sampled type=] of the texture variable.
 
-The texture is parameterized by a [=sampled type=] and
+`texture_multisampled_2d` is parameterized by a [=sampled type=] and
 [=shader-creation error|must=] be `f32`, `i32`, or `u32`.
 
 <table class='data'>


### PR DESCRIPTION
Fixed: #5028