### PR TITLE
Specify that ASTC Sliced 3D feature requires ASTC feature

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2431,6 +2431,8 @@ Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the followi
 - If either {{GPUFeatureName/"texture-compression-bc"}} or
     {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
     is supported, both must be supported.
+- If {{GPUFeatureName/"texture-compression-astc-sliced-3d"}}
+    is supported, then {{GPUFeatureName/"texture-compression-astc"}} must be supported.
 - All supported limits must be either the [=limit/default=] value or [=limit/better=].
 - All [=limit class/alignment|alignment-class=] limits must be powers of 2.
 - {{supported limits/maxBindingsPerBindGroup}} must be must be &ge;


### PR DESCRIPTION
To make it clear that `"texture-compression-astc-sliced-3d"` feature requires `"texture-compression-astc"` feature, let's add it to the Adapter Capability Guarantees section.

cc @mehmetoguzderin 