### PR TITLE
Add clamp-to-border-color sampler address mode

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5457,6 +5457,7 @@ dictionary GPUSamplerDescriptor
     float lodMaxClamp = 32;
     GPUCompareFunction compare;
     [Clamp] unsigned short maxAnisotropy = 1;
+    GPUBorderColor borderColor = "transparent-black";
 };
 </script>
 
@@ -5511,6 +5512,11 @@ dictionary GPUSamplerDescriptor
 
             The precise filtering behavior is implementation-dependent.
         </div>
+
+    : <dfn>borderColor</dfn>
+    ::
+        Specifies the border color used by the sampler when the {{GPUAddressMode|address mode}} is
+        {{GPUAddressMode/"clamp-to-border-color"}}.
 </dl>
 
 <dfn dfn lt="levels of detail|lod">Level of detail</dfn> (LOD) describes which mip level(s) are selected when sampling a
@@ -5528,6 +5534,7 @@ enum GPUAddressMode {
     "clamp-to-edge",
     "repeat",
     "mirror-repeat",
+    "clamp-to-border-color",
 };
 </script>
 
@@ -5544,6 +5551,12 @@ enum GPUAddressMode {
     ::
         Texture coordinates wrap to the other side of the texture, but the texture is flipped
         when the integer part of the coordinate is odd.
+
+    : <dfn>"clamp-to-border-color"</dfn>
+    ::
+        Out-of-range texture coordinates use the value specified by
+        {{GPUSamplerDescriptor/borderColor}}.
+
 </dl>
 
 {{GPUFilterMode}} and {{GPUMipmapFilterMode}} describe the behavior of the sampler if the sampled
@@ -5627,6 +5640,31 @@ enum GPUCompareFunction {
     : <dfn>"always"</dfn>
     ::
         Comparison tests always pass.
+</dl>
+
+{{GPUBorderColor}} specifies the border color for clamped texture coordinates when the sampler address
+mode is {{GPUAddressMode/"clamp-to-border-color"}}.
+
+<script type=idl>
+enum GPUBorderColor {
+    "transparent-black",
+    "opaque-black",
+    "opaque-white",
+};
+</script>
+
+<dl dfn-type=enum-value dfn-for=GPUBorderColor>
+    : <dfn>"transparent-black"</dfn>
+    ::
+        A transparent black color (0, 0, 0, 0) for texture coordinates outside the border.
+
+    : <dfn>"opaque-black"</dfn>
+    ::
+        An opaque black color (0, 0, 0, 1) for texture coordinates outside the border.
+
+    : <dfn>"opaque-white"</dfn>
+    ::
+        An opaque white color (1, 1, 1, 1) for texture coordinates outside the border.
 </dl>
 
 ### Sampler Creation ### {#sampler-creation}


### PR DESCRIPTION
Following up on https://github.com/gpuweb/gpuweb/issues/1305, this PR adds the `"clamp-to-border-color"` sampler address mode to WebGPU as it's now supported on iOS 14.

