### PR TITLE
Compat: depthBiasClamp must be zero.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8408,7 +8408,7 @@ dictionary GPURenderPipelineDescriptor
                         must have a [=aspect/depth=] aspect.
             - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|) succeeds.
             - If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is [=map/exist|provided=]:
-                - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}},
+                - [$validating GPUDepthStencilState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}},
                     |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}}) succeeds.
             - [$validating GPUMultisampleState$](|descriptor|.{{GPURenderPipelineDescriptor/multisample}}) succeeds.
             - If |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}}
@@ -9187,10 +9187,11 @@ must be 0.
 </div>
 
 <div algorithm data-timeline=device>
-    <dfn abstract-op>validating GPUDepthStencilState</dfn>(|descriptor|, |topology|)
+    <dfn abstract-op>validating GPUDepthStencilState</dfn>(|device|, |descriptor|, |topology|)
 
     **Arguments:**
 
+    - {{GPUDevice}}            |device|
     - {{GPUDepthStencilState}} |descriptor|
     - {{GPUPrimitiveTopology}} |topology|
 
@@ -9220,6 +9221,12 @@ must be 0.
                 - |descriptor|.{{GPUDepthStencilState/depthBias}} must be 0.
                 - |descriptor|.{{GPUDepthStencilState/depthBiasSlopeScale}} must be 0.
                 - |descriptor|.{{GPUDepthStencilState/depthBiasClamp}} must be 0.
+
+            <div class=compatmode>
+                - If |device|.{{device/[[features]]}} does not [=list/contain=]
+                     {{GPUFeatureName/"core-features-and-limits"}}:
+                    - |descriptor|.{{GPUDepthStencilState/depthBiasClamp}} must be 0.
+            </div>
         </div>
 
 </div>


### PR DESCRIPTION
GPUDepthStencilState.depthBiasClamp must be zero in Compat mode.

This represents [restriction 9](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#9-depth-bias-clamp-must-be-zero) from the Compatibility Mode proposal.