### PR TITLE
Copy license to out/ for gh-pages

### DIFF
--- a/tools/populate-out.sh
+++ b/tools/populate-out.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 
 mkdir -p out/{wgsl,wgsl/grammar,explainer,correspondence}
 
+cp LICENSE.md out/
+
 cp -r spec/{index.html,webgpu.idl,img} out/
 cp spec/webgpu.idl out/webgpu.idl.txt
 


### PR DESCRIPTION
The autogenerate gh-pages branch currently has no license. This branch is sometimes used as a dependency because it contains `webgpu.idl`. So it should include the license file.