### PR TITLE
WGSL: Fix shader value of rg11b10ufloat texel format

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4334,7 +4334,7 @@ The last column in the table below uses the format-specific
   <tr><td><dfn for="texel format">r16float</dfn><td>16float<td>r<td>vec4&lt;f32&gt;(CTF(r), 0.0, 0.0, 1.0)
   <tr><td><dfn for="texel format">rgb10a2unorm</dfn><td>r, g, b: 10unorm a: 2unorm<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
   <tr><td><dfn for="texel format">rgb10a2uint</dfn><td>r, g, b: 10uint a: 2uint<td>r, g, b, a<td>vec4&lt;u32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
-  <tr><td><dfn for="texel format">rg11b10ufloat</dfn><td>r, g: 11float b: 10float<td>r, g, b<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td><dfn for="texel format">rg11b10ufloat</dfn><td>r, g: 11float b: 10float<td>r, g, b<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), 1.0)
 </table>
 
 WGSL [=predeclared|predeclares=] an [=enumerant=] for each of the texel formats in the table.


### PR DESCRIPTION
This PR fix the shader value formula for rg11b10ufloat texel which has no alpha channel.