### PR TITLE
wgsl: further clarify override expr evaluation only if in the shader

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5331,19 +5331,22 @@ An expression is an override-expression if all its [=identifiers=] [=resolve=] t
 
 Note: All [=const-expressions=] are also override-expressions.
 
-Override-expressions are only validated or evaluated after any API-provided
+Override-expressions other than const-expressions are only validated or evaluated 
+during [=pipeline creation=], and only after any API-provided
 values are substituted for [=override-declarations=].
 If an [=override-declaration=] has its value substituted via the API, its
 initializer expression, if present, will not be evaluated.
 Otherwise, an override-expression |E| [=behavioral requirement|will=] be
 evaluated if and only if:
-* |E| is [=top-level expression=] (after value substitution),
-* |E| is a [=subexpression=] of an expression |OuterE|, and |OuterE|
-    [=behavioral requirement|will=] be evaluated, and evaluation of |OuterE|
-    requires |E| to be evaluated, or
-* |E| is a [=subexpression=] of an expression |OuterE| such that |OuterE| requires
-    |E| to be evaluated to produce a [=pipeline-creation error=]
-    (e.g. [[#arithmetic-expr|integer division]]).
+* |E| forms part of the [=shader=] for the [=entry point=] specified by the {{GPUProgrammableStage}}, and:
+* Any of the following are true:
+    * |E| is [=top-level expression=] (after value substitution), or
+    * |E| is a [=subexpression=] of an expression |OuterE|, and |OuterE|
+        [=behavioral requirement|will=] be evaluated, and evaluation of |OuterE|
+        requires |E| to be evaluated, or
+    * |E| is a [=subexpression=] of an expression |OuterE| such that |OuterE| requires
+        |E| to be evaluated to produce a [=pipeline-creation error=]
+        (e.g. [[#arithmetic-expr|integer division]]).
 
 Note: Not all override-expressions may be usable as the initializer for an
 [=override-declaration=], because such initializers must [=type rules|resolve=]


### PR DESCRIPTION
Reinforces the fix to #4648