### PR TITLE
Compat: texture view must contain all array layers

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6552,6 +6552,16 @@ following members:
                                                         must be 1.
                                             </dl>
                                 </dl>
+                                <div class=compatmode>
+                                    - If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
+                                        {{GPUFeatureName/"core-features-and-limits"}}:
+                                        - For each {{GPUBindGroupEntry}} |bindGroupEntry| in |descriptor|.{{GPUBindGroupDescriptor/entries}}:
+                                            - If |bindGroupEntry|.{{GPUBindGroupEntry/resource}} is  {{GPUTextureView}}:
+                                                - Let |textureView| be |bindGroupEntry|.{{GPUBindGroupEntry/resource}}.
+                                                - Let |descriptor| be |textureView|.{{GPUTextureView/[[descriptor]]}}.
+                                                - |descriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} must be `0`.
+                                                - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be equal to |textureView|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/depthOrArrayLayers}}.
+                                </div>
                     </div>
 
                 1. Let |bindGroup|.{{GPUBindGroup/[[layout]]}} =


### PR DESCRIPTION
At bind group creation time, validate that texture views contain all array layers (view.baseArrayLayer == 0, view.arrayLayerCount == texture.depthOrArrayLayers).

This is [restriction #6](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#6-array-texture-views-used-in-bind-groups-must-consist-of-the-entire-array-that-is-basearraylayer-must-be-zero-and-arraylayercount-must-be-equal-to-the-size-of-the-texture-array) from the compatibility-mode proposal.