### PR TITLE
Move Correspondence Reference from LD to UD, to fix CSS

### DIFF
--- a/correspondence/index.bs
+++ b/correspondence/index.bs
@@ -2,7 +2,7 @@
 Title: WebGPU Correspondence Reference
 Shortname: webgpu-correspondence
 Level: None
-Status: LD
+Status: UD
 Group: webgpu
 URL: https://gpuweb.github.io/gpuweb/correspondence/
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues">open issues</a>)


### PR DESCRIPTION
`Status: LD` is "Living Document", which makes sense but has broken CSS if used with `Group: webgpu`. If not used with `Group: webgpu`, then the license is CC0 (Public Domain) which is probably fine but not really appropriate.

`Status: UD` is "Unofficial Proposal Draft", which is not really what I would call this document, but it renders correctly :)

Any other status causes an error message saying something like: `You used Status NOTE, but your Group (WEBGPU) is limited to the statuses CG-DRAFT, CG-FINAL, or UD.` (Probably LD isn't supposed to be used either and that's why it's broken.)

Documentation: https://speced.github.io/bikeshed/#metadata