### PR TITLE
Fix code in pointer-as-short-name example

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3736,8 +3736,7 @@ Defining pointers in this way enables two key use cases:
     @compute @workgroup_size(1)
     fn main() {
       // Form a pointer to a specific Particle in storage memory.
-      let active_particle: ptr<storage,Particle> =
-          &system.particles[system.active_index];
+      let active_particle = &system.particles[system.active_index];
 
       let delta_position: vec3<f32> = (*active_particle).velocity * system.timestep;
       let current_position: vec3<f32>  = (*active_particle).position;


### PR DESCRIPTION
The explicit pointer type for the let declaration was wrong. Don't write the pointer type: use inference instead.

Fixes: #5083