### PR TITLE
Add "core-features-and-limits" to spec

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1375,6 +1375,7 @@ implicitly [$valid to use with|unusable$].
 
     1. Let |features| be the [=set=] of values in
         |descriptor|.{{GPUDeviceDescriptor/requiredFeatures}}.
+    1. [=set/Prepend=] {{GPUFeatureName/"core-features-and-limits"}} to |features|.
     1. Let |limits| be a [=supported limits=] object with all values set to their defaults.
     1. For each (|key|, |value|) pair in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}:
         1. If |value| is not `undefined` and |value| is [=limit/better=] than |limits|[|key|]:
@@ -2332,13 +2333,15 @@ interface GPU {
                     1. Set |adapter| to an [=adapter=] chosen according to
                         the rules in [[#adapter-selection]] and the criteria in |options|,
                         adhering to [[#adapter-capability-guarantees]].
+                        Initialize the properties of |adapter| according to their definitions:
 
-                        The [=supported limits=] of the adapter must adhere to the requirements
-                        defined in [[#limits]].
-                    1. If |adapter| meets the criteria of a [=fallback adapter=] set
-                        |adapter|.{{adapter/[[fallback]]}} to `true`.
-                    1. Set |adapter|.{{adapter/[[xrCompatible]]}} to
-                        |options|.{{GPURequestAdapterOptions/xrCompatible}}.
+                        1. Set |adapter|.{{adapter/[[limits]]}} and |adapter|.{{adapter/[[features]]}}
+                            according to the supported capabilities of the adapter.
+                            |adapter|.{{adapter/[[features]]}} must contain {{GPUFeatureName/"core-features-and-limits"}}.
+                        1. If |adapter| meets the criteria of a [=fallback adapter=] set
+                            |adapter|.{{adapter/[[fallback]]}} to `true`. Otherwise, set it to `false`.
+                        1. Set |adapter|.{{adapter/[[xrCompatible]]}} to
+                            |options|.{{GPURequestAdapterOptions/xrCompatible}}.
 
                     Otherwise:
 
@@ -2865,6 +2868,7 @@ allows additional usages of WebGPU that would have otherwise been invalid.
 
 <script type=idl>
 enum GPUFeatureName {
+    "core-features-and-limits",
     "depth-clip-control",
     "depth32float-stencil8",
     "texture-compression-bc",
@@ -16479,6 +16483,13 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 </div>
 
 # Feature Index # {#feature-index}
+
+<h3 id=core-features-and-limits data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"core-features-and-limits"`
+</h3>
+
+Allows all Core WebGPU features and limits to be used.
+
+Note: This is currently available on all adapters and enabled automatically on all devices even if not requested.
 
 <h3 id=depth-clip-control data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"depth-clip-control"`
 <span id=dom-gpufeaturename-depth-clip-control></span>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1375,7 +1375,7 @@ implicitly [$valid to use with|unusable$].
 
     1. Let |features| be the [=set=] of values in
         |descriptor|.{{GPUDeviceDescriptor/requiredFeatures}}.
-    1. [=set/Prepend=] {{GPUFeatureName/"core-features-and-limits"}} to |features|.
+    1. [=set/Append=] {{GPUFeatureName/"core-features-and-limits"}} to |features|.
     1. Let |limits| be a [=supported limits=] object with all values set to their defaults.
     1. For each (|key|, |value|) pair in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}:
         1. If |value| is not `undefined` and |value| is [=limit/better=] than |limits|[|key|]:


### PR DESCRIPTION
Add this to the main spec so that browsers can start implementing/shipping it. This allows applications to start relying on the presence of this feature name as soon as browsers ship it.

Currently since Compat is in the spec yet, this is always available on adapters and always auto-enabled on devices.

Fixes #5127