### PR TITLE
Add GPUTextureView support to importExternalTexture()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5299,7 +5299,30 @@ dictionary GPUExternalTextureDescriptor
 
                     Otherwise:
 
-                    1. If |source| is not an {{GPUTextureView}}:
+                    1. If |source| is a {{GPUTextureView}}:
+
+                        1. If any of the following conditions are unsatisfied
+                            [$generate a validation error$] and return an [$invalidated$] {{GPUExternalTexture}}.
+
+                            <div class=validusage>
+                                - Let |sourceDescriptor| be |source|.{{GPUTextureView/[[descriptor]]}}.
+                                - |sourceDescriptor|.{{GPUTextureViewDescriptor/usage}}
+                                    includes {{GPUTextureUsage/TEXTURE_BINDING}}.
+                                - |sourceDescriptor|.{{GPUTextureViewDescriptor/dimension}}
+                                    is {{GPUTextureViewDimension/"2d"}}.
+                                - |sourceDescriptor|.{{GPUTextureViewDescriptor/mipLevelCount}}
+                                    is 1.
+                                - |sourceDescriptor|.{{GPUTextureViewDescriptor/format}}
+                                    is listed in [[#plain-color-formats]] table.
+                                - |sourceDescriptor|.{{GPUTextureViewDescriptor/format}}
+                                    is a [=filterable format=].
+                                - |sourceDescriptor|.{{GPUTextureViewDescriptor/format}}
+                                    has 4 color channels.
+                                - |source|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}
+                                    is 1.
+                            </div>
+
+                        Otherwise
 
                         1. If |source| <l spec=html>[=is not origin-clean=]</l>,
                             throw a {{SecurityError}} and return.
@@ -6490,28 +6513,6 @@ following members:
                                     ::
                                         - |resource| is a {{GPUExternalTexture}}.
                                         - |resource| is [$valid to use with$] |this|.
-                                        - Let |source| be |resource|.{{GPUExternalTexture/[[descriptor]]}}.{{GPUExternalTextureDescriptor/source}}.
-                                        - If |source| is
-
-                                            <dl class=switch>
-                                                : {{GPUTextureView}}
-                                                ::
-                                                    - Let |sourceDescriptor| be |source|.{{GPUTextureView/[[descriptor]]}}.
-                                                    - |sourceDescriptor|.{{GPUTextureViewDescriptor/usage}}
-                                                        includes {{GPUTextureUsage/TEXTURE_BINDING}}.
-                                                    - |sourceDescriptor|.{{GPUTextureViewDescriptor/dimension}}
-                                                        is {{GPUTextureViewDimension/"2d"}}.
-                                                    - |sourceDescriptor|.{{GPUTextureViewDescriptor/mipLevelCount}}
-                                                        is 1.
-                                                    - |sourceDescriptor|.{{GPUTextureViewDescriptor/format}}
-                                                        is listed in [[#plain-color-formats]] table.
-                                                    - |sourceDescriptor|.{{GPUTextureViewDescriptor/format}}
-                                                        is a [=filterable format=].
-                                                    - |sourceDescriptor|.{{GPUTextureViewDescriptor/format}}
-                                                        has 4 color channels.
-                                                    - |source|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}
-                                                        is 1.
-                                            </dl>
                                 </dl>
                     </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5149,7 +5149,7 @@ See [[#texture-format-caps]] for information about which {{GPUTextureFormat}}s r
 <span id=gpu-external-texture></span>
 </h3>
 
-A {{GPUExternalTexture}} is a sampleable 2D texture wrapping an external video object.
+A {{GPUExternalTexture}} is a sampleable 2D texture that can wrap an external video object.
 The contents of a {{GPUExternalTexture}} object are a snapshot and may not change, either from inside WebGPU
 (it is only sampleable) or from outside WebGPU (e.g. due to video frame advancement).
 
@@ -5209,8 +5209,11 @@ GPUExternalTexture includes GPUObjectBase;
 
 ### Importing External Textures ### {#external-texture-creation}
 
-An external texture is created from an external video object
+An external texture is created from an external video object or a texture view
 using {{GPUDevice/importExternalTexture()}}.
+
+An external texture created from an {{GPUTextureView}} expires (is destroyed) automatically when
+the texture into which this is a view is destroyed.
 
 An external texture created from an {{HTMLVideoElement}} expires (is destroyed) automatically in a
 task after it is imported, instead of manually or upon garbage collection like other resources.
@@ -5237,7 +5240,7 @@ If the same object is returned again, it will compare equal, and {{GPUBindGroup}
 <script type=idl>
 dictionary GPUExternalTextureDescriptor
          : GPUObjectDescriptorBase {
-    required (HTMLVideoElement or VideoFrame) source;
+    required (GPUTextureView or HTMLVideoElement or VideoFrame) source;
     PredefinedColorSpace colorSpace = "srgb";
 };
 </script>
@@ -5247,7 +5250,7 @@ dictionary GPUExternalTextureDescriptor
 <dl dfn-type=dict-member dfn-for=GPUExternalTextureDescriptor>
     : <dfn>source</dfn>
     ::
-        The video source to import the external texture from. Source size is determined as described
+        The source to import the external texture from. Source size is determined as described
         by the [=external source dimensions=] table.
 
     : <dfn>colorSpace</dfn>
@@ -5296,14 +5299,16 @@ dictionary GPUExternalTextureDescriptor
 
                     Otherwise:
 
-                    1. If |source| <l spec=html>[=is not origin-clean=]</l>,
-                        throw a {{SecurityError}} and return.
+                    1. If |source| is not an {{GPUTextureView}}:
 
-                    1. Let |usability| be [=?=] [=check the usability of the image argument=](|source|).
+                        1. If |source| <l spec=html>[=is not origin-clean=]</l>,
+                            throw a {{SecurityError}} and return.
 
-                    1. If |usability| is not `good`:
-                        1. [$Generate a validation error$].
-                        1. Return an [$invalidated$] {{GPUExternalTexture}}.
+                        1. Let |usability| be [=?=] [=check the usability of the image argument=](|source|).
+
+                        1. If |usability| is not `good`:
+                            1. [$Generate a validation error$].
+                            1. Return an [$invalidated$] {{GPUExternalTexture}}.
 
                     1. Let |data| be the result of converting the current image contents of |source| into
                         the color space |descriptor|.{{GPUExternalTextureDescriptor/colorSpace}}
@@ -5316,6 +5321,14 @@ dictionary GPUExternalTextureDescriptor
                         read-only underlying data plus appropriate metadata to perform conversion later.
 
                     1. Let |result| be a new {{GPUExternalTexture}} object wrapping |data|.
+
+                1. If |source| is a {{GPUTextureView}}, then when
+                    |source|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[destroyed]]}} is `true`,
+                    run the following steps:
+
+                    <div data-timeline=content>
+                        1. Set |result|.{{GPUExternalTexture/[[expired]]}} to `true`.
+                    </div>
 
                 1. If |source| is an {{HTMLVideoElement}},
                     [$queue an automatic expiry task$] with device |this| and the following steps:
@@ -6477,6 +6490,28 @@ following members:
                                     ::
                                         - |resource| is a {{GPUExternalTexture}}.
                                         - |resource| is [$valid to use with$] |this|.
+                                        - Let |source| be |resource|.{{GPUExternalTexture/[[descriptor]]}}.{{GPUExternalTextureDescriptor/source}}.
+                                        - If |source| is
+
+                                            <dl class=switch>
+                                                : {{GPUTextureView}}
+                                                ::
+                                                    - Let |sourceDescriptor| be |source|.{{GPUTextureView/[[descriptor]]}}.
+                                                    - |sourceDescriptor|.{{GPUTextureViewDescriptor/usage}}
+                                                        includes {{GPUTextureUsage/TEXTURE_BINDING}}.
+                                                    - |sourceDescriptor|.{{GPUTextureViewDescriptor/dimension}}
+                                                        is {{GPUTextureViewDimension/"2d"}}.
+                                                    - |sourceDescriptor|.{{GPUTextureViewDescriptor/mipLevelCount}}
+                                                        is 1.
+                                                    - |sourceDescriptor|.{{GPUTextureViewDescriptor/format}}
+                                                        is listed in [[#plain-color-formats]] table.
+                                                    - |sourceDescriptor|.{{GPUTextureViewDescriptor/format}}
+                                                        is a [=filterable format=].
+                                                    - |sourceDescriptor|.{{GPUTextureViewDescriptor/format}}
+                                                        has 4 color channels.
+                                                    - |source|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}
+                                                        is 1.
+                                            </dl>
                                 </dl>
                     </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5305,6 +5305,7 @@ dictionary GPUExternalTextureDescriptor
                             [$generate a validation error$] and return an [$invalidated$] {{GPUExternalTexture}}.
 
                             <div class=validusage>
+                                - |source| is [$valid to use with$] |this|.
                                 - Let |sourceDescriptor| be |source|.{{GPUTextureView/[[descriptor]]}}.
                                 - |sourceDescriptor|.{{GPUTextureViewDescriptor/usage}}
                                     includes {{GPUTextureUsage/TEXTURE_BINDING}}.

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -422,8 +422,10 @@ are defined by the source type, given by this table:
                 {{HTMLImageElement/naturalHeight|HTMLImageElement.naturalHeight}}
         <tr>
             <td>{{GPUTextureView}}
-            <td>{{GPUTextureView/[[texture]]|texture}}.{{GPUTexture/width}},
-                {{GPUTextureView/[[texture]]|texture}}.{{GPUTexture/height}}
+            <td>{{GPUTextureView/[[texture]]}}'s [=logical miplevel-specific texture extent=]
+                at [=mipmap level=] {{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/baseMipLevel}}
+                [=GPUExtent3D/width=],
+                [=GPUExtent3D/height=]
         <tr>
             <td>{{HTMLVideoElement}}
             <td>[=video/intrinsic width|intrinsic width of the frame=],

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -421,6 +421,10 @@ are defined by the source type, given by this table:
             <td>{{HTMLImageElement/naturalWidth|HTMLImageElement.naturalWidth}},
                 {{HTMLImageElement/naturalHeight|HTMLImageElement.naturalHeight}}
         <tr>
+            <td>{{GPUTextureView}}
+            <td>{{GPUTextureView/[[texture]]|texture}}.{{GPUTexture/width}},
+                {{GPUTextureView/[[texture]]|texture}}.{{GPUTexture/height}}
+        <tr>
             <td>{{HTMLVideoElement}}
             <td>[=video/intrinsic width|intrinsic width of the frame=],
                 [=video/intrinsic height|intrinsic height of the frame=]


### PR DESCRIPTION
This PR is a first step for adding GPUTextureView support to importExternalTexture() into the WebGPU spec. Let's discuss it.

FIX https://github.com/gpuweb/gpuweb/issues/4504