### PR TITLE
Support Resolve for 16unorm and 16snorm in texture-formats-tier1

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -16777,7 +16777,7 @@ expose real values whenever the feature is available on the adapter:
 </h3>
 
 Supports the below new {{GPUTextureFormat}}s with the {{GPUTextureUsage/RENDER_ATTACHMENT}},
-[=blendable=], `multisampling` and `resolve` capabilities, and the
+[=blendable=], `multisampling`, `resolve` capabilities and the
 {{GPUTextureUsage/STORAGE_BINDING}} capability with the {{GPUStorageTextureAccess/"read-only"}} and
 {{GPUStorageTextureAccess/"write-only"}} {{GPUStorageTextureAccess}}es:
 - {{GPUTextureFormat/"r16unorm"}}


### PR DESCRIPTION
This patch adds `Resolve` capability for all `16unorm` and `16snorm`
formats in `texture-formats-tier1` as only Apple2 and Apple3 devices
cannot support `Resolve` capability for these formats, while WebGPU
won't be supported on these devices according to
https://github.com/gpuweb/gpuweb/issues/1069#issuecomment-1758221820.