### PR TITLE
wgsl: Remove binding_array from reserved keywords

### DIFF
--- a/wgsl/tools/keywords
+++ b/wgsl/tools/keywords
@@ -604,7 +604,6 @@ workgroup
 # Deliberately reserved by WGSL
 my @wgsl_reserved = qw(
 asm
-binding_array
 demote
 demote_to_helper
 do

--- a/wgsl/wgsl.reserved.bs.include
+++ b/wgsl/wgsl.reserved.bs.include
@@ -29,8 +29,6 @@
 
     | `'become'`   <!-- Rust -->
 
-    | `'binding_array'`   <!-- WGSL -->
-
     | `'cast'`   <!-- GLSL(reserved) -->
 
     | `'catch'`   <!-- C++ ECMAScript2022 -->


### PR DESCRIPTION
Type names should not be reserved as they are shadowable by user declarations.

Fixes #5088