### PR TITLE
Reformat builtins table

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9227,107 +9227,122 @@ Note: The [=built-in values/position=] built-in is both an output of a vertex sh
 
 Collectively, built-in input and built-in output values are known as <dfn noexport>built-in values</dfn>.
 
-The following table summarizes the available built-in values.
+The following tables summarizes the available built-in values by stage.
 Each is a [=built-in value name-token|built-in value name=] [=token=] for a [=built-in value=].
 Each is described in detail in subsequent sections.
 
 <table class='data'>
-  <caption>Built-in input and output values</caption>
+  <caption>Built-in Vertex stage inputs</caption>
   <thead>
-    <tr><th>Name<th>Stage<th>Direction<th>Type<th>[=Extension=]
+    <tr><th>Name<th>Type<th>[=Extension=]
   </thead>
 
   <tr><td>[=built-in values/vertex_index=]
-      <td>vertex
-      <td>input
       <td>u32
-      <td rowspan=2>
+      <td>
 
   <tr><td>[=built-in values/instance_index=]
-      <td>vertex
-      <td>input
       <td>u32
+      <td>
+</table>
+
+<table class='data'>
+  <caption>Built-in Vertex stage outputs</caption>
+  <thead>
+    <tr><th>Name<th>Type<th>[=Extension=]
+  </thead>
 
   <tr><td>[=built-in values/clip_distances=]
-      <td>vertex
-      <td>output
       <td>array&lt;f32, N&gt; (`N` &le; `8`)
       <td>[=extension/clip_distances=]
 
-  <tr><td rowspan=2>[=built-in values/position=]
-      <td>vertex
-      <td>output
+  <tr><td>[=built-in values/position=]
       <td>vec4&lt;f32&gt;
-      <td rowspan=12>
+      <td>
 
-  <tr>
-      <td>fragment
-      <td>input
+</table>
+
+<table class='data'>
+  <caption>Built-in Fragment stage inputs</caption>
+  <thead>
+    <tr><th>Name<th>Type<th>[=Extension=]
+  </thead>
+
+  <tr><td>[=built-in values/position=]
       <td>vec4&lt;f32&gt;
+      <td>
 
   <tr><td>[=built-in values/front_facing=]
-      <td>fragment
-      <td>input
       <td>bool
-
-  <tr><td>[=built-in values/frag_depth=]
-      <td>fragment
-      <td>output
-      <td>f32
+      <td>
 
   <tr><td>[=built-in values/sample_index=]
-      <td>fragment
-      <td>input
       <td>u32
+      <td>
 
-  <tr><td rowspan=2>[=built-in values/sample_mask=]
-      <td>fragment
-      <td>input
+  <tr><td>[=built-in values/sample_mask=]
       <td>u32
+      <td>
 
-  <tr>
-      <td>fragment
-      <td>output
+  <tr><td>[=built-in values/subgroup_invocation_id=]
       <td>u32
+      <td>[=extension/subgroups=]
+
+  <tr><td>[=built-in values/subgroup_size=]
+      <td>u32
+      <td>[=extension/subgroups=]
+
+</table>
+
+<table class='data'>
+  <caption>Built-in Fragment stage outputs</caption>
+  <thead>
+    <tr><th>Name<th>Type<th>[=Extension=]
+  </thead>
+
+  <tr><td>[=built-in values/frag_depth=]
+      <td>f32
+      <td>
+
+  <tr><td>[=built-in values/sample_mask=]
+      <td>u32
+      <td>
+
+</table>
+
+<table class='data'>
+  <caption>Built-in Compute stage inputs</caption>
+  <thead>
+    <tr><th>Name<th>Type<th>[=Extension=]
+  </thead>
 
   <tr><td>[=built-in values/local_invocation_id=]
-      <td>compute
-      <td>input
       <td>vec3&lt;u32&gt;
+      <td>
 
   <tr><td>[=built-in values/local_invocation_index=]
-      <td>compute
-      <td>input
       <td>u32
+      <td>
 
   <tr><td>[=built-in values/global_invocation_id=]
-      <td>compute
-      <td>input
       <td>vec3&lt;u32&gt;
+      <td>
 
   <tr><td>[=built-in values/workgroup_id=]
-      <td>compute
-      <td>input
       <td>vec3&lt;u32&gt;
+      <td>
 
   <tr><td>[=built-in values/num_workgroups=]
-      <td>compute
-      <td>input
       <td>vec3&lt;u32&gt;
+      <td>
 
-  <tr><td rowspan=2>[=built-in values/subgroup_invocation_id=]
-      <td>compute
-      <td rowspan=2>input
-      <td rowspan=2>u32
-      <td rowspan=2>[=extension/subgroups=]
-  <tr><td>fragment
+  <tr><td>[=built-in values/subgroup_invocation_id=]
+      <td>u32
+      <td>[=extension/subgroups=]
 
-  <tr><td rowspan=2>[=built-in values/subgroup_size=]
-      <td>compute
-      <td rowspan=2>input
-      <td rowspan=2>u32
-      <td rowspan=2>[=extension/subgroups=]
-  <tr><td>fragment
+  <tr><td>[=built-in values/subgroup_size=]
+      <td>u32
+      <td>[=extension/subgroups=]
 </table>
 
 <div class='example wgsl global-scope' heading="Declaring built-in values">


### PR DESCRIPTION
Separate the builtins by stage and input/output as it's arguably less confusiung.

Note: This only separates the table. It would be nice to also separate the documentation so that vertex position links to a different place than fragment position and sample_mask input links to different place than sample_mask output. That change can happen in another PR.

Issue #5081

Note: Other GPU API specs do not combine inputs and outputs from multiple stages into one.

* [GLSL](https://registry.khronos.org/OpenGL/specs/es/3.1/GLSL_ES_Specification_3.10.withchanges.pdf) sections 7.1.1, 7.1.2, 7.1.3

* [HLSL](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics)

* [MSL](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf) sections 5.2.3.1, 5.2.3.3, 5.2.3.4, 5.2.3.5, 5.2.3.6

Result:

<img width="726" alt="Screenshot 2025-02-28 at 14 56 33" src="https://github.com/user-attachments/assets/cbad9b8b-fef6-4f9c-961d-074ebd040141" />
