### PR TITLE
mapAsync always AbortErrors after device loss

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3673,7 +3673,6 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                     1. Set |deviceLost| to `true`.
                     1. Issue the <var data-timeline=content>map failure steps</var> on
                         <var data-timeline=content>contentTimeline</var>.
-                    1. [$Generate a validation error$].
                     1. Return.
 
                 1. If any of the following conditions are unsatisfied:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3668,7 +3668,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                     <div class=validusage>
                         - |this| must be [$valid$].
-                    <div class=validusage>
+                    </div>
 
                     1. Set |deviceLost| to `true`.
                     1. Issue the <var data-timeline=content>map failure steps</var> on
@@ -3676,7 +3676,8 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                     1. Return.
 
                 1. If any of the following conditions are unsatisfied:
-                    </div>
+
+                    <div class=validusage>
                         - |this|.{{GPUBuffer/[[internal state]]}} is "[=GPUBuffer/[[internal state]]/available=]".
                         - |offset| is a multiple of 8.
                         - |rangeSize| is a multiple of 4.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3668,6 +3668,16 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                     <div class=validusage>
                         - |this| must be [$valid$].
+                    <div class=validusage>
+
+                    1. Set |deviceLost| to `true`.
+                    1. Issue the <var data-timeline=content>map failure steps</var> on
+                        <var data-timeline=content>contentTimeline</var>.
+                    1. [$Generate a validation error$].
+                    1. Return.
+
+                1. If any of the following conditions are unsatisfied:
+                    </div>
                         - |this|.{{GPUBuffer/[[internal state]]}} is "[=GPUBuffer/[[internal state]]/available=]".
                         - |offset| is a multiple of 8.
                         - |rangeSize| is a multiple of 4.
@@ -3680,6 +3690,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                     Then:
 
+                    1. Set |deviceLost| to `false`.
                     1. Issue the <var data-timeline=content>map failure steps</var> on
                         <var data-timeline=content>contentTimeline</var>.
                     1. [$Generate a validation error$].
@@ -3708,6 +3719,8 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                 1. Set |deviceLost| to `true` if |this|.{{GPUObjectBase/[[device]]}} is [$invalid|lost$],
                     and `false` otherwise.
+
+                    Note: The device could have been lost between the previous block of steps and this one.
                 1. If |deviceLost|:
 
                     1. Issue the <var data-timeline=content>map failure steps</var> on


### PR DESCRIPTION
If `mapAsync()` is interrupted by device loss, it rejects with AbortError. If `mapAsync()` is called after the device was already lost, the local `deviceLost` variable would not be defined so we didn't know whether to reject with AbortError or OperationError. This makes it AbortError for consistency.

Fixes #5101