### PR TITLE
Fix custom dark mode styles for Bikeshed switcher

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -493,17 +493,15 @@ thead.stickyheader th, th.stickyheader {
     --note-editorial-color: #c06e00;
     --note-editorial-bg: #ffeedd;
 }
-@media (prefers-color-scheme:dark) {
-    :root {
-        --watermark-text: rgba(255, 255, 255, 25%);
-        --stickyheader-background: #181818;
-        --tint-red: rgba(255, 0, 0, 20%);
-        --tint-green: rgba(0, 255, 0, 18%);
-        --tint-blue: rgba(0, 130, 255, 24%);
-        --tint-purple: rgba(255, 0, 255, 22%);
-        --note-editorial-color: #ff9100;
-        --note-editorial-bg: var(--borderedblock-bg);
-    }
+body.darkmode {
+    --watermark-text: rgba(255, 255, 255, 25%);
+    --stickyheader-background: #181818;
+    --tint-red: rgba(255, 0, 0, 20%);
+    --tint-green: rgba(0, 255, 0, 18%);
+    --tint-blue: rgba(0, 130, 255, 24%);
+    --tint-purple: rgba(255, 0, 255, 22%);
+    --note-editorial-color: #ff9100;
+    --note-editorial-bg: var(--borderedblock-bg);
 }
 </style>
 


### PR DESCRIPTION
Bikeshed added a light/dark mode theme switcher in a floating sidebar (in the lower left). Rather than change the media query (because that's not possible), it changes the class on the body element and enables/disables the dark.css stylesheet.

Currently this switcher only works in TR (see speced/bikeshed#3092), but working around that locally, this makes our styles follow the switcher properly. (Unfortunately since the switcher doesn't work on github.io, this makes it so that IF you use it, it messes up these particular styles. But that'll go away when it's fixed.)

Issue: https://github.com/gpuweb/gpuweb/discussions/5178#discussioncomment-12987193