### PR TITLE
Make quotes part of the link for consistency

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1802,7 +1802,7 @@ The valid [=enable-extensions=] are listed in the following table.
       <td>The attribute [=attribute/blend_src=] is valid to use in the WGSL module. Otherwise, using
           [=attribute/blend_src=] will result in a [=shader-creation error=].
   <tr><td><dfn noexport dfn-for="extension">`subgroups`</dfn>
-      <td>"[=subgroups-feature|subgroups=]"
+      <td>[=subgroups-feature|"subgroups"=]
       <td>It is valid to use [[#builtin-inputs-outputs|subgroup built-in values]],
           [[#subgroup-builtin-functions|subgroup built-in functions]], and
           [[#quad-builtin-functions|quad built-in functions]] in a WGSL module.


### PR DESCRIPTION
Other enable-extensions include quotes as part of link so difference in color here makes it stand out as if there is exception or sth. but it is actually same as other rows. PTAL! Thanks in advance.