### PR TITLE
Add [AllowShared] to setBindGroup

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10812,7 +10812,7 @@ interface mixin GPUBindingCommandsMixin {
         optional sequence<GPUBufferDynamicOffset> dynamicOffsets = []);
 
     undefined setBindGroup(GPUIndex32 index, GPUBindGroup? bindGroup,
-        Uint32Array dynamicOffsetsData,
+        [AllowShared] Uint32Array dynamicOffsetsData,
         GPUSize64 dynamicOffsetsDataStart,
         GPUSize32 dynamicOffsetsDataLength);
 };


### PR DESCRIPTION
This was always intended to be here, we just forgot it when we were adding SharedArrayBuffer support elsewhere (which went through many iterations due to lack of support in WebIDL).

This is not technically an editorial change but we definitely intended it, so IMO we should go ahead and land it and I'll put it as an FYI on the WG agenda.

Fixes #5201