### PR TITLE
Adjust metadata and workflow to resume publication to /TR

### DIFF
--- a/.github/workflows/publish-TR-webgpu.yml
+++ b/.github/workflows/publish-TR-webgpu.yml
@@ -34,4 +34,4 @@ jobs:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN_WEBGPU }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-gpu/2021Apr/0004.html
           W3C_BUILD_OVERRIDE: |
-            status: WD
+            status: CRD

--- a/.github/workflows/publish-TR-wgsl.yml
+++ b/.github/workflows/publish-TR-wgsl.yml
@@ -34,4 +34,4 @@ jobs:
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN_WGSL }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-gpu/2021Apr/0004.html
           W3C_BUILD_OVERRIDE: |
-            status: WD
+            status: CRD

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8,6 +8,7 @@ ED: https://gpuweb.github.io/gpuweb/
 TR: https://www.w3.org/TR/webgpu/
 Repository: gpuweb/gpuweb
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues">open issues</a>)
+!Test Suite: <a href="https://github.com/gpuweb/cts">WebGPU CTS</a>
 
 Editor: Kai Ninomiya, Google https://www.google.com, kainino@google.com, w3cid 99487
 Editor: Brandon Jones, Google https://www.google.com, bajones@google.com, w3cid 87824
@@ -21,9 +22,8 @@ Markup Shorthands: dfn yes
 Markup Shorthands: idl yes
 Markup Shorthands: css no
 Assume Explicit For: yes
-Deadline: 1111-11-11
+Deadline: 2025-02-28
 </pre>
-<!-- TODO(https://github.com/speced/bikeshed/issues/3000): Deadline is a hack for a Bikeshed compile error. -->
 
 <pre class=link-defaults>
 spec:webidl; type:exception; text:TypeError

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -24,7 +24,7 @@ Text Macro: NINF &minus;&infin;
 Ignored Vars: i, c0, e, e1, e2, e3, edge, eN, p, s1, s2, sn, AS, AM, N, newbits, M, C, R, v, Stride, Offset, Align, Extent, T, T1, E, S, F, x, y, a, b
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
-!Tests: <a href=https://github.com/gpuweb/cts/tree/main/src/webgpu/shader/>WebGPU CTS shader/</a>
+!Test Suite: <a href=https://github.com/gpuweb/cts/tree/main/src/webgpu/shader/>WebGPU CTS shader/</a>
 
 Editor: Alan Baker, Google https://www.google.com, alanbaker@google.com, w3cid 129277
 Editor: Mehmet Oguz Derin, mehmetoguzderin@mehmetoguzderin.com, w3cid 101130
@@ -37,9 +37,8 @@ Markup Shorthands: biblio yes
 Markup Shorthands: idl yes
 Markup Shorthands: css no
 Assume Explicit For: yes
-Deadline: 1111-11-11
+Deadline: 2025-02-28
 </pre>
-<!-- TODO(https://github.com/speced/bikeshed/issues/3000): Deadline is a hack for a Bikeshed compile error. -->
 
 <style>
 tr:nth-child(2n) {


### PR DESCRIPTION
New spec drafts need to be published as "Candidate Recommendation Drafts". This status requires a deadline date to be specified. That deadline could be set as a `W3C_BUILD_OVERRIDE` parameter in the workflow, but then it's inherent to the specs, so it seems good to have it defined in the source directly. (That information is not useful for the Editor's Draft in theory, but also needed in practice since Bikeshed replaces all macro texts in the boilerplate before it drops the bits that aren't needed).

The update also adds a link to the test suite in WebGPU and renames "Tests" into "Test Suite" in WGSL (usual name across specs).

NB: I'll add the secret tokens once that PR gets merged to effectively resume publication to /TR.