### PR TITLE
Allow `index < limits.maxBindGroups` in `getBindGroupLayout()`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7227,6 +7227,7 @@ interface mixin GPUPipelineBase {
             <div data-timeline=device>
                 [=Device timeline=] |initialization steps|:
 
+                1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                 1. If any of the following conditions are unsatisfied
                     [$generate a validation error$], [$invalidate$] |layout| and return.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6590,9 +6590,11 @@ pipeline, and have the following members:
                 [=Device timeline=] |initialization steps|:
 
                 1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
-                1. Let |bindGroupLayouts| be a copy of |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
-                1. For each |i| in the [=list/get the indices|indices=] of |bindGroupLayouts|:
-                    1. If |bindGroupLayouts|[|i|] is not `null` and
+                1. Let |bindGroupLayouts| be a [=list=] of `null` {{GPUBindGroupLayout}}s with [=list/size=]
+                     equal to |limits|.{{supported limits/maxBindGroups}}.
+                1. For each |i| in the [=list/get the indices|indices=] of |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}:
+                    1. Set |bindGroupLayouts|[|i|] to ||descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}|[|i|].
+                    1. If |bindGroupLayouts|[|i|] is `undefined` or |bindGroupLayouts|[|i|] is not `null` and
                         |bindGroupLayouts|[|i|].{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
                         is [=list/empty=], set |bindGroupLayouts|[|i|] to `null`.
                 1. Let |allEntries| be the result of concatenating
@@ -7230,8 +7232,7 @@ interface mixin GPUPipelineBase {
 
                     <div class=validusage>
                         - |this| must be [$valid$].
-                        - |index| &lt; the [=list/size=] of
-                            |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}
+                        - |index| &lt; |limits|.{{supported limits/maxBindGroups}}.
                     </div>
 
                 1. Initialize |layout| so it is a copy of

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6622,11 +6622,11 @@ pipeline, and have the following members:
                 1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                 1. Let |bindGroupLayouts| be a [=list=] of `null` {{GPUBindGroupLayout}}s with [=list/size=]
                      equal to |limits|.{{supported limits/maxBindGroups}}.
-                1. For each |i| in the [=list/get the indices|indices=] of |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}:
-                    1. Set |bindGroupLayouts|[|i|] to ||descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}|[|i|].
-                    1. If |bindGroupLayouts|[|i|] is `undefined` or |bindGroupLayouts|[|i|] is not `null` and
-                        |bindGroupLayouts|[|i|].{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
-                        is [=list/empty=], set |bindGroupLayouts|[|i|] to `null`.
+                1. [=list/For each=] |bindGroupLayout| at index |i| in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}:
+                    1. If |bindGroupLayout| is not `null` and
+                        |bindGroupLayout|.{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
+                        is not [=list/empty=]:
+                        1. Set |bindGroupLayouts|[|i|] to |bindGroupLayout|.
                 1. Let |allEntries| be the result of concatenating
                     |bgl|.{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
                     for all non-`null` |bgl| in |bindGroupLayouts|.


### PR DESCRIPTION
This patch relaxes the check on the parameter `index` in `getBindGroupLayout()` by allowing `index < limits.maxBindGroups` instead of only limiting `index` must be less than the array size of the bind group layouts used in the creation of the pipeline.