### PR TITLE
Compat: update new limits proposal

### DIFF
--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -218,8 +218,8 @@ In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` an
 
 In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInFragmentStage` will default to the same value as `maxStorageBuffersPerShaderStage`, and `maxStorageTexturesInFragmentStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
 
-In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInFragmentStage` exceeds the effective requested limit for `maxStorageBuffersPerShaderStage` then the requested limit for `maxStorageBuffersPerShaderStage` will be raised to the
-value requested for `maxStorageBuffersInFragmentStage`. If the requested limit for `maxStorageTexturesInFragmentStage` exceeds the effective limit for `maxStorageTexturePerShaderStage`  then the requested limit for `maxStorageTexturesPerShaderStage` will be raised to the
+In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInFragmentStage` exceeds the effective requested limit for `maxStorageBuffersPerShaderStage`, then the requested limit for `maxStorageBuffersPerShaderStage` will be raised to the
+value requested for `maxStorageBuffersInFragmentStage`. If the requested limit for `maxStorageTexturesInFragmentStage` exceeds the effective limit for `maxStorageTexturePerShaderStage`, then the requested limit for `maxStorageTexturesPerShaderStage` will be raised to the
 value requested for `macStorageTexturesInFragmentStage`.
 
 In Core mode, at device creation time, and after application of the previous rule, `maxStorageBuffersInFragmentStage` is set to the effective limit for `maxStorageBuffersPerShaderStage` and, `maxStorageTexturesInFragmentStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -212,7 +212,7 @@ In Core mode, at device creation time, and after application of the previous rul
 
 In `createBindGroupLayout`, `createPipelineLayout` (including `"auto"` layout creation), if the number of `"storage"`/`"read-only-storage"` buffer bindings with visibility bit `FRAGMENT` exceeds the `maxStorageBuffersInFragmentStage` limit, a validation error will occur.
 
-In `createBindGroupLayout`, `createPipelineLayout` (including `"auto"` layout creation), if the number of bindings of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` with visibility `FRAGMENT` bit true, exceeds the `maxStorageTexturesInFragmentStage` limit, a validation error will occur.
+In `createBindGroupLayout`, `createPipelineLayout` (including `"auto"` layout creation), if the number of `storageTexture` bindings with visibility bit `FRAGMENT` exceeds the `maxStorageTexturesInFragmentStage` limit, a validation error will occur.
 
 In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limits continue to apply to all stages. E.g., the effective storage buffer limit in the fragment stage is `min(maxStorageBuffersPerShaderStage, maxStorageBuffersInFragmentStage)`.
 

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -216,7 +216,7 @@ In `createBindGroupLayout`, `createPipelineLayout` (including `"auto"` layout cr
 
 In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limits continue to apply to all stages. E.g., the effective storage buffer limit in the fragment stage is `min(maxStorageBuffersPerShaderStage, maxStorageBuffersInFragmentStage)`.
 
-In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInFragmentStage` will default to the same value as `maxStorageBuffersPerShaderStage` and, `maxStorageTexturesInFragmentStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
+In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInFragmentStage` will default to the same value as `maxStorageBuffersPerShaderStage`, and `maxStorageTexturesInFragmentStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
 
 In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInFragmentStage` exceeds the effective requested limit for `maxStorageBuffersPerShaderStage` then the requested limit for `maxStorageBuffersPerShaderStage` will be raised to the
 value requested for `maxStorageBuffersInFragmentStage`. If the requested limit for `maxStorageTexturesInFragmentStage` exceeds the effective limit for `maxStorageTexturePerShaderStage`  then the requested limit for `maxStorageTexturesPerShaderStage` will be raised to the

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -200,8 +200,8 @@ In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` an
 
 In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInVertexStage` will default to the same value as `maxStorageBuffersPerShaderStage` and `maxStorageTexturesInVertexStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
 
-In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInVertexStage` exceeds the effective requested limit for `maxStorageBuffersPerShaderStage` then the requested limit for `maxStorageBuffersPerShaderStage` is raised to the
-value requested for `maxStorageBuffersInVertexStage`. If the requested limit for `maxStorageTexturesInVertexStage` exceeds the effective requested limit for `maxStorageTexturesPerShaderStage` then the requested limit for `maxStorageTexturesPerShaderStage` is raised to the
+In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInVertexStage` exceeds the effective requested limit for `maxStorageBuffersPerShaderStage`, then the requested limit for `maxStorageBuffersPerShaderStage` is raised to the
+value requested for `maxStorageBuffersInVertexStage`. If the requested limit for `maxStorageTexturesInVertexStage` exceeds the effective requested limit for `maxStorageTexturesPerShaderStage`, then the requested limit for `maxStorageTexturesPerShaderStage` is raised to the
 value requested for `maxStorageTexturesInVertexStage`.
 
 In Core mode, at device creation time, and after application of the previous rule, `maxStorageBuffersInVertexStage` is set to the effective requested limit for `maxStorageBuffersPerShaderStage`, and `maxStorageTexturesInVertexStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -194,15 +194,17 @@ compatibility mode.
 
 In `createBindGroupLayout` and `createPipelineLayout` (including `"auto"` layout creation), if the number of bindings of type `storage_buffer` with visibility `VERTEX` bit true, exceeds the `maxStorageBuffersInVertexStage` limit a validation error will occur.
 
-In `createBindGroupLayout`, `createPipelineLayout` and at pipeline creation time, if the number of bindings of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` with visibility `VERTEX` bit true, exceeds the `maxStorageTexturesInVertexStage` limit, a validation error will occur.
+In `createBindGroupLayout`, `createPipelineLayout` (including "auto" layout creation), if the number of bindings of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` with visibility `VERTEX` bit true, exceeds the `maxStorageTexturesInVertexStage` limit, a validation error will occur.
 
 In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limits continue to apply to all stages. E.g., the effective storage buffer limit in the vertex stage is `min(maxStorageBuffersPerShaderStage, maxStorageBuffersInVertexStage)`.
 
 In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInVertexStage` will default to the same value as `maxStorageBuffersPerShaderStage` and `maxStorageTexturesInVertexStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
 
-In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInVertexStage` exceeds the effective limit for `maxStorageBuffersPerShaderStage` or if the requested limit for `maxStorageTexturesInVertexStage` exceeds the effective limit for `maxStorageTexturesPerShaderStage` an `OperationError` is thrown.
+In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInVertexStage` exceeds the effective requested limit for `maxStorageBuffersPerShaderStage` then the requested limit for `maxStorageBuffersPerShaderStage` is raised to the
+value requested for `maxStorageBuffersInVertexStage`. If the requested limit for `maxStorageTexturesInVertexStage` exceeds the effective requested limit for `maxStorageTexturesPerShaderStage` then the requested limit for `maxStorageTexturesPerShaderStage` is raised to the
+value requested for `maxStorageTexturesInVertexStage`.
 
-In Core mode, at device creation, `maxStorageBuffersInVertexStage` is set to the effective limit for `maxStorageBuffersPerShaderStage` and, `maxStorageTexturesInVertexStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.
+In Core mode, at device creation time, and after application of the previous rule, `maxStorageBuffersInVertexStage` is set to the effective requested limit for `maxStorageBuffersPerShaderStage` and, `maxStorageTexturesInVertexStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.
 
 **Justification**: OpenGL ES 3.1 allows `MAX_VERTEX_SHADER_STORAGE_BLOCKS` and `MAX_VERTEX_IMAGE_UNIFORMS` to be zero, and there are a significant number of devices in the field with that value.
 
@@ -212,13 +214,15 @@ In `createBindGroupLayout`, `createPipelineLayout` (including `"auto"` layout cr
 
 In `createBindGroupLayout`, `createPipelineLayout` (including `"auto"` layout creation), if the number of bindings of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` with visibility `FRAGMENT` bit true, exceeds the `maxStorageTexturesInFragmentStage` limit, a validation error will occur.
 
-In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInFragmentStage` will default to the same value as `maxStorageBuffersPerShaderStage` and, `maxStorageTexturesInFragmentStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
-
 In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limits continue to apply to all stages. E.g., the effective storage buffer limit in the fragment stage is `min(maxStorageBuffersPerShaderStage, maxStorageBuffersInFragmentStage)`.
 
-In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInFragmentStage` exceeds the effective limit for `maxStorageBuffersPerShaderStage` or if the requested limit for `maxStorageTexturesInFragmentStage` exceeds the effective limit for `maxStorageTexturePerShaderStage`  an `OperationError` is thrown.
+In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInFragmentStage` will default to the same value as `maxStorageBuffersPerShaderStage` and, `maxStorageTexturesInFragmentStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
 
-In Core mode, at device creation, both `maxStorageBuffersInFragmentStage` is set to the effective limit for `maxStorageBuffersPerShaderStage` and, `maxStorageTexturesInFragmentStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.
+In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInFragmentStage` exceeds the effective requested limit for `maxStorageBuffersPerShaderStage` then the requested limit for `maxStorageBuffersPerShaderStage` will be raised to the
+value requested for `maxStorageBuffersInFragmentStage`. If the requested limit for `maxStorageTexturesInFragmentStage` exceeds the effective limit for `maxStorageTexturePerShaderStage`  then the requested limit for `maxStorageTexturesPerShaderStage` will be raised to the
+value requested for `macStorageTexturesInFragmentStage`.
+
+In Core mode, at device creation time, and after application of the previous rule, `maxStorageBuffersInFragmentStage` is set to the effective limit for `maxStorageBuffersPerShaderStage` and, `maxStorageTexturesInFragmentStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.
 
 **Justification**: OpenGL ES 3.1 allows `MAX_FRAGMENT_SHADER_STORAGE_BLOCKS` and `MAX_FRAGMENT_IMAGE_UNIFORMS` to be zero, and there are a significant number of devices in the field with that value.
 

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -204,7 +204,7 @@ In both Compatibility Mode and Core, at device creation time, if the requested l
 value requested for `maxStorageBuffersInVertexStage`. If the requested limit for `maxStorageTexturesInVertexStage` exceeds the effective requested limit for `maxStorageTexturesPerShaderStage` then the requested limit for `maxStorageTexturesPerShaderStage` is raised to the
 value requested for `maxStorageTexturesInVertexStage`.
 
-In Core mode, at device creation time, and after application of the previous rule, `maxStorageBuffersInVertexStage` is set to the effective requested limit for `maxStorageBuffersPerShaderStage` and, `maxStorageTexturesInVertexStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.
+In Core mode, at device creation time, and after application of the previous rule, `maxStorageBuffersInVertexStage` is set to the effective requested limit for `maxStorageBuffersPerShaderStage`, and `maxStorageTexturesInVertexStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.
 
 **Justification**: OpenGL ES 3.1 allows `MAX_VERTEX_SHADER_STORAGE_BLOCKS` and `MAX_VERTEX_IMAGE_UNIFORMS` to be zero, and there are a significant number of devices in the field with that value.
 

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -192,25 +192,33 @@ compatibility mode.
 
 ## 18. Introduce new `maxStorageBuffersInVertexStage` and `maxStorageTexturesInVertexStage` limits.
 
-If the number of shader variables of type `storage_buffer` in a vertex shader exceeds the `maxStorageBuffersInVertexStage` limit, a validation error will occur at pipeline creation time.
+In `createBindGroupLayout`, `createPipelineLayout` and at pipeline creation time, if the number of bindings of type `storage_buffer` with visibility `VERTEX` bit true, exceeds the `maxStorageBuffersInVertexStage` limit a validation error will occur.
 
-If the number of shader variables of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` in a vertex shader exceeds the `maxStorageTexturesInVertexStage` limit, a validation error will occur at pipeline creation time.
-
-In Compatibility mode, these new limits will have a default of zero. In Core mode, they will default to the maximum value of a GPUSize32.
+In `createBindGroupLayout`, `createPipelineLayout` and at pipeline creation time, if the number of bindings of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` with visibility `VERTEX` bit true, exceeds the `maxStorageTexturesInVertexStage` limit, a validation error will occur.
 
 In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limits continue to apply to all stages. E.g., the effective storage buffer limit in the vertex stage is `min(maxStorageBuffersPerShaderStage, maxStorageBuffersInVertexStage)`.
+
+In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInVertexStage` will default to the same value as ``maxStorageBuffersPerShaderStage` and `maxStorageBuffersInVertexStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
+
+In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInVertexStage` exceeds the effective limit for `maxStorageBuffersPerShaderStage` or if the requested limit for `maxStorageTexturesInVertexStage` exceeds the effective limit for `maxStorageTexturesPerShaderStage` an `OperationError` is thrown.
+
+In Core mode, at device creation, `maxStorageBuffersInVertexStage` is set to the effective limit for `maxStorageBuffersPerShaderStage` and `maxStorageTexturesInVertexStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.
 
 **Justification**: OpenGL ES 3.1 allows `MAX_VERTEX_SHADER_STORAGE_BLOCKS` and `MAX_VERTEX_IMAGE_UNIFORMS` to be zero, and there are a significant number of devices in the field with that value.
 
 ## 19. Introduce new `maxStorageBuffersInFragmentStage` and `maxStorageTexturesInFragmentStage` limits.
 
-If the number of shader variables of type `storage_buffer` in a fragment shader exceeds the `maxStorageBuffersInFragmentStage` limit, a validation error will occur at pipeline creation time.
+In `createBindGroupLayout`, `createPipelineLayout` and at pipeline creation time, if the number of bindings of type `storage_buffer` with visibility `FRAGMENT` bit true, exceeds the `maxStorageBuffersInFragmentStage` limit, a validation error will occur.
 
-If the number of shader variables of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` in a fragment shader exceeds the `maxStorageTexturesInFragmentStage` limit, a validation error will occur at pipeline creation time.
+In `createBindGroupLayout`, `createPipelineLayout` and at pipeline creation time, if the number of bindings of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` with visibility `FRAGMENT` bit true, exceeds the `maxStorageTexturesInFragmentStage` limit, a validation error will occur.
 
-In Compatibility mode, these new limits will have a default of zero. In Core mode, they will default to the maximum value of a GPUSize32.
+In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInFragmentStage` will default to the same value as `maxStorageBuffersPerShaderStage` and `maxStorageTexturesInFragmentStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
 
 In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limits continue to apply to all stages. E.g., the effective storage buffer limit in the fragment stage is `min(maxStorageBuffersPerShaderStage, maxStorageBuffersInFragmentStage)`.
+
+In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInFragmentStage` exceeds the effective limit for `maxStorageBuffersPerShaderStage` or if the requested limit for `maxStorageTexturesInFragmentStage` exceeds the effective limit for `maxStorageTexturePerShaderStage`  an `OperationError` is thrown.
+
+In Core mode, at device creation, both `maxStorageBuffersInFragmentStage` is set to the effective limit for `maxStorageBuffersPerShaderStage` and `maxStorageTexturesInFragmentStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.
 
 **Justification**: OpenGL ES 3.1 allows `MAX_FRAGMENT_SHADER_STORAGE_BLOCKS` and `MAX_FRAGMENT_IMAGE_UNIFORMS` to be zero, and there are a significant number of devices in the field with that value.
 

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -194,7 +194,7 @@ compatibility mode.
 
 In `createBindGroupLayout` and `createPipelineLayout` (including `"auto"` layout creation), if the number of bindings of type `storage_buffer` with visibility `VERTEX` bit true, exceeds the `maxStorageBuffersInVertexStage` limit a validation error will occur.
 
-In `createBindGroupLayout`, `createPipelineLayout` (including "auto" layout creation), if the number of bindings of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` with visibility `VERTEX` bit true, exceeds the `maxStorageTexturesInVertexStage` limit, a validation error will occur.
+In `createBindGroupLayout`, `createPipelineLayout` (including "auto" layout creation), if the number of `storageTexture` bindings with visibility bit `VERTEX` exceeds the `maxStorageTexturesInVertexStage` limit, a validation error will occur.
 
 In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limits continue to apply to all stages. E.g., the effective storage buffer limit in the vertex stage is `min(maxStorageBuffersPerShaderStage, maxStorageBuffersInVertexStage)`.
 

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -198,7 +198,7 @@ In `createBindGroupLayout`, `createPipelineLayout` and at pipeline creation time
 
 In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limits continue to apply to all stages. E.g., the effective storage buffer limit in the vertex stage is `min(maxStorageBuffersPerShaderStage, maxStorageBuffersInVertexStage)`.
 
-In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInVertexStage` will default to the same value as ``maxStorageBuffersPerShaderStage` and `maxStorageBuffersInVertexStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
+In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInVertexStage` will default to the same value as `maxStorageBuffersPerShaderStage` and `maxStorageBuffersInVertexStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
 
 In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInVertexStage` exceeds the effective limit for `maxStorageBuffersPerShaderStage` or if the requested limit for `maxStorageTexturesInVertexStage` exceeds the effective limit for `maxStorageTexturesPerShaderStage` an `OperationError` is thrown.
 

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -192,7 +192,7 @@ compatibility mode.
 
 ## 18. Introduce new `maxStorageBuffersInVertexStage` and `maxStorageTexturesInVertexStage` limits.
 
-In `createBindGroupLayout` and `createPipelineLayout` (including `"auto"` layout creation), if the number of bindings of type `storage_buffer` with visibility `VERTEX` bit true, exceeds the `maxStorageBuffersInVertexStage` limit a validation error will occur.
+In `createBindGroupLayout` and `createPipelineLayout` (including `"auto"` layout creation), if the number of `"storage"`/`"read-only-storage"` buffer bindings with visibility bit `VERTEX` exceeds the `maxStorageBuffersInVertexStage` limit, a validation error will occur.
 
 In `createBindGroupLayout`, `createPipelineLayout` (including "auto" layout creation), if the number of `storageTexture` bindings with visibility bit `VERTEX` exceeds the `maxStorageTexturesInVertexStage` limit, a validation error will occur.
 

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -192,7 +192,7 @@ compatibility mode.
 
 ## 18. Introduce new `maxStorageBuffersInVertexStage` and `maxStorageTexturesInVertexStage` limits.
 
-In `createBindGroupLayout`, `createPipelineLayout` and at pipeline creation time, if the number of bindings of type `storage_buffer` with visibility `VERTEX` bit true, exceeds the `maxStorageBuffersInVertexStage` limit a validation error will occur.
+In `createBindGroupLayout` and `createPipelineLayout` (including `"auto"` layout creation), if the number of bindings of type `storage_buffer` with visibility `VERTEX` bit true, exceeds the `maxStorageBuffersInVertexStage` limit a validation error will occur.
 
 In `createBindGroupLayout`, `createPipelineLayout` and at pipeline creation time, if the number of bindings of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` with visibility `VERTEX` bit true, exceeds the `maxStorageTexturesInVertexStage` limit, a validation error will occur.
 

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -210,7 +210,7 @@ In Core mode, at device creation time, and after application of the previous rul
 
 ## 19. Introduce new `maxStorageBuffersInFragmentStage` and `maxStorageTexturesInFragmentStage` limits.
 
-In `createBindGroupLayout`, `createPipelineLayout` (including `"auto"` layout creation), if the number of bindings of type `storage_buffer` with visibility `FRAGMENT` bit true, exceeds the `maxStorageBuffersInFragmentStage` limit, a validation error will occur.
+In `createBindGroupLayout`, `createPipelineLayout` (including `"auto"` layout creation), if the number of `"storage"`/`"read-only-storage"` buffer bindings with visibility bit `FRAGMENT` exceeds the `maxStorageBuffersInFragmentStage` limit, a validation error will occur.
 
 In `createBindGroupLayout`, `createPipelineLayout` (including `"auto"` layout creation), if the number of bindings of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` with visibility `FRAGMENT` bit true, exceeds the `maxStorageTexturesInFragmentStage` limit, a validation error will occur.
 

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -198,7 +198,7 @@ In `createBindGroupLayout`, `createPipelineLayout` and at pipeline creation time
 
 In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limits continue to apply to all stages. E.g., the effective storage buffer limit in the vertex stage is `min(maxStorageBuffersPerShaderStage, maxStorageBuffersInVertexStage)`.
 
-In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInVertexStage` will default to the same value as `maxStorageBuffersPerShaderStage` and `maxStorageBuffersInVertexStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
+In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInVertexStage` will default to the same value as `maxStorageBuffersPerShaderStage` and `maxStorageTexturesInVertexStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
 
 In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInVertexStage` exceeds the effective limit for `maxStorageBuffersPerShaderStage` or if the requested limit for `maxStorageTexturesInVertexStage` exceeds the effective limit for `maxStorageTexturesPerShaderStage` an `OperationError` is thrown.
 

--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -202,23 +202,23 @@ In Compatibility mode, these new limits will have a default of zero. In Core mod
 
 In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInVertexStage` exceeds the effective limit for `maxStorageBuffersPerShaderStage` or if the requested limit for `maxStorageTexturesInVertexStage` exceeds the effective limit for `maxStorageTexturesPerShaderStage` an `OperationError` is thrown.
 
-In Core mode, at device creation, `maxStorageBuffersInVertexStage` is set to the effective limit for `maxStorageBuffersPerShaderStage` and `maxStorageTexturesInVertexStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.
+In Core mode, at device creation, `maxStorageBuffersInVertexStage` is set to the effective limit for `maxStorageBuffersPerShaderStage` and, `maxStorageTexturesInVertexStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.
 
 **Justification**: OpenGL ES 3.1 allows `MAX_VERTEX_SHADER_STORAGE_BLOCKS` and `MAX_VERTEX_IMAGE_UNIFORMS` to be zero, and there are a significant number of devices in the field with that value.
 
 ## 19. Introduce new `maxStorageBuffersInFragmentStage` and `maxStorageTexturesInFragmentStage` limits.
 
-In `createBindGroupLayout`, `createPipelineLayout` and at pipeline creation time, if the number of bindings of type `storage_buffer` with visibility `FRAGMENT` bit true, exceeds the `maxStorageBuffersInFragmentStage` limit, a validation error will occur.
+In `createBindGroupLayout`, `createPipelineLayout` (including `"auto"` layout creation), if the number of bindings of type `storage_buffer` with visibility `FRAGMENT` bit true, exceeds the `maxStorageBuffersInFragmentStage` limit, a validation error will occur.
 
-In `createBindGroupLayout`, `createPipelineLayout` and at pipeline creation time, if the number of bindings of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` with visibility `FRAGMENT` bit true, exceeds the `maxStorageTexturesInFragmentStage` limit, a validation error will occur.
+In `createBindGroupLayout`, `createPipelineLayout` (including `"auto"` layout creation), if the number of bindings of type `texture_storage_1d`, `texture_storage_2d`, `texture_storage_2d_array` and `texture_storage_3d` with visibility `FRAGMENT` bit true, exceeds the `maxStorageTexturesInFragmentStage` limit, a validation error will occur.
 
-In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInFragmentStage` will default to the same value as `maxStorageBuffersPerShaderStage` and `maxStorageTexturesInFragmentStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
+In Compatibility mode, these new limits will have a default of zero. In Core mode, `maxStorageBuffersInFragmentStage` will default to the same value as `maxStorageBuffersPerShaderStage` and, `maxStorageTexturesInFragmentStage` will default to the same value as `maxStorageTexturesPerShaderStage`.
 
 In addition to the new limits, the existing `maxStorageBuffersPerShaderStage` and `maxStorageTexturesPerShaderStage` limits continue to apply to all stages. E.g., the effective storage buffer limit in the fragment stage is `min(maxStorageBuffersPerShaderStage, maxStorageBuffersInFragmentStage)`.
 
 In both Compatibility Mode and Core, at device creation time, if the requested limit for `maxStorageBuffersInFragmentStage` exceeds the effective limit for `maxStorageBuffersPerShaderStage` or if the requested limit for `maxStorageTexturesInFragmentStage` exceeds the effective limit for `maxStorageTexturePerShaderStage`  an `OperationError` is thrown.
 
-In Core mode, at device creation, both `maxStorageBuffersInFragmentStage` is set to the effective limit for `maxStorageBuffersPerShaderStage` and `maxStorageTexturesInFragmentStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.
+In Core mode, at device creation, both `maxStorageBuffersInFragmentStage` is set to the effective limit for `maxStorageBuffersPerShaderStage` and, `maxStorageTexturesInFragmentStage` is set to the effective limit for `maxStorageTexturesPerShaderStage`.
 
 **Justification**: OpenGL ES 3.1 allows `MAX_FRAGMENT_SHADER_STORAGE_BLOCKS` and `MAX_FRAGMENT_IMAGE_UNIFORMS` to be zero, and there are a significant number of devices in the field with that value.
 


### PR DESCRIPTION
Effectively, in both compat and core, requesting limits for `maxStorageBuffersInFragmentStage` and/or `maxStorageBuffersInVertexStage` that are greater than `maxStorageBuffersPerShaderStage` is an error.

Similarly, in both compat and core, requesting limit for `maxStorageTexturesInFragmentStage` and/or `maxStorageTexturesInVertexStage` that are greater than `maxStorageTexturesPerShaderStage` is an error.

Assume the adapter supports 16 of each:

```js
requiredLimits: {
  maxStorageBuffersInFragmentStage: 3,
}
```

In compat this return a device with

```js
limits: {
  maxStorageBuffersInFragmentStage: 3,
  maxStorageBuffersPerShaderStage: 4,   // the default in compat
}
```

In core it returns a device with

```js
limits: {
  maxStorageBuffersInFragmentStage: 8,
  maxStorageBuffersPerShaderStage: 8,   // the default in core
}
```

Another example:

```js
requiredLimits: {
  maxStorageBuffersInFragmentStage: 9,
  maxStorageBuffersPerShaderStage: 10,
}
```

In compat this return a device with

```js
limits: {
  maxStorageBuffersInFragmentStage: 9,
  maxStorageBuffersPerShaderStage: 10,
}
```

In core it returns a device with

```js
limits: {
  maxStorageBuffersInFragmentStage: 10,
  maxStorageBuffersPerShaderStage: 10,
}
```

This reflects what is actually enforced. Another option is to have core report the same as compat even though it would not enforce the `maxStorageXXXInXXXStage` limits.