### PR TITLE
Add optional feature `texture-formats-tier2`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1378,6 +1378,8 @@ implicitly [$valid to use with|unusable$].
 
     1. Let |features| be the [=set=] of values in
         |descriptor|.{{GPUDeviceDescriptor/requiredFeatures}}.
+    1. If |features| contains {{GPUFeatureName/"texture-formats-tier2"}}:
+        1. [=set/Append=] {{GPUFeatureName/"texture-formats-tier1"}} to |features|
     1. If |features| contains {{GPUFeatureName/"texture-formats-tier1"}}:
         1. [=set/Append=] {{GPUFeatureName/"rg11b10ufloat-renderable"}} to |features|
     1. [=set/Append=] {{GPUFeatureName/"core-features-and-limits"}} to |features|.
@@ -2887,6 +2889,7 @@ enum GPUFeatureName {
     "dual-source-blending",
     "subgroups",
     "texture-formats-tier1",
+    "texture-formats-tier2",
 };
 </script>
 
@@ -16790,9 +16793,6 @@ capabilities on below {{GPUTextureFormat}}s:
 - {{GPUTextureFormat/"rg8snorm"}}
 - {{GPUTextureFormat/"rgba8snorm"}}
 
-Enabling {{GPUFeatureName/"texture-formats-tier1"}} at device creation will also enable
-{{GPUFeatureName/"rg11b10ufloat-renderable"}}.
-
 Allows the {{GPUStorageTextureAccess/"read-only"}} or {{GPUStorageTextureAccess/"write-only"}}
 {{GPUStorageTextureAccess}} on below {{GPUTextureFormat}}s:
 - {{GPUTextureFormat/"r8unorm"}}
@@ -16813,7 +16813,36 @@ Allows the {{GPUStorageTextureAccess/"read-only"}} or {{GPUStorageTextureAccess/
 - {{GPUTextureFormat/"rgb10a2unorm"}}
 - {{GPUTextureFormat/"rg11b10ufloat"}}
 
-This feature adds no [=optional API surfaces=].
+Enabling {{GPUFeatureName/"texture-formats-tier2"}} at device creation will also enable
+{{GPUFeatureName/"texture-formats-tier1"}}.
+
+Enabling {{GPUFeatureName/"texture-formats-tier1"}} at device creation will also enable
+{{GPUFeatureName/"rg11b10ufloat-renderable"}}.
+
+<h3 id=texture-formats-tier2 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-formats-tier2"`
+
+Allows the {{GPUStorageTextureAccess/"read-write"}} {{GPUStorageTextureAccess}} on below
+{{GPUTextureFormat}}s:
+- {{GPUTextureFormat/"r8unorm"}}
+- {{GPUTextureFormat/"r8uint"}}
+- {{GPUTextureFormat/"r8sint"}}
+- {{GPUTextureFormat/"rgba8unorm"}}
+- {{GPUTextureFormat/"rgba8uint"}}
+- {{GPUTextureFormat/"rgba8sint"}}
+- {{GPUTextureFormat/"r16uint"}}
+- {{GPUTextureFormat/"r16sint"}}
+- {{GPUTextureFormat/"r16float"}}
+- {{GPUTextureFormat/"rgba16uint"}}
+- {{GPUTextureFormat/"rgba16sint"}}
+- {{GPUTextureFormat/"rgba16float"}}
+- {{GPUTextureFormat/"rgba32uint"}}
+- {{GPUTextureFormat/"rgba32sint"}}
+- {{GPUTextureFormat/"rgba32float"}}
+
+Enabling {{GPUFeatureName/"texture-formats-tier2"}} at device creation will also enable
+{{GPUFeatureName/"texture-formats-tier1"}}.
+
+</h3>
 
 # Appendices # {#appendices}
 
@@ -16865,7 +16894,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>1
     <tr>
         <td>{{GPUTextureFormat/r8snorm}}
@@ -16884,7 +16913,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td><!-- Metal -->
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>1
     <tr>
         <td>{{GPUTextureFormat/r8sint}}
@@ -16895,7 +16924,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td><!-- Metal -->
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>1
     <tr>
         <td>{{GPUTextureFormat/rg8unorm}}
@@ -16948,7 +16977,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td>4
         <td>8
     <tr>
@@ -16984,7 +17013,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/rgba8sint}}
@@ -16996,7 +17025,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>4
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm}}
@@ -17058,7 +17087,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td><!-- Metal -->
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/r16sint}}
@@ -17069,7 +17098,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td><!-- Metal -->
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/r16float}}
@@ -17080,7 +17109,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/rg16unorm}}
@@ -17173,7 +17202,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>8
     <tr>
         <td>{{GPUTextureFormat/rgba16sint}}
@@ -17185,7 +17214,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td><!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>8
     <tr>
         <td>{{GPUTextureFormat/rgba16float}}
@@ -17197,7 +17226,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>8
     <tr><th colspan=12>32 bits per component (4-byte [=render target component alignment=])
     <tr>
@@ -17286,7 +17315,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td>&checkmark;
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>16
     <tr>
         <td>{{GPUTextureFormat/rgba32sint}}
@@ -17298,7 +17327,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td>&checkmark;
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>16
     <tr>
         <td>{{GPUTextureFormat/rgba32float}}
@@ -17312,7 +17341,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td>&checkmark;
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
         <td colspan=2>16
     <tr><th colspan=12>mixed component width, 32 bits per texel (4-byte [=render target component alignment=])
     <tr>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -16820,6 +16820,7 @@ Enabling {{GPUFeatureName/"texture-formats-tier1"}} at device creation will also
 {{GPUFeatureName/"rg11b10ufloat-renderable"}}.
 
 <h3 id=texture-formats-tier2 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-formats-tier2"`
+</h3>
 
 Allows the {{GPUStorageTextureAccess/"read-write"}} {{GPUStorageTextureAccess}} on below
 {{GPUTextureFormat}}s:
@@ -16841,8 +16842,6 @@ Allows the {{GPUStorageTextureAccess/"read-write"}} {{GPUStorageTextureAccess}} 
 
 Enabling {{GPUFeatureName/"texture-formats-tier2"}} at device creation will also enable
 {{GPUFeatureName/"texture-formats-tier1"}}.
-
-</h3>
 
 # Appendices # {#appendices}
 


### PR DESCRIPTION
This patch adds the optional feature `texture-formats-tier2` with below new features
based on [the previous investigation](https://github.com/gpuweb/gpuweb/pull/5160#issuecomment-2880054964):

- Allows the `read-write` storage texture access on below texture formats:
  - `r8unorm`
  - `r8uint`
  - `r8sint`
  - `rgba8unorm`
  - `rgba8uint`
  - `rgba8sint`
  - `r16uint`
  - `r16sint`
  - `r16float`
  - `rgba16uint`
  - `rgba16sint`
  - `rgba16float`
  - `rgba32uint`
  - `rgba32sint`
  - `rgba32float`
- Enabling `texture-formats-tier2` will also enable `texture-formats-tier1`.

Fixed: #3838