### PR TITLE
Allow GPUTexture where GPUTextureView is used

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6460,7 +6460,7 @@ following members:
                                     ::
                                         - |resource| is either a {{GPUTexture}} or a {{GPUTextureView}}.
                                         - |resource| is [$valid to use with$] |this|.
-                                        - Let |textureView| be [$get texture view$](|resource|).
+                                        - Let |textureView| be [$resolve texture view$](|resource|).
                                         - Let |texture| be |textureView|.{{GPUTextureView/[[texture]]}}.
                                         - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}
                                             is equal to |textureView|'s {{GPUTextureViewDescriptor/dimension}}.
@@ -6477,7 +6477,7 @@ following members:
                                     ::
                                         - |resource| is either a {{GPUTexture}} or a {{GPUTextureView}}.
                                         - |resource| is [$valid to use with$] |this|.
-                                        - Let |storageTextureView| be [$get texture view$](|resource|).
+                                        - Let |storageTextureView| be [$resolve texture view$](|resource|).
                                         - Let |texture| be |storageTextureView|.{{GPUTextureView/[[texture]]}}.
                                         - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/viewDimension}}
                                             is equal to |storageTextureView|'s {{GPUTextureViewDescriptor/dimension}}.
@@ -6530,7 +6530,7 @@ following members:
                                             <dl class=switch>
                                                 : {{GPUTexture}} or {{GPUTextureView}}
                                                 ::
-                                                    - Let |externalTextureView| be [$get texture view$](|resource|).
+                                                    - Let |externalTextureView| be [$resolve texture view$](|resource|).
                                                     - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
                                                         must include {{GPUTextureUsage/TEXTURE_BINDING}}.
                                                     - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/dimension}}
@@ -6566,7 +6566,7 @@ following members:
 </dl>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>get texture view</dfn>(|resource|)
+    <dfn abstract-op>resolve texture view</dfn>(|resource|)
 
     **Arguments:**
 
@@ -11880,9 +11880,8 @@ dictionary GPURenderPassColorAttachment {
 <dl dfn-type=dict-member dfn-for=GPURenderPassColorAttachment>
     : <dfn>view</dfn>
     ::
-        A {{GPUTextureView}} describing the texture [=subresource=] that will be output to for this
-        color attachment. If {{GPURenderPassColorAttachment/view}} is a {{GPUTexture}},
-        returns [$get texture view$]({{GPURenderPassColorAttachment/view}}).
+        Describes the texture [=subresource=] that will be output to for this color attachment.
+        The [=subresource=] is determined by calling [$resolve texture view$]({{GPURenderPassColorAttachment/view}}).
 
     : <dfn>depthSlice</dfn>
     ::
@@ -11891,10 +11890,9 @@ dictionary GPURenderPassColorAttachment {
 
     : <dfn>resolveTarget</dfn>
     ::
-        A {{GPUTextureView}} describing the texture [=subresource=] that will receive the resolved
-        output for this color attachment if {{GPURenderPassColorAttachment/view}} is
-        multisampled. If {{GPURenderPassColorAttachment/resolveTarget}} is a {{GPUTexture}},
-        returns [$get texture view$]({{GPURenderPassColorAttachment/resolveTarget}}).
+        Describes the texture [=subresource=] that will receive the resolved output for this color
+        attachment if {{GPURenderPassColorAttachment/view}} is multisampled.
+        The [=subresource=] is determined by calling [$resolve texture view$]({{GPURenderPassColorAttachment/resolveTarget}}).
 
     : <dfn>clearValue</dfn>
     ::
@@ -12020,9 +12018,9 @@ dictionary GPURenderPassDepthStencilAttachment {
 <dl dfn-type=dict-member dfn-for=GPURenderPassDepthStencilAttachment>
     : <dfn>view</dfn>
     ::
-        A {{GPUTextureView}} describing the texture [=subresource=] that will be output to
-        and read from for this depth/stencil attachment. If {{GPURenderPassDepthStencilAttachment/view}}
-        is a {{GPUTexture}}, returns [$get texture view$]({{GPURenderPassDepthStencilAttachment/view}}).
+        Describes the texture [=subresource=] that will be output to and read from for this
+        depth/stencil attachment.
+        The [=subresource=] is determined by calling [$resolve texture view$]({{GPURenderPassDepthStencilAttachment/view}}).
 
     : <dfn>depthClearValue</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5814,31 +5814,16 @@ dictionary GPUBindGroupLayoutEntry {
         will be accessible from the associated shader stage.
 
     : <dfn>buffer</dfn>
-    ::
-        When [=map/exist|provided=], indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is either {{GPUBuffer}} or {{GPUBufferBinding}}.
-
     : <dfn>sampler</dfn>
-    ::
-        When [=map/exist|provided=], indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is {{GPUSampler}}.
-
     : <dfn>texture</dfn>
-    ::
-        When [=map/exist|provided=], indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is either {{GPUTexture}} or {{GPUTextureView}}.
-
     : <dfn>storageTexture</dfn>
-    ::
-        When [=map/exist|provided=], indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is either {{GPUTexture}} or {{GPUTextureView}}.
-
     : <dfn>externalTexture</dfn>
     ::
-        When [=map/exist|provided=], indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is either {{GPUExternalTexture}}, {{GPUTexture}}, or {{GPUTextureView}}.
+        Exactly one of these members must be set, indicating the binding type.
+        The contents of the member specify options specific to that type.
 
-        External textures use several binding slots: see [=Exceeds the binding slot limits=].
+        The corresponding resource in {{GPUDevice/createBindGroup()}} requires
+        the corresponding [=binding resource type=] for this binding.
 </dl>
 
 <script type=idl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5887,7 +5887,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     </thead>
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/buffer}}
-        <td rowspan=3>{{GPUBuffer}} or <br/>{{GPUBufferBinding}}
+        <td rowspan=3>{{GPUBufferBinding}}<br>(or {{GPUBuffer}} as [$get as buffer binding|shorthand$])
         <td>{{GPUBufferBindingType/"uniform"}}
         <td>[=internal usage/constant=]
     <tr>
@@ -5909,7 +5909,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
 
     <tr>
         <td rowspan=5>{{GPUBindGroupLayoutEntry/texture}}
-        <td rowspan=5>{{GPUTexture}} or<br/>{{GPUTextureView}}
+        <td rowspan=5>{{GPUTextureView}}<br>(or {{GPUTexture}} as [$get as texture view|shorthand$])
         <td>{{GPUTextureSampleType/"float"}}
         <td rowspan=5>[=internal usage/constant=]
     <tr>
@@ -5923,7 +5923,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
 
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/storageTexture}}
-        <td rowspan=3>{{GPUTexture}} or<br/>{{GPUTextureView}}
+        <td rowspan=3>{{GPUTextureView}}<br>(or {{GPUTexture}} as [$get as texture view|shorthand$])
         <td>{{GPUStorageTextureAccess/"write-only"}}
         <td rowspan=2>[=internal usage/storage=]
     <tr>
@@ -5934,7 +5934,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
 
     <tr>
         <td>{{GPUBindGroupLayoutEntry/externalTexture}}
-        <td>{{GPUExternalTexture}},<br/>{{GPUTexture}}, or<br/>{{GPUTextureView}}
+        <td>{{GPUExternalTexture}}<br>or {{GPUTextureView}}<br>(or {{GPUTexture}} as [$get as texture view|shorthand$])
         <td>
         <td>[=internal usage/constant=]
 </table>
@@ -6293,7 +6293,7 @@ GPUBindGroup includes GPUObjectBase;
             |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[entryMap]]}}[|bindGroupEntry|.{{GPUBindGroupEntry/binding}}].
         1. If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}} is not
             [=map/exists|provided=], **continue**.
-        1. Let |bound| be [$get buffer binding$](|bindGroupEntry|.{{GPUBindGroupEntry/resource}}).
+        1. Let |bound| be [$get as buffer binding$](|bindGroupEntry|.{{GPUBindGroupEntry/resource}}).
         1. If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}:
             1. Increment |bound|.{{GPUBufferBinding/offset}} by
                 |dynamicOffsets|[|dynamicOffsetIndex|].
@@ -6493,7 +6493,7 @@ following members:
                                     :  {{GPUBindGroupLayoutEntry/buffer}}
                                     ::
                                         - |resource| is either a {{GPUBuffer}} or a {{GPUBufferBinding}}.
-                                        - Let |bufferBinding| be [$get buffer binding$](|resource|).
+                                        - Let |bufferBinding| be [$get as buffer binding$](|resource|).
                                         - |bufferBinding|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
                                         - The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
                                             |bufferBinding|.{{GPUBufferBinding/size}} resides inside the buffer and has non-zero size.
@@ -6533,18 +6533,18 @@ following members:
                                             <dl class=switch>
                                                 : {{GPUTexture}} or {{GPUTextureView}}
                                                 ::
-                                                    - Let |externalTextureView| be [$get as texture view$](|resource|).
-                                                    - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
+                                                    - Let |view| be [$get as texture view$](|resource|).
+                                                    - |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
                                                         must include {{GPUTextureUsage/TEXTURE_BINDING}}.
-                                                    - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/dimension}}
+                                                    - |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/dimension}}
                                                         must be {{GPUTextureViewDimension/"2d"}}.
-                                                    - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}}
+                                                    - |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}}
                                                         must be 1.
-                                                    - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+                                                    - |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
                                                         must be {{GPUTextureFormat/"rgba8unorm"}},
                                                         {{GPUTextureFormat/"bgra8unorm"}}, or
                                                         {{GPUTextureFormat/"rgba16float"}}.
-                                                    - |externalTextureView|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}
+                                                    - |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}
                                                         must be 1.
                                             </dl>
                                 </dl>
@@ -6590,7 +6590,7 @@ following members:
 </div>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>get buffer binding</dfn>(|resource|)
+    <dfn abstract-op>get as buffer binding</dfn>(|resource|)
 
     **Arguments:**
 
@@ -11081,7 +11081,7 @@ It must only be included by interfaces which also include those mixins.
         1. Let |bindingDescriptor| be the {{GPUBindGroupLayoutEntry}} at
             |layout|.{{GPUBindGroupLayout/[[entryMap]]}}[|entry|.{{GPUBindGroupEntry/binding}}]:
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`:
-            1. Let |bufferBinding| be [$get buffer binding$](|entry|.{{GPUBindGroupEntry/resource}}).
+            1. Let |bufferBinding| be [$get as buffer binding$](|entry|.{{GPUBindGroupEntry/resource}}).
             1. Let |bufferLayout| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.
             1. Call |steps| with |bufferBinding|, |bufferLayout|, and |dynamicOffsetIndex|.
             1. Let |dynamicOffsetIndex| be |dynamicOffsetIndex| + `1`
@@ -11118,7 +11118,7 @@ It must only be included by interfaces which also include those mixins.
                         |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[entryMap]]}}[|bindGroupEntry|.{{GPUBindGroupEntry/binding}}].
                     - If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}} is not
                         [=map/exists|provided=], **continue**.
-                    - Let |bound| be [$get buffer binding$](|bindGroupEntry|.{{GPUBindGroupEntry/resource}}).
+                    - Let |bound| be [$get as buffer binding$](|bindGroupEntry|.{{GPUBindGroupEntry/resource}}).
                     - If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}:
                         - Increment |bound|.{{GPUBufferBinding/offset}} by
                             |dynamicOffsets|[|dynamicOffsetIndex|].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5420,11 +5420,12 @@ dictionary GPUExternalTextureDescriptor
 ## Sampling External Texture Bindings ## {#external-texture-sampling}
 
 The {{GPUBindGroupLayoutEntry/externalTexture}} binding point allows binding {{GPUExternalTexture}}
-objects (from dynamic image sources like videos). It also supports {{GPUTextureView}}.
+objects (from dynamic image sources like videos). It also supports {{GPUTexture}} and {{GPUTextureView}}.
 
 Note:
-When a {{GPUTextureView}} is bound to an {{GPUBindGroupLayoutEntry/externalTexture}} binding, it is
-like a {{GPUExternalTexture}} with a single RGBA plane and no crop, rotation, or color conversion.
+When a {{GPUTexture}} or a {{GPUTextureView}} is bound to an {{GPUBindGroupLayoutEntry/externalTexture}}
+binding, it is like a {{GPUExternalTexture}} with a single RGBA plane and no crop, rotation, or color
+conversion.
 
 External textures are represented in WGSL with `texture_external` and may be read using
 `textureLoad` and `textureSampleBaseClampToEdge`.
@@ -5812,7 +5813,7 @@ dictionary GPUBindGroupLayoutEntry {
     : <dfn>buffer</dfn>
     ::
         When [=map/exist|provided=], indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is {{GPUBufferBinding}}.
+        is either {{GPUBuffer}} or {{GPUBufferBinding}}.
 
     : <dfn>sampler</dfn>
     ::
@@ -5822,17 +5823,17 @@ dictionary GPUBindGroupLayoutEntry {
     : <dfn>texture</dfn>
     ::
         When [=map/exist|provided=], indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is {{GPUTextureView}}.
+        is either {{GPUTexture}} or {{GPUTextureView}}.
 
     : <dfn>storageTexture</dfn>
     ::
         When [=map/exist|provided=], indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is {{GPUTextureView}}.
+        is either {{GPUTexture}} or {{GPUTextureView}}.
 
     : <dfn>externalTexture</dfn>
     ::
         When [=map/exist|provided=], indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is either {{GPUExternalTexture}} or {{GPUTextureView}}.
+        is either {{GPUExternalTexture}}, {{GPUTexture}}, or {{GPUTextureView}}.
 
         External textures use several binding slots: see [=Exceeds the binding slot limits=].
 </dl>
@@ -5883,7 +5884,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     </thead>
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/buffer}}
-        <td rowspan=3>{{GPUBufferBinding}}
+        <td rowspan=3>{{GPUBuffer}} or <br/>{{GPUBufferBinding}}
         <td>{{GPUBufferBindingType/"uniform"}}
         <td>[=internal usage/constant=]
     <tr>
@@ -5905,7 +5906,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
 
     <tr>
         <td rowspan=5>{{GPUBindGroupLayoutEntry/texture}}
-        <td rowspan=5>{{GPUTextureView}}
+        <td rowspan=5>{{GPUTexture}} or<br/>{{GPUTextureView}}
         <td>{{GPUTextureSampleType/"float"}}
         <td rowspan=5>[=internal usage/constant=]
     <tr>
@@ -5919,7 +5920,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
 
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/storageTexture}}
-        <td rowspan=3>{{GPUTextureView}}
+        <td rowspan=3>{{GPUTexture}} or<br/>{{GPUTextureView}}
         <td>{{GPUStorageTextureAccess/"write-only"}}
         <td rowspan=2>[=internal usage/storage=]
     <tr>
@@ -5929,12 +5930,10 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td>[=internal usage/storage-read=]
 
     <tr>
-        <td rowspan=2>{{GPUBindGroupLayoutEntry/externalTexture}}
-        <td>{{GPUExternalTexture}}
-        <td rowspan=2>
-        <td rowspan=2>[=internal usage/constant=]
-    <tr>
-        <td>{{GPUTextureView}}
+        <td>{{GPUBindGroupLayoutEntry/externalTexture}}
+        <td>{{GPUExternalTexture}},<br/>{{GPUTexture}}, or<br/>{{GPUTextureView}}
+        <td>
+        <td>[=internal usage/constant=]
 </table>
 
 <div algorithm data-timeline=device>
@@ -6327,6 +6326,7 @@ dictionary GPUBindGroupDescriptor
 
 <script type=idl>
 typedef (GPUSampler or
+         GPUTexture or
          GPUTextureView or
          GPUBuffer or
          GPUBufferBinding or
@@ -6350,7 +6350,7 @@ following members:
 
     : <dfn>resource</dfn>
     ::
-        The resource to bind, which may be a {{GPUSampler}}, {{GPUTextureView}},
+        The resource to bind, which may be a {{GPUSampler}}, {{GPUTexture}}, {{GPUTextureView}},
         {{GPUBuffer}}, {{GPUBufferBinding}}, or {{GPUExternalTexture}}.
 </dl>
 
@@ -6458,15 +6458,16 @@ following members:
 
                                     : {{GPUBindGroupLayoutEntry/texture}}
                                     ::
-                                        - |resource| is a {{GPUTextureView}}.
+                                        - |resource| is either a {{GPUTexture}} or a {{GPUTextureView}}.
                                         - |resource| is [$valid to use with$] |this|.
-                                        - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
+                                        - Let |textureView| be [$get texture view$](|resource|).
+                                        - Let |texture| be |textureView|.{{GPUTextureView/[[texture]]}}.
                                         - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}
-                                            is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
+                                            is equal to |textureView|'s {{GPUTextureViewDescriptor/dimension}}.
                                         - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}
                                             is [[#texture-format-caps|compatible]] with
-                                            |resource|'s {{GPUTextureViewDescriptor/format}}.
-                                        - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
+                                            |textureView|'s {{GPUTextureViewDescriptor/format}}.
+                                        - |textureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
                                             includes {{GPUTextureUsage/TEXTURE_BINDING}}.
                                         - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/multisampled}}
                                             is `true`, |texture|'s {{GPUTextureDescriptor/sampleCount}}
@@ -6474,16 +6475,17 @@ following members:
 
                                     : {{GPUBindGroupLayoutEntry/storageTexture}}
                                     ::
-                                        - |resource| is a {{GPUTextureView}}.
+                                        - |resource| is either a {{GPUTexture}} or a {{GPUTextureView}}.
                                         - |resource| is [$valid to use with$] |this|.
-                                        - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
+                                        - Let |storageTextureView| be [$get texture view$](|resource|).
+                                        - Let |texture| be |storageTextureView|.{{GPUTextureView/[[texture]]}}.
                                         - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/viewDimension}}
-                                            is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
+                                            is equal to |storageTextureView|'s {{GPUTextureViewDescriptor/dimension}}.
                                         - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
-                                            is equal to |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
-                                        - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
+                                            is equal to |storageTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
+                                        - |storageTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
                                             includes {{GPUTextureUsage/STORAGE_BINDING}}.
-                                        - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
+                                        - |storageTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
 
                                     :  {{GPUBindGroupLayoutEntry/buffer}}
                                     ::
@@ -6521,23 +6523,25 @@ following members:
 
                                     :  {{GPUBindGroupLayoutEntry/externalTexture}}
                                     ::
-                                        - |resource| is either a {{GPUExternalTexture}} or a {{GPUTextureView}}.
+                                        - |resource| is either a {{GPUExternalTexture}}, a {{GPUTexture}}, or a {{GPUTextureView}}.
                                         - |resource| is [$valid to use with$] |this|.
                                         - If |resource| is a:
+
                                             <dl class=switch>
-                                                : {{GPUTextureView}}
+                                                : {{GPUTexture}} or {{GPUTextureView}}
                                                 ::
-                                                    - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
+                                                    - Let |externalTextureView| be [$get texture view$](|resource|).
+                                                    - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
                                                         must include {{GPUTextureUsage/TEXTURE_BINDING}}.
-                                                    - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/dimension}}
+                                                    - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/dimension}}
                                                         must be {{GPUTextureViewDimension/"2d"}}.
-                                                    - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}}
+                                                    - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}}
                                                         must be 1.
-                                                    - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+                                                    - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
                                                         must be {{GPUTextureFormat/"rgba8unorm"}},
                                                         {{GPUTextureFormat/"bgra8unorm"}}, or
                                                         {{GPUTextureFormat/"rgba16float"}}.
-                                                    - |resource|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}
+                                                    - |externalTextureView|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}
                                                         must be 1.
                                             </dl>
                                 </dl>
@@ -6560,6 +6564,27 @@ following members:
             </div>
         </div>
 </dl>
+
+<div algorithm data-timeline=device>
+    <dfn abstract-op>get texture view</dfn>(|resource|)
+
+    **Arguments:**
+
+    - {{GPUBindingResource}} |resource|
+
+    **Returns:** {{GPUTextureView}}
+
+    1. [=Assert=] |resource| is either a {{GPUTexture}} or a {{GPUTextureView}}.
+    1. If |resource| is a:
+        <dl class=switch>
+            : {{GPUTexture}}
+            ::
+                1. Return |resource|.{{GPUTexture/createView()}}.
+            : {{GPUTextureView}}
+            ::
+                1. Return |resource|.
+        </dl>
+</div>
 
 <div algorithm data-timeline=device>
     <dfn abstract-op>get buffer binding</dfn>(|resource|)
@@ -11842,9 +11867,9 @@ dictionary GPURenderPassDescriptor
 
 <script type=idl>
 dictionary GPURenderPassColorAttachment {
-    required GPUTextureView view;
+    required (GPUTexture or GPUTextureView) view;
     GPUIntegerCoordinate depthSlice;
-    GPUTextureView resolveTarget;
+    (GPUTexture or GPUTextureView) resolveTarget;
 
     GPUColor clearValue;
     required GPULoadOp loadOp;
@@ -11856,7 +11881,8 @@ dictionary GPURenderPassColorAttachment {
     : <dfn>view</dfn>
     ::
         A {{GPUTextureView}} describing the texture [=subresource=] that will be output to for this
-        color attachment.
+        color attachment. If {{GPURenderPassColorAttachment/view}} is a {{GPUTexture}},
+        returns [$get texture view$]({{GPURenderPassColorAttachment/view}}).
 
     : <dfn>depthSlice</dfn>
     ::
@@ -11867,7 +11893,8 @@ dictionary GPURenderPassColorAttachment {
     ::
         A {{GPUTextureView}} describing the texture [=subresource=] that will receive the resolved
         output for this color attachment if {{GPURenderPassColorAttachment/view}} is
-        multisampled.
+        multisampled. If {{GPURenderPassColorAttachment/resolveTarget}} is a {{GPUTexture}},
+        returns [$get texture view$]({{GPURenderPassColorAttachment/resolveTarget}}).
 
     : <dfn>clearValue</dfn>
     ::
@@ -11976,7 +12003,7 @@ dictionary GPURenderPassColorAttachment {
 
 <script type=idl>
 dictionary GPURenderPassDepthStencilAttachment {
-    required GPUTextureView view;
+    required (GPUTexture or GPUTextureView) view;
 
     float depthClearValue;
     GPULoadOp depthLoadOp;
@@ -11994,7 +12021,8 @@ dictionary GPURenderPassDepthStencilAttachment {
     : <dfn>view</dfn>
     ::
         A {{GPUTextureView}} describing the texture [=subresource=] that will be output to
-        and read from for this depth/stencil attachment.
+        and read from for this depth/stencil attachment. If {{GPURenderPassDepthStencilAttachment/view}}
+        is a {{GPUTexture}}, returns [$get texture view$]({{GPURenderPassDepthStencilAttachment/view}}).
 
     : <dfn>depthClearValue</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6463,7 +6463,7 @@ following members:
                                     ::
                                         - |resource| is either a {{GPUTexture}} or a {{GPUTextureView}}.
                                         - |resource| is [$valid to use with$] |this|.
-                                        - Let |textureView| be [$resolve texture view$](|resource|).
+                                        - Let |textureView| be [$get view for texture binding$](|resource|).
                                         - Let |texture| be |textureView|.{{GPUTextureView/[[texture]]}}.
                                         - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}
                                             is equal to |textureView|'s {{GPUTextureViewDescriptor/dimension}}.
@@ -6480,7 +6480,7 @@ following members:
                                     ::
                                         - |resource| is either a {{GPUTexture}} or a {{GPUTextureView}}.
                                         - |resource| is [$valid to use with$] |this|.
-                                        - Let |storageTextureView| be [$resolve texture view$](|resource|).
+                                        - Let |storageTextureView| be [$get view for texture binding$](|resource|).
                                         - Let |texture| be |storageTextureView|.{{GPUTextureView/[[texture]]}}.
                                         - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/viewDimension}}
                                             is equal to |storageTextureView|'s {{GPUTextureViewDescriptor/dimension}}.
@@ -6533,7 +6533,7 @@ following members:
                                             <dl class=switch>
                                                 : {{GPUTexture}} or {{GPUTextureView}}
                                                 ::
-                                                    - Let |externalTextureView| be [$resolve texture view$](|resource|).
+                                                    - Let |externalTextureView| be [$get view for texture binding$](|resource|).
                                                     - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
                                                         must include {{GPUTextureUsage/TEXTURE_BINDING}}.
                                                     - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/dimension}}
@@ -6569,7 +6569,7 @@ following members:
 </dl>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>resolve texture view</dfn>(|resource|)
+    <dfn abstract-op>get view for texture binding</dfn>(|resource|)
 
     **Arguments:**
 
@@ -11884,7 +11884,7 @@ dictionary GPURenderPassColorAttachment {
     : <dfn>view</dfn>
     ::
         Describes the texture [=subresource=] that will be output to for this color attachment.
-        The [=subresource=] is determined by calling [$resolve texture view$]({{GPURenderPassColorAttachment/view}}).
+        The [=subresource=] is determined by calling [$get view for texture binding$]({{GPURenderPassColorAttachment/view}}).
 
     : <dfn>depthSlice</dfn>
     ::
@@ -11895,7 +11895,7 @@ dictionary GPURenderPassColorAttachment {
     ::
         Describes the texture [=subresource=] that will receive the resolved output for this color
         attachment if {{GPURenderPassColorAttachment/view}} is multisampled.
-        The [=subresource=] is determined by calling [$resolve texture view$]({{GPURenderPassColorAttachment/resolveTarget}}).
+        The [=subresource=] is determined by calling [$get view for texture binding$]({{GPURenderPassColorAttachment/resolveTarget}}).
 
     : <dfn>clearValue</dfn>
     ::
@@ -12023,7 +12023,7 @@ dictionary GPURenderPassDepthStencilAttachment {
     ::
         Describes the texture [=subresource=] that will be output to and read from for this
         depth/stencil attachment.
-        The [=subresource=] is determined by calling [$resolve texture view$]({{GPURenderPassDepthStencilAttachment/view}}).
+        The [=subresource=] is determined by calling [$get view for texture binding$]({{GPURenderPassDepthStencilAttachment/view}}).
 
     : <dfn>depthClearValue</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6463,7 +6463,7 @@ following members:
                                     ::
                                         - |resource| is either a {{GPUTexture}} or a {{GPUTextureView}}.
                                         - |resource| is [$valid to use with$] |this|.
-                                        - Let |textureView| be [$get view for texture binding$](|resource|).
+                                        - Let |textureView| be [$get as texture view$](|resource|).
                                         - Let |texture| be |textureView|.{{GPUTextureView/[[texture]]}}.
                                         - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}
                                             is equal to |textureView|'s {{GPUTextureViewDescriptor/dimension}}.
@@ -6480,7 +6480,7 @@ following members:
                                     ::
                                         - |resource| is either a {{GPUTexture}} or a {{GPUTextureView}}.
                                         - |resource| is [$valid to use with$] |this|.
-                                        - Let |storageTextureView| be [$get view for texture binding$](|resource|).
+                                        - Let |storageTextureView| be [$get as texture view$](|resource|).
                                         - Let |texture| be |storageTextureView|.{{GPUTextureView/[[texture]]}}.
                                         - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/viewDimension}}
                                             is equal to |storageTextureView|'s {{GPUTextureViewDescriptor/dimension}}.
@@ -6533,7 +6533,7 @@ following members:
                                             <dl class=switch>
                                                 : {{GPUTexture}} or {{GPUTextureView}}
                                                 ::
-                                                    - Let |externalTextureView| be [$get view for texture binding$](|resource|).
+                                                    - Let |externalTextureView| be [$get as texture view$](|resource|).
                                                     - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/usage}}
                                                         must include {{GPUTextureUsage/TEXTURE_BINDING}}.
                                                     - |externalTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/dimension}}
@@ -6569,7 +6569,7 @@ following members:
 </dl>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>get view for texture binding</dfn>(|resource|)
+    <dfn abstract-op>get as texture view</dfn>(|resource|)
 
     **Arguments:**
 
@@ -11884,7 +11884,7 @@ dictionary GPURenderPassColorAttachment {
     : <dfn>view</dfn>
     ::
         Describes the texture [=subresource=] that will be output to for this color attachment.
-        The [=subresource=] is determined by calling [$get view for texture binding$]({{GPURenderPassColorAttachment/view}}).
+        The [=subresource=] is determined by calling [$get as texture view$]({{GPURenderPassColorAttachment/view}}).
 
     : <dfn>depthSlice</dfn>
     ::
@@ -11895,7 +11895,7 @@ dictionary GPURenderPassColorAttachment {
     ::
         Describes the texture [=subresource=] that will receive the resolved output for this color
         attachment if {{GPURenderPassColorAttachment/view}} is multisampled.
-        The [=subresource=] is determined by calling [$get view for texture binding$]({{GPURenderPassColorAttachment/resolveTarget}}).
+        The [=subresource=] is determined by calling [$get as texture view$]({{GPURenderPassColorAttachment/resolveTarget}}).
 
     : <dfn>clearValue</dfn>
     ::
@@ -12023,7 +12023,7 @@ dictionary GPURenderPassDepthStencilAttachment {
     ::
         Describes the texture [=subresource=] that will be output to and read from for this
         depth/stencil attachment.
-        The [=subresource=] is determined by calling [$get view for texture binding$]({{GPURenderPassDepthStencilAttachment/view}}).
+        The [=subresource=] is determined by calling [$get as texture view$]({{GPURenderPassDepthStencilAttachment/view}}).
 
     : <dfn>depthClearValue</dfn>
     ::

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10012,7 +10012,7 @@ where compatibility is defined by the following table.
         <th colspan=2>WebGPU [=binding type=]
   </thead>
   <tr><td>[=uniform buffer=]
-      <td rowspan=3>{{GPUBuffer}} or {{GPUBufferBinding}}
+      <td rowspan=3>{{GPUBufferBinding}} (or {{GPUBuffer}} as [$get as buffer binding|shorthand$])
       <td rowspan=3>{{GPUBindGroupLayoutEntry/buffer}}
       <td rowspan=3>GPUBufferBindingType
       <td>{{GPUBufferBindingType/"uniform"}}
@@ -10032,7 +10032,7 @@ where compatibility is defined by the following table.
   <tr><td rowspan=5>[=type/sampled texture=],
                     [=type/depth texture=], or
                     [=type/multisampled texture=]
-      <td rowspan=5>{{GPUTexture}} or {{GPUTextureView}}
+      <td rowspan=5>{{GPUTextureView}} (or {{GPUTexture}} as [$get as texture view|shorthand$])
       <td rowspan=5>{{GPUBindGroupLayoutEntry/texture}}
       <td rowspan=5>GPUTextureSampleType
       <td>{{GPUTextureSampleType/"float"}}
@@ -10045,7 +10045,7 @@ where compatibility is defined by the following table.
   <tr>
       <td>{{GPUTextureSampleType/"depth"}}
   <tr><td>[=type/write-only storage texture=]
-      <td rowspan=3>{{GPUTexture}} or {{GPUTextureView}}
+      <td rowspan=3>{{GPUTextureView}} (or {{GPUTexture}} as [$get as texture view|shorthand$])
       <td rowspan=3>{{GPUBindGroupLayoutEntry/storageTexture}}
       <td rowspan=3>{{GPUStorageTextureAccess}}
       <td>{{GPUStorageTextureAccess/"write-only"}}
@@ -10054,7 +10054,7 @@ where compatibility is defined by the following table.
   <tr><td>[=type/read-only storage texture=]
       <td>{{GPUStorageTextureAccess/"read-only"}}
   <tr><td>[=type/external texture=]
-      <td>{{GPUExternalTexture}}, {{GPUTexture}}, or {{GPUTextureView}}
+      <td>{{GPUExternalTexture}} or {{GPUTextureView}} (or {{GPUTexture}} as [$get as texture view|shorthand$])
       <td>{{GPUBindGroupLayoutEntry/externalTexture}}
       <td colspan=2>(not applicable)
 </table>
@@ -10070,7 +10070,7 @@ is determined from the size of the corresponding {{GPUBindGroupEntry/resource}}:
 <blockquote algorithm="element count of runtime-sized array">
 * Let |T| be the [=store type=] for a [=storage buffer=] variable,
     where |T| is a [=runtime-sized=] array type or contains a runtime-sized array type.
-* Let |bufferBinding| be [$get buffer binding$]({{GPUBindGroupEntry/resource}}).
+* Let |bufferBinding| be [$get as buffer binding$]({{GPUBindGroupEntry/resource}}).
 * Let |EBS| be the
     [=effective buffer binding size=]
     for the |bufferBinding| bound to the pipeline binding address corresponding to the storage buffer variable.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10012,7 +10012,7 @@ where compatibility is defined by the following table.
         <th colspan=2>WebGPU [=binding type=]
   </thead>
   <tr><td>[=uniform buffer=]
-      <td rowspan=3>{{GPUBufferBinding}}
+      <td rowspan=3>{{GPUBuffer}} or {{GPUBufferBinding}}
       <td rowspan=3>{{GPUBindGroupLayoutEntry/buffer}}
       <td rowspan=3>GPUBufferBindingType
       <td>{{GPUBufferBindingType/"uniform"}}
@@ -10032,7 +10032,7 @@ where compatibility is defined by the following table.
   <tr><td rowspan=5>[=type/sampled texture=],
                     [=type/depth texture=], or
                     [=type/multisampled texture=]
-      <td rowspan=5>{{GPUTextureView}}
+      <td rowspan=5>{{GPUTexture}} or {{GPUTextureView}}
       <td rowspan=5>{{GPUBindGroupLayoutEntry/texture}}
       <td rowspan=5>GPUTextureSampleType
       <td>{{GPUTextureSampleType/"float"}}
@@ -10045,7 +10045,7 @@ where compatibility is defined by the following table.
   <tr>
       <td>{{GPUTextureSampleType/"depth"}}
   <tr><td>[=type/write-only storage texture=]
-      <td rowspan=3>{{GPUTextureView}}
+      <td rowspan=3>{{GPUTexture}} or {{GPUTextureView}}
       <td rowspan=3>{{GPUBindGroupLayoutEntry/storageTexture}}
       <td rowspan=3>{{GPUStorageTextureAccess}}
       <td>{{GPUStorageTextureAccess/"write-only"}}
@@ -10054,7 +10054,7 @@ where compatibility is defined by the following table.
   <tr><td>[=type/read-only storage texture=]
       <td>{{GPUStorageTextureAccess/"read-only"}}
   <tr><td>[=type/external texture=]
-      <td>{{GPUExternalTexture}}
+      <td>{{GPUExternalTexture}}, {{GPUTexture}}, or {{GPUTextureView}}
       <td>{{GPUBindGroupLayoutEntry/externalTexture}}
       <td colspan=2>(not applicable)
 </table>
@@ -10065,14 +10065,15 @@ specification for interface validation requirements.
 ### Buffer Binding Determines Runtime-Sized Array Element Count ### {#buffer-binding-determines-runtime-sized-array-element-count}
 
 When a [=storage buffer=] variable contains a [=runtime-sized=] array, then the number of elements in that array
-is determined from the size of the corresponding {{GPUBufferBinding}}:
+is determined from the size of the corresponding {{GPUBindGroupEntry/resource}}:
 
 <blockquote algorithm="element count of runtime-sized array">
 * Let |T| be the [=store type=] for a [=storage buffer=] variable,
     where |T| is a [=runtime-sized=] array type or contains a runtime-sized array type.
+* Let |bufferBinding| be [$get buffer binding$]({{GPUBindGroupEntry/resource}}).
 * Let |EBS| be the
     [=effective buffer binding size=]
-    for the {{GPUBufferBinding}} bound to the pipeline binding address corresponding to the storage buffer variable.
+    for the |bufferBinding| bound to the pipeline binding address corresponding to the storage buffer variable.
 * Then <dfn noexport>NRuntime</dfn>, i.e.
     the number of elements in the runtime-sized array,
     is the largest integer such that [=SizeOf=](|T|) &le; |EBS|.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -281,6 +281,8 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
         text: validating GPUProgrammableStage; url: abstract-opdef-validating-gpuprogrammablestage
         text: validating shader binding; url: abstract-opdef-validating-shader-binding
         text: Interstage interface validation; url: abstract-opdef-validating-inter-stage-interfaces
+        text: get as texture view; url: abstract-opdef-get-as-texture
+        text: get as buffer binding; url: abstract-opdef-get-as-buffer-binding
 </pre>
 
 # Introduction # {#intro}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -254,7 +254,6 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
         text: RasterizationPoint; url: rasterizationpoint
         text: effective buffer binding size; url: abstract-opdef-effective-buffer-binding-size
         text: binding member; url: binding-member
-        text: binding resource type; url: binding-resource-type
         text: binding type; url: binding-type
         text: device loss; url: lose-the-device
         text: GPU error scope; url: gpu-error-scope
@@ -281,7 +280,6 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
         text: validating GPUProgrammableStage; url: abstract-opdef-validating-gpuprogrammablestage
         text: validating shader binding; url: abstract-opdef-validating-shader-binding
         text: Interstage interface validation; url: abstract-opdef-validating-inter-stage-interfaces
-        text: get as texture view; url: abstract-opdef-get-as-texture
         text: get as buffer binding; url: abstract-opdef-get-as-buffer-binding
 </pre>
 
@@ -10003,29 +10001,26 @@ WebGPU requires that a shader's resource interface match the [[WebGPU#gpupipelin
 using the shader.
 
 It is a [=pipeline-creation error=] if a WGSL variable in a resource interface is bound to an incompatible WebGPU
-[=binding resource type=] or [=binding type=],
+[=binding member=] or [=binding type=],
 where compatibility is defined by the following table.
 <table class='data'>
   <caption>WebGPU binding type compatibility</caption>
   <thead>
     <tr><th>WGSL resource
-        <th>WebGPU<br>[=binding resource type|resource type=]
         <th>WebGPU [=binding member=]
         <th colspan=2>WebGPU [=binding type=]
   </thead>
   <tr><td>[=uniform buffer=]
-      <td rowspan=3>{{GPUBufferBinding}} (or {{GPUBuffer}} as [$get as buffer binding|shorthand$])
       <td rowspan=3>{{GPUBindGroupLayoutEntry/buffer}}
-      <td rowspan=3>GPUBufferBindingType
+      <td rowspan=3>{{GPUBufferBindingType}}
       <td>{{GPUBufferBindingType/"uniform"}}
   <tr><td>[=storage buffer=] with [=access/read_write=] access
       <td>{{GPUBufferBindingType/"storage"}}
   <tr><td>[=storage buffer=] with [=access/read=] access
       <td>{{GPUBufferBindingType/"read-only-storage"}}
   <tr><td rowspan=2>[=type/sampler=]
-      <td rowspan=3>{{GPUSampler}}
       <td rowspan=3>{{GPUBindGroupLayoutEntry/sampler}}
-      <td rowspan=3>GPUSamplerBindingType
+      <td rowspan=3>{{GPUSamplerBindingType}}
       <td>{{GPUSamplerBindingType/"filtering"}}
   <tr>
       <td>{{GPUSamplerBindingType/"non-filtering"}}
@@ -10034,9 +10029,8 @@ where compatibility is defined by the following table.
   <tr><td rowspan=5>[=type/sampled texture=],
                     [=type/depth texture=], or
                     [=type/multisampled texture=]
-      <td rowspan=5>{{GPUTextureView}} (or {{GPUTexture}} as [$get as texture view|shorthand$])
       <td rowspan=5>{{GPUBindGroupLayoutEntry/texture}}
-      <td rowspan=5>GPUTextureSampleType
+      <td rowspan=5>{{GPUTextureSampleType}}
       <td>{{GPUTextureSampleType/"float"}}
   <tr>
       <td>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -10047,7 +10041,6 @@ where compatibility is defined by the following table.
   <tr>
       <td>{{GPUTextureSampleType/"depth"}}
   <tr><td>[=type/write-only storage texture=]
-      <td rowspan=3>{{GPUTextureView}} (or {{GPUTexture}} as [$get as texture view|shorthand$])
       <td rowspan=3>{{GPUBindGroupLayoutEntry/storageTexture}}
       <td rowspan=3>{{GPUStorageTextureAccess}}
       <td>{{GPUStorageTextureAccess/"write-only"}}
@@ -10056,7 +10049,6 @@ where compatibility is defined by the following table.
   <tr><td>[=type/read-only storage texture=]
       <td>{{GPUStorageTextureAccess/"read-only"}}
   <tr><td>[=type/external texture=]
-      <td>{{GPUExternalTexture}} or {{GPUTextureView}} (or {{GPUTexture}} as [$get as texture view|shorthand$])
       <td>{{GPUBindGroupLayoutEntry/externalTexture}}
       <td colspan=2>(not applicable)
 </table>


### PR DESCRIPTION
This PR adds GPUTexture support to the following attributes: 
- GPUBindingResource
- GPURenderPassColorAttachment view
- GPURenderPassColorAttachment resolveTarget
- GPURenderPassDepthStencilAttachment view

It also updates parts of the WebGPU and WGSL specs that I've missed when adding GPUBuffer in GPUBindingResource with https://github.com/gpuweb/gpuweb/pull/5193

FIX https://github.com/gpuweb/gpuweb/issues/5215