### PR TITLE
Add Compat mode limits.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9914,7 +9914,7 @@ dictionary GPUVertexAttribute {
             1. Let |totalEffectiveVertexAttributes| be the sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.[=list/size=],
                 over every |vertexBuffer| in |descriptor|.{{GPUVertexState/buffers}}.
                 <div class=compatmode>
-                    - If |device|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}} and |descriptor|.{{GPURenderPipelineDescriptor/vertex}} is [=map/exist|provided=]:
+                    - If |device|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}:
                         - If the [=builtin/vertex_index=] builtin is a [=shader stage input=] of
                             |descriptor|.{{GPURenderPipelineDescriptor/vertex}}:
                             - Add 1 to |totalEffectiveVertexAttributes|


### PR DESCRIPTION
Add the Compatibility Mode limits to the limits table.

Increase the `colspan` of the full-width rows to match the new column count (4 -> 5).
This represents [restriction 10](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#10-lower-limits) from the compatibility-mode proposal.