### PR TITLE
float to int conversion maps to value in original type

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12983,20 +12983,25 @@ The <dfn noexport>scalar floating point to integral conversion</dfn> algorithm i
 To convert a floating point scalar value |X| to an [=integer scalar=] type |T|:
 * If |X| is a [=NaN=], the result is an [=indeterminate value=] in |T|.
 * If |X| is exactly representable in the target type |T|, then the result is that value.
-* Otherwise, the result is the value in |T| that is closest to [=truncate=](|X|).
+* Otherwise, the result is the value in |T| closest to [=truncate=](|X|) and also exactly
+    representable in |X|.
 
 </blockquote>
 
-Note: In other words, floating point to integer conversion rounds toward zero, then saturates in the target type.
-This saturation requirement the result is one place where WGSL mandates a meaningful result,
-but where [[!IEEE-754|IEEE-754]] mandates an invalid operation exception and a NaN result.
+Note: In other words, for non-NaN cases, floating point to integer conversion 
+clamps the value to be within the range of the target type, then rounds toward zero.
+This clamping requirement is one place where WGSL mandates a meaningful result,
+but which would yield undefined behavior in C and C++,
+and where [[!IEEE-754|IEEE-754]] mandates an invalid operation exception and a NaN result.
 
 <div class=note><span class=marker>Note:</span> For example:
 * 3.9f converted to [=u32=] is 3u
 * -1f converted to [=u32=] is 0u
-* 1e20f converted to [=u32=] is the maximum u32 value, 4294967295u
+* 1e20f converted to [=u32=] is the largest float value representable in u32, 4294967040u
+   * Note this is smaller than the maximum u32 value 4294967295u
 * -3.9f converted to [=i32=] is -3i
-* 1e20f converted to [=i32=] is the maximum i32 value, 2147483647i
+* 1e20f converted to [=i32=] is the maximum i32 value, 2147483520i
+   * Note this is smaller than the maximum i32 value 2147483647i
 * -1e20f converted to [=i32=] is the minimum i32 value, i32(-2147483648)
 
 </div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12984,7 +12984,7 @@ To convert a floating point scalar value |X| to an [=integer scalar=] type |T|:
 * If |X| is a [=NaN=], the result is an [=indeterminate value=] in |T|.
 * If |X| is exactly representable in the target type |T|, then the result is that value.
 * Otherwise, the result is the value in |T| closest to [=truncate=](|X|) and also exactly
-    representable in |X|.
+    representable in the original floating point type.
 
 </blockquote>
 


### PR DESCRIPTION
This avoids length and branchy code sequences to avoid undefined behaviour when mapping to C-based languages, and invalid operation exceptions when mapping to strictly IEEE conformant implementations.

The differences are:
* too-high float to u32 maps to 4294967040 instead of 4294967295
* too-high float to i32 maps to 2147483520 instead of 2147483647

Fixes #5043