### PR TITLE
Introduce some CSS style for Compat Mode restrictions; give an example

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -219,7 +219,7 @@ object[type="image/svg+xml"] {
 
 /* The new spec template doesn't put a box around algorithms anymore. */
 /* Add a similar box for Valid Usage requirements. */
-div.algorithm, div.validusage {
+div.algorithm, div.validusage, div.compatmode {
     margin: .5em 0;
     padding: .5em;
     border-width: thin;
@@ -228,6 +228,9 @@ div.algorithm, div.validusage {
 }
 div.validusage {
     border-color: #88e;
+}
+div.compatmode {
+    border-color: #f0f;
 }
 div.algorithm {
     border-color: #ddd;
@@ -322,12 +325,13 @@ div.algorithm > div[data-timeline] {
  * NOTE: This text is non-accessible (no alt text) and non-selectable;
  * surrounding text must also explain the context.
  */
-.validusage,
+.validusage, .compatmode,
 .content-timeline, .device-timeline, .queue-timeline,
 [data-timeline] {
     position: relative;
 }
 .validusage::before,
+.compatmode::before,
 .content-timeline::before,
 .device-timeline::before,
 .queue-timeline::before {
@@ -343,6 +347,10 @@ div.algorithm > div[data-timeline] {
 .validusage::before {
     content: "Valid Usage";
     content: "Valid Usage" / ""; /* No alt text, see above */
+}
+.compatmode::before {
+    content: "Compatibility Mode";
+    content: "Compatibility Mode" / ""; /* No alt text, see above */
 }
 .content-timeline::before {
     content: "Content Timeline";
@@ -8714,6 +8722,13 @@ dictionary GPUFragmentState
                 - All the [=shader stage outputs=] with [=location=] in |entryPoint| must be in one
                     struct and [=use dual source blending=].
             - [$Validating GPUFragmentState's color attachment bytes per sample$](|device|, |descriptor|.{{GPUFragmentState/targets}}) succeeds.
+        </div>
+
+        <div class=compatmode>
+            - [=list/For each=] |index| of the [=list/indices=] of |descriptor|.{{GPUFragmentState/targets}}
+                - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}} must have the same value
+                - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}} must have the same value
+                - |colorState|.{{GPUColorTargetState/writeMask}} must have the same value
         </div>
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2499,7 +2499,7 @@ enum GPUPowerPreference {
             : <dfn noexport>"core"</dfn>
             :: Requests a Core Level Adapter. If the implementation does not support Core Level, a null Adapter will be returned.
             : <dfn noexport>"compatibility"</dfn>
-            :: Requests a Compatibility Adapter. If the implementation supports Compatibility mode, the returned Adapter will support Compatiblity mode. All Devices created from it will enforce Compatiblity mode validation. If the implementation does not support compatibility mode, a Core level Adapter will be returned, with the "core-features-and-limits" Feature enabled.
+            :: Requests a Compatibility Mode Adapter. If the request is honored by the User Agent, the resulting adapter will be a "Compatibility-defaulting" Adapter. If not, and the device supports Core WebGPU, the resulting adapter will be a "Core-defaulting" adapter, the same as would be obtained by `featureLevel: "core"`. By default, all Devices created from a "Compatibility-defaulting" adapter will enforce the Compatibility mode subset via validation. Compatibility-defaulting Adapters *may* support the "core-features-and-limits" feature. It *may be requested* on devices created from such adapters. Core-defaulting adapters *always* support the `"core-features-and-limits"` feature. It is *automatically enabled* on devices created from such adapters.
         </dl>
 
     : <dfn>powerPreference</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2497,13 +2497,9 @@ enum GPUPowerPreference {
 
         <dl dfn-type=dfn dfn-for="feature level string">
             : <dfn noexport>"core"</dfn>
-            :: No effect.
+            :: Requests a Core Level Adapter. If the implementation does not support Core Level, a null Adapter will be returned.
             : <dfn noexport>"compatibility"</dfn>
-            :: No effect.
-
-                Note:
-                This value is reserved for future use as a way to opt into additional validation restrictions.
-                Applications should not use this value at this time.
+            :: Requests a Compatibility Adapter. If the implementation supports Compatibility mode, the returned Adapter will support Compatiblity mode. All Devices created from it will enforce Compatiblity mode validation. If the implementation does not support compatibility mode, a Core level Adapter will be returned, with the "core-features-and-limits" Feature enabled.
         </dl>
 
     : <dfn>powerPreference</dfn>


### PR DESCRIPTION
Use a purple box with "Compatibility Mode" in it, similar to the "Valid Usage" styling.
As an example, add restriction 2 ("Color blending state may not differ between color attachments in a `GPUFragmentState`.") from the compat proposal in that style.

Note: the purple color was chosen not to match any existing style. Suggestions are welcome.

The example given puts a separate "Compatibility Mode" box below the "Valid Usage" box. Other options:

1. The "Compatibility Mode" box could be nested inside the "Valid Usage" box.
2. Each separate restriction (`writemask`, `blend.color`, `blend.alpha`) could have its own box in the appropriate section.