### PR TITLE
Compat: no two-component formats as storage

### DIFF
--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -146,7 +146,7 @@ Use of the `sample_mask` or `sample_index` builtins would cause a validation err
 
 The `rg32uint`, `rg32sint`, and `rg32float` texture formats no longer support the `"write-only" or "read-only" STORAGE_BINDING` capability by default.
 
-Calls to `createTexture()` or `createBindGroupLayout()` with this combination cause a validation error. Calls to `createShaderModule()` will fail if these formats are referenced as storage textures.
+Calls to `createTexture()` or `createBindGroupLayout()` with this combination cause a validation error.
 
 **Justification**: GLSL ES 3.1 (section 4.4.7, "Format Layout Qualifiers") does not permit any two-component (RG) texture formats in a format layout qualifier.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17327,8 +17327,8 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td><!-- Metal -->
         <td>
-        <td>&checkmark;
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td>
         <td colspan=2>8
     <tr>
@@ -17339,8 +17339,8 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td><!-- Metal -->
         <td>
-        <td>&checkmark;
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td>
         <td colspan=2>8
     <tr>
@@ -17353,8 +17353,8 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td><!-- Metal -->
         <td>
-        <td>&checkmark;
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td>
         <td colspan=2>8
     <tr>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17327,8 +17327,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td><!-- Metal -->
         <td>
-        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
-        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
+        <td colspan=2>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td>
         <td colspan=2>8
     <tr>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17338,8 +17338,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>
         <td><!-- Metal -->
         <td>
-        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
-        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
+        <td colspan=2>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td>
         <td colspan=2>8
     <tr>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17351,8 +17351,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td><!-- Metal -->
         <td>
-        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
-        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
+        <td colspan=2>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td>
         <td colspan=2>8
     <tr>


### PR DESCRIPTION
Prevent the use of rg32float, rg32sint, and rg32unit as STORAGE_BINDING in Compatibility Mode.

Remove the line about createShaderModule() validation, since it's unnecessary.

This is [restriction #8](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#8-disallow-two-component-rg-texture-formats-in-storage-texture-bindings) in the Compatibility Mode proposal.