### PR TITLE
Handle negative index in vertex processing

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15515,17 +15515,18 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
 
             <dl class=switch>
                 : {{GPUVertexStepMode/"vertex"}}
-                :: |vertexIndex|
+                :: |vertexIndex| (note this may be negative)
                 : {{GPUVertexStepMode/"instance"}}
                 :: |instanceIndex|
             </dl>
         1. Let |drawCallOutOfBounds| be `false`.
         1. For each |attributeDesc| in |vertexBufferLayout|.{{GPUVertexBufferLayout/attributes}}:
-            1. Let |attributeOffset| be |vertexBufferOffset| +
+            1. Let |vertexElementRelativeOffset| be
                 |vertexElementIndex| * |vertexBufferLayout|.{{GPUVertexBufferLayout/arrayStride}} +
                 |attributeDesc|.{{GPUVertexAttribute/offset}}.
-            1. If |attributeOffset| + [$GPUVertexFormat/byteSize$](|attributeDesc|.{{GPUVertexAttribute/format}}) &gt;
-                |vertexBufferOffset| + |vertexBufferBindingSize|:
+            1. If |vertexElementRelativeOffset| &lt; 0 or
+                |vertexElementRelativeOffset| + [$GPUVertexFormat/byteSize$](|attributeDesc|.{{GPUVertexAttribute/format}}) &gt;
+                |vertexBufferBindingSize|:
                 1. Set |drawCallOutOfBounds| to `true`.
                 1. <strong>Optionally ([=implementation-defined=])</strong>,
                     [=list/empty=] |vertexIndexList| and return, cancelling the draw call.
@@ -15534,20 +15535,20 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
                     before issuing a draw call, instead of using [=invalid memory reference=] behavior.
         1. For each |attributeDesc| in |vertexBufferLayout|.{{GPUVertexBufferLayout/attributes}}:
             1. If |drawCallOutOfBounds| is `true`:
-                1. Load the attribute |data| according to WGSL's [=invalid memory reference=]
+                1. Load the vertex element |data| according to WGSL's [=invalid memory reference=]
                     behavior, from |vertexBuffer|.
 
                     Note: [=Invalid memory reference=] allows several behaviors, including actually
-                    loading the "correct" result for an attribute that is in-bounds, even when
+                    loading the "correct" result for an vertex element that is in-bounds, even when
                     the draw-call-wide |drawCallOutOfBounds| is `true`.
 
                 Otherwise:
 
-                1. Let |attributeOffset| be |vertexBufferOffset| +
+                1. Let |vertexElementRelativeOffset| be
                     |vertexElementIndex| * |vertexBufferLayout|.{{GPUVertexBufferLayout/arrayStride}} +
                     |attributeDesc|.{{GPUVertexAttribute/offset}}.
-                1. Load the attribute |data| of format |attributeDesc|.{{GPUVertexAttribute/format}}
-                    from |vertexBuffer| starting at offset |attributeOffset|.
+                1. Load the vertex element |data| of format |attributeDesc|.{{GPUVertexAttribute/format}}
+                    from |vertexBuffer| starting at offset |vertexBufferOffset| + |vertexElementRelativeOffset|.
                     The components are loaded in the order `x`, `y`, `z`, `w` from buffer memory.
             1. Convert the |data| into a shader-visible format, according to [=channel formats=] rules.
 


### PR DESCRIPTION
Also refactor the prose slightly so that this change makes more sense in context.

Fixes #5064