### PR TITLE
Add placeholder Deadlines to specs as a workaround for Bikeshed problem

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -21,7 +21,9 @@ Markup Shorthands: dfn yes
 Markup Shorthands: idl yes
 Markup Shorthands: css no
 Assume Explicit For: yes
+Deadline: 1111-11-11
 </pre>
+<!-- TODO(https://github.com/speced/bikeshed/issues/3000): Deadline is a hack for a Bikeshed compile error. -->
 
 <pre class=link-defaults>
 spec:webidl; type:exception; text:TypeError

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -37,7 +37,9 @@ Markup Shorthands: biblio yes
 Markup Shorthands: idl yes
 Markup Shorthands: css no
 Assume Explicit For: yes
+Deadline: 1111-11-11
 </pre>
+<!-- TODO(https://github.com/speced/bikeshed/issues/3000): Deadline is a hack for a Bikeshed compile error. -->
 
 <style>
 tr:nth-child(2n) {


### PR DESCRIPTION
Presumably as a result of publishing CR snapshots at `w3.org/TR`, Bikeshed now refuses to build our drafts. For example on the WebGPU spec:

```
kainino@...:~/src/gpuweb/spec$ make

LINE 25:384 of status: Found unmatched text macro [ISODEADLINE] in datetime='...'. Correct the macro, or escape it by replacing the opening [ with &#91;.
LINE 25:395 of status: Found unmatched text macro [DEADLINE]. Correct the macro, or escape it by replacing the opening [ with &#91;
LINE 29:381 of status: Found unmatched text macro [ISODEADLINE] in datetime='...'. Correct the macro, or escape it by replacing the opening [ with &#91;.
LINE 29:392 of status: Found unmatched text macro [DEADLINE]. Correct the macro, or escape it by replacing the opening [ with &#91;
```

I don't know how to fix this properly, but this unblocks our presubmit.
Bikeshed issue: https://github.com/speced/bikeshed/issues/3000