### PR TITLE
Compat: Disallow copying of compressed textures

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10573,6 +10573,12 @@ dictionary GPUCommandEncoderDescriptor
                         - |destination|.{{GPUTexelCopyBufferInfo/buffer}}.{{GPUBuffer/usage}} contains
                             {{GPUBufferUsage/COPY_DST}}.
                         - [$validating texture buffer copy$](|source|, |destination|, |dataLength|, |copySize|, {{GPUTextureUsage/COPY_SRC}}, |aligned|) returns `true`.
+
+                        <div class=compatmode>
+                            - If device.{{device/[[features]]}} does not [=list/contain=]
+                                {{GPUFeatureName/"core-features-and-limits"}}:
+                                - |source|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}} must not be a [=compressed format=].
+                        </div>
                     </div>
 
                 1. [$Enqueue a command$] on |this| which issues the subsequent steps on the
@@ -10657,6 +10663,13 @@ dictionary GPUCommandEncoderDescriptor
                                 and |dstTexture|.{{GPUTexture/format}}, respectively.
                         - The [$set of subresources for texture copy$](|source|, |copySize|) and
                             the [$set of subresources for texture copy$](|destination|, |copySize|) are disjoint.
+
+                        <div class=compatmode>
+                            - If device.{{device/[[features]]}} does not [=list/contain=]
+                                {{GPUFeatureName/"core-features-and-limits"}}:
+                                - |source|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}} must not be a [=compressed format=].
+                                - |destination|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}} must not be a [=compressed format=].
+                        </div>
                     </div>
 
                 1. [$Enqueue a command$] on |this| which issues the subsequent steps on the


### PR DESCRIPTION
This is restriction #3 from the compat proposal.