### PR TITLE
Add guidance to build the image with devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/universal
 {
-    // Use the image from the CI
+    // Use the image that is pre-built by CI:
     "image": "ghcr.io/gpuweb/gpuweb:main",
     // Use this instead if you need to build the image from the local Dockerfile:
     // "build": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
     //     "dockerfile": "../tools/custom-action/Dockerfile",
     //     "context": ".."
     // },
+
     // Prepare environment to be identical to entrypoint.sh,
     // since entrypoint.sh is not run on creation.
     "postCreateCommand": "bash /prepare.sh",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 {
     // Use the image from the CI
     "image": "ghcr.io/gpuweb/gpuweb:main",
-    // Build the image from the Dockerfile
+    // Use this instead if you need to build the image from the local Dockerfile:
     // "build": {
     //     "dockerfile": "../tools/custom-action/Dockerfile",
     //     "context": ".."

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,13 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/universal
 {
+    // Use the image from the CI
     "image": "ghcr.io/gpuweb/gpuweb:main",
-
+    // Build the image from the Dockerfile
+    // "build": {
+    //     "dockerfile": "../tools/custom-action/Dockerfile",
+    //     "context": ".."
+    // },
     // Prepare environment to be identical to entrypoint.sh,
     // since entrypoint.sh is not run on creation.
     "postCreateCommand": "bash /prepare.sh",


### PR DESCRIPTION
Adds comments to clarify the use of the image from the CI and the option to build the image from a Dockerfile. The latter is commented out so that if developer intends to try something, they can easily uncomment. I am using this often when I iterate locally.