### PR TITLE
Fix prose for rg11b10ufloat-renderable to allow resolving

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -16596,7 +16596,7 @@ This feature adds the following [=optional API surfaces=]:
 </h3>
 
 Allows the {{GPUTextureUsage/RENDER_ATTACHMENT}} usage on textures with format {{GPUTextureFormat/"rg11b10ufloat"}},
-and also allows textures of that format to be blended and multisampled.
+and also allows textures of that format to be blended, multisampled, and resolved.
 
 This feature adds no [=optional API surfaces=].
 


### PR DESCRIPTION
This is already true since PR #3834, but I forgot to update this prose.

Fixes #5075