### PR TITLE
BC does not guarantee Sliced 3D

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2428,9 +2428,8 @@ Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the followi
     - {{GPUFeatureName/"texture-compression-bc"}} is supported.
     - Both {{GPUFeatureName/"texture-compression-etc2"}} and
         {{GPUFeatureName/"texture-compression-astc"}} are supported.
-- If either {{GPUFeatureName/"texture-compression-bc"}} or
-    {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
-    is supported, both must be supported.
+- If {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
+    is supported, then {{GPUFeatureName/"texture-compression-bc"}} must be supported.
 - If {{GPUFeatureName/"texture-compression-astc-sliced-3d"}}
     is supported, then {{GPUFeatureName/"texture-compression-astc"}} must be supported.
 - All supported limits must be either the [=limit/default=] value or [=limit/better=].
@@ -16521,10 +16520,11 @@ This feature adds the following [=optional API surfaces=]:
 
 Allows for explicit creation of textures of BC compressed formats. Only supports 2D textures.
 
-Note: Adapters which support either {{GPUFeatureName/"texture-compression-bc"}}
-or {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
-always support both, even though they are separate features.
-To use {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}, enable it separately.
+Note: Adapters which support {{GPUFeatureName/"texture-compression-bc"}} do not
+always support {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}.
+To use {{GPUFeatureName/"texture-compression-bc-sliced-3d"}},
+{{GPUFeatureName/"texture-compression-bc"}} must be enabled explicitly as this feature
+does not enable the BC formats.
 
 This feature adds the following [=optional API surfaces=]:
 
@@ -16550,11 +16550,11 @@ This feature adds the following [=optional API surfaces=]:
 
 Allows the {{GPUTextureDimension/3d}} dimension for textures with BC compressed formats.
 
-Note: Adapters which support either {{GPUFeatureName/"texture-compression-bc"}}
-or {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
-always support both, even though they are separate features.
+Note: Adapters which support {{GPUFeatureName/"texture-compression-bc"}} do not
+always support {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}.
 To use {{GPUFeatureName/"texture-compression-bc-sliced-3d"}},
-both must be enabled explicitly as this feature does not enable the BC formats.
+{{GPUFeatureName/"texture-compression-bc"}} must be enabled explicitly as this feature
+does not enable the BC formats.
 
 This feature adds no [=optional API surfaces=].
 


### PR DESCRIPTION
This PR drops the requirement for BC to guarantee Sliced 3D from core, which increases symmetry with ASTC.

Previous discussion: https://github.com/gpuweb/gpuweb/pull/5180 (thanks to @SenorBlanco for review)