### PR TITLE
Remove GPUComponentSwizzle identity from texture component swizzle proposal

### DIFF
--- a/proposals/texture-component-swizzle.md
+++ b/proposals/texture-component-swizzle.md
@@ -30,15 +30,14 @@ partial dictionary GPUTextureViewDescriptor {
 
 // Structure specifying a custom color component mapping for a texture view.
 dictionary GPUTextureComponentSwizzle {
-    GPUComponentSwizzle r = "identity";
-    GPUComponentSwizzle g = "identity";
-    GPUComponentSwizzle b = "identity";
-    GPUComponentSwizzle a = "identity";
+    GPUComponentSwizzle r = "r";
+    GPUComponentSwizzle g = "g";
+    GPUComponentSwizzle b = "b";
+    GPUComponentSwizzle a = "a";
 };
 
 // A set of options to choose from when specifying a component swizzle.
 enum GPUComponentSwizzle {
-    "identity", // Set to the identity swizzle.
     "zero",     // Force its value to 0.
     "one",      // Force its value to 1.
     "r",        // Take its value from the red channel of the texture.
@@ -51,10 +50,10 @@ enum GPUComponentSwizzle {
 The `GPUTexture.createView(descriptor)` algorithm is extended with the following validation rules changes:
 
 - If `descriptor.usage` includes the `RENDER_ATTACHMENT` or `STORAGE_BINDING` bit:
-  - `descriptor.swizzle.r` must be `"identity"`.
-  - `descriptor.swizzle.g` must be `"identity"`.
-  - `descriptor.swizzle.b` must be `"identity"`.
-  - `descriptor.swizzle.a` must be `"identity"`.
+  - `descriptor.swizzle.r` must be `"r"`.
+  - `descriptor.swizzle.g` must be `"g"`.
+  - `descriptor.swizzle.b` must be `"b"`.
+  - `descriptor.swizzle.a` must be `"a"`.
 
 ## Javascript example
 


### PR DESCRIPTION
Following https://github.com/gpuweb/gpuweb/pull/5217#pullrequestreview-2936578403 and [GPU Web WG meeting 2025-06-18 Atlantic-time discussion](https://docs.google.com/document/d/16BClHgYUMpyjwsjsJ-HknFpjkLf4HbdvchsfWCa_AUw/edit?tab=t.0#heading=h.d42mv5ngrgum), this PR removes the GPUComponentSwizzle `"identity"` from the texture component swizzle proposal.