### PR TITLE
In "Limits", remove duplicated note.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1492,7 +1492,7 @@ Each <dfn dfn>limit</dfn> is a numeric limit on the usage of WebGPU on a device.
 Note:
 Setting "better" limits may not necessarily be desirable, as doing so may have a performance impact.
 Because of this, and to improve portability across devices and implementations, applications should
-generally only request better limits if they may actually require them.
+generally only request limits better than the defaults if they may actually require them.
 
 Each limit has a <dfn dfn for=limit>default</dfn> value.
 
@@ -1530,12 +1530,6 @@ Different limits have different <dfn dfn lt="limit class">limit classes</dfn>:
         Values which are not powers of 2 are invalid.
         Higher powers of 2 are clamped to the [=limit/default=].
 </dl>
-
-Note:
-Setting "better" limits may not necessarily be desirable, as they may have a performance impact.
-Because of this, and to improve portability across devices and implementations,
-applications should generally request the "worst" limits that work for their content
-(ideally, the default values).
 
 A <dfn dfn>supported limits</dfn> object has a value for every limit defined by WebGPU:
 


### PR DESCRIPTION
The note recommending users request the lowest limits that work for their content occurs in two places with slightly different wording, the first added in 26e66b0d5 (2024-08-13), and the second in a2b36aeb8 (2020-10-01).

Delete the second occurrence, but retain the mention of the default values.