### PR TITLE
Fix API spec build errors

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -23,6 +23,7 @@ Markup Shorthands: idl yes
 Markup Shorthands: css no
 Assume Explicit For: yes
 Deadline: 2025-02-28
+Ignored Vars: message, options, descriptor, index, groupLabel, baseVertex, reference, filter
 </pre>
 
 <pre class=link-defaults>
@@ -2298,7 +2299,7 @@ interface GPU {
                 **Arguments:**
 
                 <pre class=argumentdef for="GPU/requestAdapter(options)">
-                    |options|: Criteria used to select the adapter.
+                    options: Criteria used to select the adapter.
                 </pre>
 
                 **Returns:** {{Promise}}&lt;{{GPUAdapter}}?&gt;
@@ -2662,7 +2663,7 @@ interface GPUAdapter {
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUAdapter/requestDevice(descriptor)">
-                    |descriptor|: Description of the {{GPUDevice}} to request.
+                    descriptor: Description of the {{GPUDevice}} to request.
                 </pre>
 
                 **Returns:** {{Promise}}&lt;{{GPUDevice}}&gt;
@@ -3420,7 +3421,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createBuffer(descriptor)">
-                    |descriptor|: Description of the {{GPUBuffer}} to create.
+                    descriptor: Description of the {{GPUBuffer}} to create.
                 </pre>
 
                 **Returns:** {{GPUBuffer}}
@@ -3625,9 +3626,9 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUBuffer/mapAsync(mode, offset, size)">
-                    |mode|: Whether the buffer should be mapped for reading or writing.
-                    |offset|: Offset in bytes into the buffer to the start of the range to map.
-                    |size|: Size in bytes of the range to map.
+                    mode: Whether the buffer should be mapped for reading or writing.
+                    offset: Offset in bytes into the buffer to the start of the range to map.
+                    size: Size in bytes of the range to map.
                 </pre>
 
                 **Returns:** {{Promise}}&lt;{{undefined}}&gt;
@@ -3782,8 +3783,8 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUBuffer/getMappedRange(offset, size)">
-                    |offset|: Offset in bytes into the buffer to return buffer contents from.
-                    |size|: Size in bytes of the {{ArrayBuffer}} to return.
+                    offset: Offset in bytes into the buffer to return buffer contents from.
+                    size: Size in bytes of the {{ArrayBuffer}} to return.
                 </pre>
 
                 **Returns:** {{ArrayBuffer}}
@@ -4299,7 +4300,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createTexture(descriptor)">
-                    |descriptor|: Description of the {{GPUTexture}} to create.
+                    descriptor: Description of the {{GPUTexture}} to create.
                 </pre>
 
                 **Returns:** {{GPUTexture}}
@@ -4739,7 +4740,7 @@ enum GPUTextureAspect {
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUTexture/createView(descriptor)">
-                    |descriptor|: Description of the {{GPUTextureView}} to create.
+                    descriptor: Description of the {{GPUTextureView}} to create.
                 </pre>
 
                 **Returns:** |view|, of type {{GPUTextureView}}.
@@ -5268,7 +5269,7 @@ dictionary GPUExternalTextureDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/importExternalTexture(descriptor)">
-                    |descriptor|: Provides the external image source object (and any creation options).
+                    descriptor: Provides the external image source object (and any creation options).
                 </pre>
 
                 **Returns:** {{GPUExternalTexture}}
@@ -5643,7 +5644,7 @@ enum GPUCompareFunction {
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createSampler(descriptor)">
-                    |descriptor|: Description of the {{GPUSampler}} to create.
+                    descriptor: Description of the {{GPUSampler}} to create.
                 </pre>
 
                 **Returns:** {{GPUSampler}}
@@ -6113,7 +6114,7 @@ A {{GPUBindGroupLayout}} object has the following [=device timeline properties=]
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createBindGroupLayout(descriptor)">
-                    |descriptor|: Description of the {{GPUBindGroupLayout}} to create.
+                    descriptor: Description of the {{GPUBindGroupLayout}} to create.
                 </pre>
 
                 **Returns:** {{GPUBindGroupLayout}}
@@ -6357,7 +6358,7 @@ following members:
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createBindGroup(descriptor)">
-                    |descriptor|: Description of the {{GPUBindGroup}} to create.
+                    descriptor: Description of the {{GPUBindGroup}} to create.
                 </pre>
 
                 **Returns:** {{GPUBindGroup}}
@@ -6606,7 +6607,7 @@ pipeline, and have the following members:
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createPipelineLayout(descriptor)">
-                    |descriptor|: Description of the {{GPUPipelineLayout}} to create.
+                    descriptor: Description of the {{GPUPipelineLayout}} to create.
                 </pre>
 
                 **Returns:** {{GPUPipelineLayout}}
@@ -6773,7 +6774,7 @@ dictionary GPUShaderModuleDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createShaderModule(descriptor)">
-                    |descriptor|: Description of the {{GPUShaderModule}} to create.
+                    descriptor: Description of the {{GPUShaderModule}} to create.
                 </pre>
 
                 **Returns:** {{GPUShaderModule}}
@@ -7151,8 +7152,8 @@ enum GPUPipelineErrorReason {
             **Arguments:**
 
             <pre class=argumentdef for="GPUPipelineError/constructor()">
-                |message|: Error message of the base {{DOMException}}.
-                |options|: Options specific to {{GPUPipelineError}}.
+                message: Error message of the base {{DOMException}}.
+                options: Options specific to {{GPUPipelineError}}.
             </pre>
 
             [=Content timeline=] steps:
@@ -7243,7 +7244,7 @@ interface mixin GPUPipelineBase {
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUPipelineBase/getBindGroupLayout(index)">
-                    |index|: Index into the pipeline layout's {{GPUPipelineLayout/[[bindGroupLayouts]]}}
+                    index: Index into the pipeline layout's {{GPUPipelineLayout/[[bindGroupLayouts]]}}
                         sequence.
                 </pre>
 
@@ -7836,7 +7837,7 @@ dictionary GPUComputePipelineDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createComputePipeline(descriptor)">
-                    |descriptor|: Description of the {{GPUComputePipeline}} to create.
+                    descriptor: Description of the {{GPUComputePipeline}} to create.
                 </pre>
 
                 **Returns:** {{GPUComputePipeline}}
@@ -7911,7 +7912,7 @@ dictionary GPUComputePipelineDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createComputePipelineAsync(descriptor)">
-                    |descriptor|: Description of the {{GPUComputePipeline}} to create.
+                    descriptor: Description of the {{GPUComputePipeline}} to create.
                 </pre>
 
                 **Returns:** {{Promise}}&lt;{{GPUComputePipeline}}&gt;
@@ -8100,7 +8101,7 @@ dictionary GPURenderPipelineDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createRenderPipeline(descriptor)">
-                    |descriptor|: Description of the {{GPURenderPipeline}} to create.
+                    descriptor: Description of the {{GPURenderPipeline}} to create.
                 </pre>
 
                 **Returns:** {{GPURenderPipeline}}
@@ -8187,7 +8188,7 @@ dictionary GPURenderPipelineDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createRenderPipelineAsync(descriptor)">
-                    |descriptor|: Description of the {{GPURenderPipeline}} to create.
+                    descriptor: Description of the {{GPURenderPipeline}} to create.
                 </pre>
 
                 **Returns:** {{Promise}}&lt;{{GPURenderPipeline}}&gt;
@@ -9966,7 +9967,7 @@ dictionary GPUCommandEncoderDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createCommandEncoder(descriptor)">
-                    |descriptor|: Description of the {{GPUCommandEncoder}} to create.
+                    descriptor: Description of the {{GPUCommandEncoder}} to create.
                 </pre>
 
                 **Returns:** {{GPUCommandEncoder}}
@@ -10016,7 +10017,7 @@ dictionary GPUCommandEncoderDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUCommandEncoder/beginRenderPass(descriptor)">
-                    |descriptor|: Description of the {{GPURenderPassEncoder}} to create.
+                    descriptor: Description of the {{GPURenderPassEncoder}} to create.
                 </pre>
 
                 **Returns:** {{GPURenderPassEncoder}}
@@ -10267,11 +10268,11 @@ dictionary GPUCommandEncoderDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUCommandEncoder/copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size)">
-                    |source|: The {{GPUBuffer}} to copy from.
-                    |sourceOffset|: Offset in bytes into |source| to begin copying from.
-                    |destination|: The {{GPUBuffer}} to copy to.
-                    |destinationOffset|: Offset in bytes into |destination| to place the copied data.
-                    |size|: Bytes to copy.
+                    source: The {{GPUBuffer}} to copy from.
+                    sourceOffset: Offset in bytes into |source| to begin copying from.
+                    destination: The {{GPUBuffer}} to copy to.
+                    destinationOffset: Offset in bytes into |destination| to place the copied data.
+                    size: Bytes to copy.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -10323,9 +10324,9 @@ dictionary GPUCommandEncoderDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUCommandEncoder/clearBuffer(buffer, offset, size)">
-                    |buffer|: The {{GPUBuffer}} to clear.
-                    |offset|: Offset in bytes into |buffer| where the sub-region to clear begins.
-                    |size|: Size in bytes of the sub-region to clear. Defaults to the size of the buffer minus |offset|.
+                    buffer: The {{GPUBuffer}} to clear.
+                    offset: Offset in bytes into |buffer| where the sub-region to clear begins.
+                    size: Size in bytes of the sub-region to clear. Defaults to the size of the buffer minus |offset|.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -10379,9 +10380,9 @@ dictionary GPUCommandEncoderDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUCommandEncoder/copyBufferToTexture(source, destination, copySize)">
-                    |source|: Combined with |copySize|, defines the region of the source buffer.
-                    |destination|: Combined with |copySize|, defines the region of the destination [=texture subresource=].
-                    |copySize|:
+                    source: Combined with |copySize|, defines the region of the source buffer.
+                    destination: Combined with |copySize|, defines the region of the destination [=texture subresource=].
+                    copySize:
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -10452,9 +10453,9 @@ dictionary GPUCommandEncoderDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUCommandEncoder/copyTextureToBuffer(source, destination, copySize)">
-                    |source|: Combined with |copySize|, defines the region of the source [=texture subresources=].
-                    |destination|: Combined with |copySize|, defines the region of the destination buffer.
-                    |copySize|:
+                    source: Combined with |copySize|, defines the region of the source [=texture subresources=].
+                    destination: Combined with |copySize|, defines the region of the destination buffer.
+                    copySize:
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -10526,9 +10527,9 @@ dictionary GPUCommandEncoderDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUCommandEncoder/copyTextureToTexture(source, destination, copySize)">
-                    |source|: Combined with |copySize|, defines the region of the source [=texture subresources=].
-                    |destination|: Combined with |copySize|, defines the region of the destination [=texture subresources=].
-                    |copySize|:
+                    source: Combined with |copySize|, defines the region of the source [=texture subresources=].
+                    destination: Combined with |copySize|, defines the region of the destination [=texture subresources=].
+                    copySize:
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -10845,15 +10846,15 @@ It must only be included by interfaces which also include those mixins.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)">
-                    |index|: The index to set the bind group at.
-                    |bindGroup|: Bind group to use for subsequent render or compute commands.
-                    |dynamicOffsetsData|: Array containing buffer offsets in bytes for each entry in
+                    index: The index to set the bind group at.
+                    bindGroup: Bind group to use for subsequent render or compute commands.
+                    dynamicOffsetsData: Array containing buffer offsets in bytes for each entry in
                         |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}},
                         ordered by {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}.
                         See [note](#dynamicOffsetOrder) for additional details.
-                    |dynamicOffsetsDataStart|: Offset in elements into |dynamicOffsetsData| where the
+                    dynamicOffsetsDataStart: Offset in elements into |dynamicOffsetsData| where the
                         buffer offset data begins.
-                    |dynamicOffsetsDataLength|: Number of buffer offsets to read from |dynamicOffsetsData|.
+                    dynamicOffsetsDataLength: Number of buffer offsets to read from |dynamicOffsetsData|.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -11107,7 +11108,7 @@ It must only be included by interfaces which also include those mixins.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDebugCommandsMixin/pushDebugGroup(groupLabel)">
-                    |groupLabel|: The label for the command group.
+                    groupLabel: The label for the command group.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -11276,7 +11277,7 @@ dictionary GPUComputePassDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUComputePassEncoder/setPipeline(pipeline)">
-                    |pipeline|: The compute pipeline to use for subsequent dispatch commands.
+                    pipeline: The compute pipeline to use for subsequent dispatch commands.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -11311,9 +11312,9 @@ dictionary GPUComputePassDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUComputePassEncoder/dispatchWorkgroups(workgroupCountX, workgroupCountY, workgroupCountZ)">
-                    |workgroupCountX|: X dimension of the grid of workgroups to dispatch.
-                    |workgroupCountY|: Y dimension of the grid of workgroups to dispatch.
-                    |workgroupCountZ|: Z dimension of the grid of workgroups to dispatch.
+                    workgroupCountX: X dimension of the grid of workgroups to dispatch.
+                    workgroupCountY: Y dimension of the grid of workgroups to dispatch.
+                    workgroupCountZ: Z dimension of the grid of workgroups to dispatch.
                 </pre>
 
                 <div class=note heading>
@@ -11393,8 +11394,8 @@ dictionary GPUComputePassDescriptor
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUComputePassEncoder/dispatchWorkgroupsIndirect(indirectBuffer, indirectOffset)">
-                    |indirectBuffer|: Buffer containing the [=indirect dispatch parameters=].
-                    |indirectOffset|: Offset in bytes into |indirectBuffer| where the dispatch data begins.
+                    indirectBuffer: Buffer containing the [=indirect dispatch parameters=].
+                    indirectOffset: Offset in bytes into |indirectBuffer| where the dispatch data begins.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -12364,7 +12365,7 @@ It must only be included by interfaces which also include those mixins.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderCommandsMixin/setPipeline(pipeline)">
-                    |pipeline|: The render pipeline to use for subsequent drawing commands.
+                    pipeline: The render pipeline to use for subsequent drawing commands.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -12404,10 +12405,10 @@ It must only be included by interfaces which also include those mixins.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderCommandsMixin/setIndexBuffer(buffer, indexFormat, offset, size)">
-                    |buffer|: Buffer containing index data to use for subsequent drawing commands.
-                    |indexFormat|: Format of the index data contained in |buffer|.
-                    |offset|: Offset in bytes into |buffer| where the index data begins. Defaults to `0`.
-                    |size|: Size in bytes of the index data in |buffer|.
+                    buffer: Buffer containing index data to use for subsequent drawing commands.
+                    indexFormat: Format of the index data contained in |buffer|.
+                    offset: Offset in bytes into |buffer| where the index data begins. Defaults to `0`.
+                    size: Size in bytes of the index data in |buffer|.
                         Defaults to the size of the buffer minus the offset.
                 </pre>
 
@@ -12450,10 +12451,10 @@ It must only be included by interfaces which also include those mixins.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderCommandsMixin/setVertexBuffer(slot, buffer, offset, size)">
-                    |slot|: The vertex buffer slot to set the vertex buffer for.
-                    |buffer|: Buffer containing vertex data to use for subsequent drawing commands.
-                    |offset|: Offset in bytes into |buffer| where the vertex data begins. Defaults to `0`.
-                    |size|: Size in bytes of the vertex data in |buffer|.
+                    slot: The vertex buffer slot to set the vertex buffer for.
+                    buffer: Buffer containing vertex data to use for subsequent drawing commands.
+                    offset: Offset in bytes into |buffer| where the vertex data begins. Defaults to `0`.
+                    size: Size in bytes of the vertex data in |buffer|.
                         Defaults to the size of the buffer minus the offset.
                 </pre>
 
@@ -12508,10 +12509,10 @@ It must only be included by interfaces which also include those mixins.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderCommandsMixin/draw(vertexCount, instanceCount, firstVertex, firstInstance)">
-                    |vertexCount|: The number of vertices to draw.
-                    |instanceCount|: The number of instances to draw.
-                    |firstVertex|: Offset into the vertex buffers, in vertices, to begin drawing from.
-                    |firstInstance|: First instance to draw.
+                    vertexCount: The number of vertices to draw.
+                    instanceCount: The number of instances to draw.
+                    firstVertex: Offset into the vertex buffers, in vertices, to begin drawing from.
+                    firstInstance: First instance to draw.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -12576,11 +12577,11 @@ It must only be included by interfaces which also include those mixins.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderCommandsMixin/drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)">
-                    |indexCount|: The number of indices to draw.
-                    |instanceCount|: The number of instances to draw.
-                    |firstIndex|: Offset into the index buffer, in indices, begin drawing from.
-                    |baseVertex|: Added to each index value before indexing into the vertex buffers.
-                    |firstInstance|: First instance to draw.
+                    indexCount: The number of indices to draw.
+                    instanceCount: The number of instances to draw.
+                    firstIndex: Offset into the index buffer, in indices, begin drawing from.
+                    baseVertex: Added to each index value before indexing into the vertex buffers.
+                    firstInstance: First instance to draw.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -12662,8 +12663,8 @@ It must only be included by interfaces which also include those mixins.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderCommandsMixin/drawIndirect(indirectBuffer, indirectOffset)">
-                    |indirectBuffer|: Buffer containing the [=indirect draw parameters=].
-                    |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
+                    indirectBuffer: Buffer containing the [=indirect draw parameters=].
+                    indirectOffset: Offset in bytes into |indirectBuffer| where the drawing data begins.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -12744,8 +12745,8 @@ It must only be included by interfaces which also include those mixins.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderCommandsMixin/drawIndexedIndirect(indirectBuffer, indirectOffset)">
-                    |indirectBuffer|: Buffer containing the [=indirect drawIndexed parameters=].
-                    |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
+                    indirectBuffer: Buffer containing the [=indirect drawIndexed parameters=].
+                    indirectOffset: Offset in bytes into |indirectBuffer| where the drawing data begins.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -12857,12 +12858,12 @@ attachments used by this encoder.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderPassEncoder/setViewport(x, y, width, height, minDepth, maxDepth)">
-                    |x|: Minimum X value of the viewport in pixels.
-                    |y|: Minimum Y value of the viewport in pixels.
-                    |width|: Width of the viewport in pixels.
-                    |height|: Height of the viewport in pixels.
-                    |minDepth|: Minimum depth value of the viewport.
-                    |maxDepth|: Maximum depth value of the viewport.
+                    x: Minimum X value of the viewport in pixels.
+                    y: Minimum Y value of the viewport in pixels.
+                    width: Width of the viewport in pixels.
+                    height: Height of the viewport in pixels.
+                    minDepth: Minimum depth value of the viewport.
+                    maxDepth: Maximum depth value of the viewport.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -12914,10 +12915,10 @@ attachments used by this encoder.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderPassEncoder/setScissorRect(x, y, width, height)">
-                    |x|: Minimum X value of the scissor rectangle in pixels.
-                    |y|: Minimum Y value of the scissor rectangle in pixels.
-                    |width|: Width of the scissor rectangle in pixels.
-                    |height|: Height of the scissor rectangle in pixels.
+                    x: Minimum X value of the scissor rectangle in pixels.
+                    y: Minimum Y value of the scissor rectangle in pixels.
+                    width: Width of the scissor rectangle in pixels.
+                    height: Height of the scissor rectangle in pixels.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -12962,7 +12963,7 @@ attachments used by this encoder.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderPassEncoder/setBlendConstant(color)">
-                    |color|: The color to use when blending.
+                    color: The color to use when blending.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -12999,7 +13000,7 @@ attachments used by this encoder.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderPassEncoder/setStencilReference(reference)">
-                    |reference|: The new stencil reference value.
+                    reference: The new stencil reference value.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -13036,7 +13037,7 @@ attachments used by this encoder.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderPassEncoder/beginOcclusionQuery(queryIndex)">
-                    |queryIndex|: The index of the query in the query set.
+                    queryIndex: The index of the query in the query set.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -13135,7 +13136,7 @@ attachments used by this encoder.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPURenderPassEncoder/executeBundles(bundles)">
-                    |bundles|: List of render bundles to execute.
+                    bundles: List of render bundles to execute.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -13270,7 +13271,7 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/createRenderBundleEncoder(descriptor)">
-                    |descriptor|: Description of the {{GPURenderBundleEncoder}} to create.
+                    descriptor: Description of the {{GPURenderBundleEncoder}} to create.
                 </pre>
 
                 **Returns:** {{GPURenderBundleEncoder}}
@@ -13456,12 +13457,12 @@ GPUQueue includes GPUObjectBase;
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUQueue/writeBuffer(buffer, bufferOffset, data, dataOffset, size)">
-                    |buffer|: The buffer to write to.
-                    |bufferOffset|: Offset in bytes into |buffer| to begin writing at.
-                    |data|: Data to write into |buffer|.
-                    |dataOffset|: Offset in into |data| to begin writing from. Given in elements if
+                    buffer: The buffer to write to.
+                    bufferOffset: Offset in bytes into |buffer| to begin writing at.
+                    data: Data to write into |buffer|.
+                    dataOffset: Offset in into |data| to begin writing from. Given in elements if
                         |data| is a `TypedArray` and bytes otherwise.
-                    |size|: Size of content to write from |data| to |buffer|. Given in elements if
+                    size: Size of content to write from |data| to |buffer|. Given in elements if
                         |data| is a `TypedArray` and bytes otherwise.
                 </pre>
 
@@ -13521,10 +13522,10 @@ GPUQueue includes GPUObjectBase;
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUQueue/writeTexture(destination, data, dataLayout, size)">
-                    |destination|: The [=texture subresource=] and origin to write to.
-                    |data|: Data to write into |destination|.
-                    |dataLayout|: Layout of the content in |data|.
-                    |size|: Extents of the content to write from |data| to |destination|.
+                    destination: The [=texture subresource=] and origin to write to.
+                    data: Data to write into |destination|.
+                    dataLayout: Layout of the content in |data|.
+                    size: Extents of the content to write from |data| to |destination|.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -13626,9 +13627,9 @@ GPUQueue includes GPUObjectBase;
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUQueue/copyExternalImageToTexture(source, destination, copySize)">
-                    |source|: source image and origin to copy to |destination|.
-                    |destination|: The [=texture subresource=] and origin to write to, and its encoding metadata.
-                    |copySize|: Extents of the content to write from |source| to |destination|.
+                    source: source image and origin to copy to |destination|.
+                    destination: The [=texture subresource=] and origin to write to, and its encoding metadata.
+                    copySize: Extents of the content to write from |source| to |destination|.
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -13728,7 +13729,7 @@ GPUQueue includes GPUObjectBase;
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUQueue/submit(commandBuffers)">
-                    |commandBuffers|:
+                    commandBuffers:
                 </pre>
 
                 **Returns:** {{undefined}}
@@ -14194,7 +14195,7 @@ interface GPUCanvasContext {
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUCanvasContext/configure(configuration)">
-                    |configuration|: Desired configuration for the context.
+                    configuration: Desired configuration for the context.
                 </pre>
 
                 **Returns:** undefined
@@ -15072,7 +15073,7 @@ partial interface GPUDevice {
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUDevice/pushErrorScope(filter)">
-                    |filter|: Which class of errors this error scope observes.
+                    filter: Which class of errors this error scope observes.
                 </pre>
 
                 **Returns:** {{undefined}}


### PR DESCRIPTION
This PR aims to fix the remaining errors in the API spec. The `|var|` style for arguments causes Bikeshed to complaint, so instead the initial defintions are plain `var`, and the once used variables are added to ignore at the top rather than going `<var>` path. If there's any way to make the changes better for long-term maintenance, I'd be glad for your review(s). In case this PR fixes the build issue, it might be good to re-enforce the branch protections to be strict.