### PR TITLE
[binding array proposal] Choose a clearer name for binding array size, in BGL

### DIFF
--- a/proposals/sized-binding-arrays.md
+++ b/proposals/sized-binding-arrays.md
@@ -15,7 +15,7 @@ The addition of arrays of bindings would let shaders perform more dynamic use of
 Note that this is *not* the addition of "bindless" which would allow dynamically indexing an unbounded amount of resources.
 Bindless requires hardware support that's missing in many devices that WebGPU supports.
 Fixed-sized binding arrays are more limited, but enjoy ubiquitous hardware support.
-However this proposal is a stepping stone towards bindless as the `arraySize`, `binding_array` and other concept can be extended for bindless in the future.
+However this proposal is a stepping stone towards bindless as the `bindingCount`, `binding_array` and other concept can be extended for bindless in the future.
 
 Hardware may have constraints around what kind of indexing is allowed in binding arrays: const-expression, uniform, or non-uniform indexing.
 The choice done for indexing uniformity influences what level of emulation will need to happen in implementations.
@@ -25,26 +25,30 @@ WebGPU needs to choose what resources can be dynamically indexed, and what level
 
 ## API changes
 
-On the API side, `GPUBindGroupLayoutEntry` gains a new `arraySize` property that gives the number of elements of the array for this entry.
-The elements for the entry are the ones with binding number between (inclusively) `entry.binding` and `entry.binding + entry.arraySize - 1`.
-Arrays of size 1 and single bindings are equivalent between shader and bind group layout matching, such that all current WebGPU code is as if it had the `arraySize` value of 1.
-For that reason, `arraySize` is defaulted to 1.
+On the API side, `GPUBindGroupLayoutEntry` gains a new `bindingCount` property that gives the number of elements of the array for this entry.
+The elements for the entry are the ones with binding number between (inclusively) `entry.binding` and `entry.binding + entry.bindingCount - 1`.
+Arrays of size 1 and single bindings are equivalent between shader and bind group layout matching, such that all current WebGPU code is as if it had the `bindingCount` value of 1.
+For that reason, `bindingCount` is defaulted to 1.
 
-```webidl
-partial dictionary GPUBindGroupLayoutEntry {
-    GPUSize32 arraySize = 1;
-};
+```diff
+ dictionary GPUBindGroupLayoutEntry {
+     required GPUIndex32 binding;
++    GPUSize32 bindingCount = 1;
+     required GPUShaderStageFlags visibility;
+
+     // ...
+ };
 ```
 
 Changes to validation are done:
 
- - An `arraySize` value of 0 is invalid and produces an error `GPUBindGroupLayout`.
- - When counting limits, the counts towards limits are multiplied by the `arraySize`.
- - Checks that bindings numbers in a `GPUBindGroupLayout` don't conflict is updated to take into account the ranges for the `arraySize`.
- - Checks that `GPUBindGroup` creation specifies all require bindings is updated to take into account the ranges for the `arraySize`.
- - (Optionally) Checks that bindings with `arraySize > 1` are in the allow-list of bindings for fixed-size arrays.
+ - An `bindingCount` value of 0 is invalid and produces an error `GPUBindGroupLayout`.
+ - When counting limits, the counts towards limits are multiplied by the `bindingCount`.
+ - Checks that bindings numbers in a `GPUBindGroupLayout` don't conflict is updated to take into account the ranges for the `bindingCount`.
+ - Checks that `GPUBindGroup` creation specifies all require bindings is updated to take into account the ranges for the `bindingCount`.
+ - (Optionally) Checks that bindings with `bindingCount > 1` are in the allow-list of bindings for fixed-size arrays.
 
-Pipeline layout defaulting is also updated to reflect and set an `arraySize` in the `GPUBindGroupLayouts` it creates.
+Pipeline layout defaulting is also updated to reflect and set an `bindingCount` in the `GPUBindGroupLayouts` it creates.
 
 ## WGSL
 
@@ -54,7 +58,7 @@ It can be used for feature detection of both the API-side support and the WGSL-s
 A new `binding_array<T, N>` type is added that can only be used as a binding and not created directly in shaders.
 
  - `N` is the size of the array and must be a compile-time constant value or (optionally) an override constant.
-   It is validated to less than or equal to the `arraySize` of the respective `GPUBindGroupLayoutEntry`.
+   It is validated to less than or equal to the `bindingCount` of the respective `GPUBindGroupLayoutEntry`.
  - `T` is the type of the binding this array is used for, which is validated against the rest of the contents of the `GPUBindGroupLayoutEntry`.
 
 (TODO for WGSL, can `binding_array` be passed around in function parameters?)
@@ -63,7 +67,7 @@ New array access expressions are added for `binding_array`:
 
  - `e: binding_array<T, N> and i: i32 or u32` -> `e[i]: T`. The result is the value of the `i`th element of the array value `e`.
     If `i` is outside of the range `[0, N-1]`:
-    
+
     - It is a shader-creation error if `i` is a const-expression.
     - It is a pipeline-creation error if `i` is an override-expression.
     - Otherwise, any element in the array may be returned.


### PR DESCRIPTION
Based on [input](https://github.com/webgpu-native/webgpu-headers/issues/387#issuecomment-2829132169) that `wgpu`'s name, [`count`](https://docs.rs/wgpu/latest/wgpu/struct.BindGroupLayoutEntry.html#:~:text=pub%20count%3A%20Option%3CNonZero%3Cu32%3E%3E), sometimes causes confusion with the number of layers in a 2d-array texture binding.

~I propose changing this to `bindingCount` since we already have `binding` (which now is more like "binding start") and putting it next to that.~
Now proposing `bindingArraySize`.