### PR TITLE
Mention normalization in `refract`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8154,7 +8154,7 @@ An <dfn noexport>assertion</dfn> is a check that ensures a boolean condition is 
 path: syntax/global_assert.syntax.bs.include
 </pre>
 
-WGSL defines one kind of [=assertion=]: the [[#const-assert-statement|const assertion]]. 
+WGSL defines one kind of [=assertion=]: the [[#const-assert-statement|const assertion]].
 
 <pre class=include>
 path: syntax/const_assert.syntax.bs.include
@@ -15969,7 +15969,9 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     indices of refraction `e3`,
     let `k = 1.0 - e3 * e3 * (1.0 - dot(e2, e1) * dot(e2, e1))`.
     If `k < 0.0`, returns the refraction vector 0.0, otherwise return the refraction vector
-    `e3 * e1 - (e3 * dot(e2, e1) + sqrt(k)) * e2`.
+    `e3 * e1 - (e3 * dot(e2, e1) + sqrt(k)) * e2`. The incident vector `e1` and the normal `e2`
+    should be normalized for desired results according to Snell's Law; otherwise, the results
+    may not conform to expected physical behavior.
 </table>
 
 ### `reverseBits` ### {#reverseBits-builtin}


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/issues/5072

I tried to incorporate the suggestion of @armansito in a minimal manner however also tried to contain what might define "desired" by pointing out to Snell's Law (and do alternative wording in otherwise part).

Thank you!