### PR TITLE
Synchronously validate size % 4 == 0 on mappedAtCreation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3434,6 +3434,8 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                 1. Set |b|.{{GPUBuffer/size}} to |descriptor|.{{GPUBufferDescriptor/size}}.
                 1. Set |b|.{{GPUBuffer/usage}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
                 1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
+                    1. If |descriptor|.{{GPUBufferDescriptor/size}} is not a multiple of 4,
+                        throw a {{RangeError}}.
                     1. Set |b|.{{GPUBuffer/[[mapping]]}} to
                         [=?=] [$initialize an active buffer mapping$] with mode {{GPUMapMode/WRITE}}
                         and range <code>[0, |descriptor|.{{GPUBufferDescriptor/size}}]</code>.
@@ -3459,8 +3461,6 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                                 except {{GPUBufferUsage/COPY_SRC}}.
                         - If |descriptor|.{{GPUBufferDescriptor/size}} must be &le;
                             |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBufferSize}}.
-                        - If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
-                            - |descriptor|.{{GPUBufferDescriptor/size}} must be a multiple of 4.
                     </div>
 
                 Note: If buffer creation fails, and |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `false`,


### PR DESCRIPTION
This makes it invariant that mapping sizes will always be a multiple of 4, even with mappedAtCreation. (mapAsync validates this asynchronously.)

This is technically a breaking change, but it only changes a validation error into an exception, so it should be pretty safe.

Fixes #5105