### PR TITLE
Allow using a texture view for an externalTexture binding

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5150,7 +5150,7 @@ See [[#texture-format-caps]] for information about which {{GPUTextureFormat}}s r
 </h3>
 
 A {{GPUExternalTexture}} is a sampleable 2D texture wrapping an external video frame.
-It is an immutable snapshot; its constents may not change over time, either from inside WebGPU
+It is an immutable snapshot; its contents may not change over time, either from inside WebGPU
 (it is only sampleable) or from outside WebGPU (e.g. due to video frame advancement).
 
 {{GPUExternalTexture}}s can be bound into bind groups via the

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6503,7 +6503,9 @@ following members:
                                                     - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}}
                                                         must be 1.
                                                     - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
-                                                        must be one of the [=Supported context formats=].
+                                                        must be {{GPUTextureFormat/"rgba8unorm"}},
+                                                        {{GPUTextureFormat/"bgra8unorm"}}, or
+                                                        {{GPUTextuerFormat/"rgba16float"}}.
                                                     - |resource|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}
                                                         must be 1.
                                             </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6505,7 +6505,7 @@ following members:
                                                     - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
                                                         must be {{GPUTextureFormat/"rgba8unorm"}},
                                                         {{GPUTextureFormat/"bgra8unorm"}}, or
-                                                        {{GPUTextuerFormat/"rgba16float"}}.
+                                                        {{GPUTextureFormat/"rgba16float"}}.
                                                     - |resource|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}
                                                         must be 1.
                                             </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5796,7 +5796,7 @@ dictionary GPUBindGroupLayoutEntry {
     : <dfn>externalTexture</dfn>
     ::
         When [=map/exist|provided=], indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is {{GPUExternalTexture}}.
+        is either {{GPUExternalTexture}} or {{GPUTextureView}}.
 </dl>
 
 <script type=idl>
@@ -5891,10 +5891,12 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td>[=internal usage/storage-read=]
 
     <tr>
-        <td>{{GPUBindGroupLayoutEntry/externalTexture}}
+        <td rowspan=2>{{GPUBindGroupLayoutEntry/externalTexture}}
         <td>{{GPUExternalTexture}}
-        <td>
-        <td>[=internal usage/constant=]
+        <td rowspan=2>
+        <td rowspan=2>[=internal usage/constant=]
+    <tr>
+        <td>{{GPUTextureView}}
 </table>
 
 <div algorithm data-timeline=device>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5390,13 +5390,19 @@ dictionary GPUExternalTextureDescriptor
     </pre>
 </div>
 
-### Sampling External Textures ### {#external-texture-sampling}
+## Sampling External Texture Bindings ## {#external-texture-sampling}
+
+The {{GPUBindGroupLayoutEntry/externalTexture}} binding point enables the integration of dynamic
+image sources. While primarily intended for {{GPUExternalTexture}} (video, camera), it also supports
+{{GPUTextureView}} for advanced texture manipulation.
 
 External textures are represented in WGSL with `texture_external` and may be read using
 `textureLoad` and `textureSampleBaseClampToEdge`.
 
 The `sampler` provided to `textureSampleBaseClampToEdge` is used to sample the underlying textures.
-The result is in the color space set by {{GPUExternalTextureDescriptor/colorSpace}}.
+
+When the [=binding resource type=] is a {{GPUExternalTexture}}, the result is in the color space set
+by {{GPUExternalTextureDescriptor/colorSpace}}.
 It is implementation-dependent whether, for any given external texture, the sampler (and filtering)
 is applied before or after conversion from underlying values into the specified color space.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6477,19 +6477,19 @@ following members:
                                     ::
                                         - |resource| is either a {{GPUExternalTexture}} or a {{GPUTextureView}}.
                                         - |resource| is [$valid to use with$] |this|.
-                                        - If |resource| is a
+                                        - If |resource| is a:
                                             <dl class=switch>
                                                 : {{GPUTextureView}}
                                                 ::
                                                     - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
-                                                        includes {{GPUTextureUsage/TEXTURE_BINDING}}.
+                                                        must include {{GPUTextureUsage/TEXTURE_BINDING}}.
                                                     - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/dimension}}
-                                                        is {{GPUTextureViewDimension/"2d"}}
+                                                        must be {{GPUTextureViewDimension/"2d"}}.
                                                     - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}}
                                                         must be 1.
                                                     - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
-                                                        is a [=filterable format=] with 4 color channels
-                                                        listed in [[#plain-color-formats]] table.
+                                                        must be a [=filterable format=] listed in
+                                                        [[#plain-color-formats]] table.
                                                     - |resource|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}
                                                         must be 1.
                                             </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5393,8 +5393,8 @@ dictionary GPUExternalTextureDescriptor
 ## Sampling External Texture Bindings ## {#external-texture-sampling}
 
 The {{GPUBindGroupLayoutEntry/externalTexture}} binding point enables the integration of dynamic
-image sources. While primarily intended for {{GPUExternalTexture}} (video, camera), it also supports
-{{GPUTextureView}} for advanced texture manipulation.
+image sources. While primarily intended for {{GPUExternalTexture}}, it also supports
+{{GPUTextureView}}.
 
 External textures are represented in WGSL with `texture_external` and may be read using
 `textureLoad` and `textureSampleBaseClampToEdge`.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5397,8 +5397,7 @@ objects (from dynamic image sources like videos). It also supports {{GPUTextureV
 
 Note:
 When a {{GPUTextureView}} is bound to an {{GPUBindGroupLayoutEntry/externalTexture}} binding, it is
-like a {{GPUExternalTexture}} with a single RGBA (or `R,0,0,1` or `R,G,0,1`) plane and no crop,
-rotation, or color conversion (except for gamma decoding performed while sampling `-srgb` formats).
+like a {{GPUExternalTexture}} with a single RGBA plane and no crop, rotation, or color conversion.
 
 External textures are represented in WGSL with `texture_external` and may be read using
 `textureLoad` and `textureSampleBaseClampToEdge`.
@@ -6504,8 +6503,7 @@ following members:
                                                     - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}}
                                                         must be 1.
                                                     - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
-                                                        must be a [=filterable format=] listed in
-                                                        [[#plain-color-formats]] table.
+                                                        must be one of the [=Supported context formats=].
                                                     - |resource|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}
                                                         must be 1.
                                             </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6475,8 +6475,24 @@ following members:
 
                                     :  {{GPUBindGroupLayoutEntry/externalTexture}}
                                     ::
-                                        - |resource| is a {{GPUExternalTexture}}.
+                                        - |resource| is either a {{GPUExternalTexture}} or a {{GPUTextureView}}.
                                         - |resource| is [$valid to use with$] |this|.
+                                        - If |resource| is a
+                                            <dl class=switch>
+                                                : {{GPUTextureView}}
+                                                ::
+                                                    - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
+                                                        includes {{GPUTextureUsage/TEXTURE_BINDING}}.
+                                                    - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/dimension}}
+                                                        is {{GPUTextureViewDimension/"2d"}}
+                                                    - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}}
+                                                        must be 1.
+                                                    - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+                                                        is a [=filterable format=] with 4 color channels
+                                                        listed in [[#plain-color-formats]] table.
+                                                    - |resource|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}
+                                                        must be 1.
+                                            </dl>
                                 </dl>
                     </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5149,29 +5149,29 @@ See [[#texture-format-caps]] for information about which {{GPUTextureFormat}}s r
 <span id=gpu-external-texture></span>
 </h3>
 
-A {{GPUExternalTexture}} is a sampleable 2D texture wrapping an external video object.
-The contents of a {{GPUExternalTexture}} object are a snapshot and may not change, either from inside WebGPU
+A {{GPUExternalTexture}} is a sampleable 2D texture wrapping an external video frame.
+It is an immutable snapshot; its constents may not change over time, either from inside WebGPU
 (it is only sampleable) or from outside WebGPU (e.g. due to video frame advancement).
 
-They are bound into bind group layouts using the {{GPUBindGroupLayoutEntry/externalTexture}}
-bind group layout entry member.
-External textures use several binding slots: see [=Exceeds the binding slot limits=].
+{{GPUExternalTexture}}s can be bound into bind groups via the
+{{GPUBindGroupLayoutEntry/externalTexture}} bind group layout entry member.
+Note that member uses several binding slots, as defined there.
 
 <div class=note heading>
-    External textures *can* be implemented without creating a copy of the imported source,
+    {{GPUExternalTexture}} *can* be implemented without creating a copy of the imported source,
     but this depends [=implementation-defined=] factors.
     Ownership of the underlying representation may either be exclusive or shared with other
     owners (such as a video decoder), but this is not visible to the application.
 
     The underlying representation of an external texture is unobservable
-    (except for sampling behavior) but typically may include
+    (except for precise sampling behavior), but typically may include:
 
     - Up to three 2D planes of data (e.g. RGBA, Y+UV, Y+U+V).
     - Metadata for converting coordinates before reading from those planes (crop and rotation).
     - Metadata for converting values into the specified output color space (matrices, gammas, 3D LUT).
 
-    The configuration used may not be stable across time, systems, user agents, media sources,
-    or frames within a single video source.
+    The configuration used internally by an implementation may not be consistent across time,
+    systems, user agents, media sources, or even frames within a single video source.
     In order to account for many possible representations,
     the binding conservatively uses the following, for *each* external texture:
 
@@ -5392,9 +5392,13 @@ dictionary GPUExternalTextureDescriptor
 
 ## Sampling External Texture Bindings ## {#external-texture-sampling}
 
-The {{GPUBindGroupLayoutEntry/externalTexture}} binding point enables the integration of dynamic
-image sources. While primarily intended for {{GPUExternalTexture}}, it also supports
-{{GPUTextureView}}.
+The {{GPUBindGroupLayoutEntry/externalTexture}} binding point allows binding {{GPUExternalTexture}}
+objects (from dynamic image sources like videos). It also supports {{GPUTextureView}}.
+
+Note:
+When a {{GPUTextureView}} is bound to an {{GPUBindGroupLayoutEntry/externalTexture}} binding, it is
+like a {{GPUExternalTexture}} with a single RGBA (or `R,0,0,1` or `R,G,0,1`) plane and no crop,
+rotation, or color conversion (except for gamma decoding performed while sampling `-srgb` formats).
 
 External textures are represented in WGSL with `texture_external` and may be read using
 `textureLoad` and `textureSampleBaseClampToEdge`.
@@ -5803,6 +5807,8 @@ dictionary GPUBindGroupLayoutEntry {
     ::
         When [=map/exist|provided=], indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
         is either {{GPUExternalTexture}} or {{GPUTextureView}}.
+
+        External textures use several binding slots: see [=Exceeds the binding slot limits=].
 </dl>
 
 <script type=idl>
@@ -5949,6 +5955,8 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
                     1 {{supported limits/maxSamplersPerShaderStage}} slot, and
                     1 {{supported limits/maxUniformBuffersPerShaderStage}} slot
                     to be used.
+
+                    Note: See {{GPUExternalTexture}} for an explanation of this behavior.
             </dl>
 </div>
 


### PR DESCRIPTION
Following latest [GPU Web WG meeting](https://docs.google.com/document/d/1t3MrwneREo4aGzXstMuuDdwcaYRUWLGJFNi2izkc-w4/edit?tab=t.0#heading=h.3ajav4m0ax6z), this PR allows using a texture view for an externalTexture binding.

This PR supersedes https://github.com/gpuweb/gpuweb/pull/5068

Fixes #4504