### PR TITLE
Compat: add limitation on cube-array.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4860,7 +4860,7 @@ enum GPUTextureAspect {
                                     - |this|.{{GPUTexture/width}} must equal |this|.{{GPUTexture/height}}.
 
                                     <div class=compatmode>
-                                        - {{GPUObjectBase/[[device]]}}.{{device/[[features]]}} must [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}
+                                        - {{GPUObjectBase/[[device]]}}.{{device/[[features]]}} must [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}.
                                     </div>
                                 : {{GPUTextureViewDimension/"3d"}}
                                 ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4859,6 +4859,9 @@ enum GPUTextureAspect {
                                     - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be a multiple of `6`.
                                     - |this|.{{GPUTexture/width}} must equal |this|.{{GPUTexture/height}}.
 
+                                    <div class=compatmode>
+                                        - {{GPUObjectBase/[[device]]}}.{{device/[[features]]}} must [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}
+                                    </div>
                                 : {{GPUTextureViewDimension/"3d"}}
                                 ::
                                     - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"3d"}}.


### PR DESCRIPTION
`GPUTextureViewDescriptor.dimension` must not be `"cube-array"` in Compatibility Mode (issue #4 from the compatibility-mode proposal).