### PR TITLE
Disallow copying of multisampled textures.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10726,6 +10726,7 @@ dictionary GPUCommandEncoderDescriptor
                                 {{GPUFeatureName/"core-features-and-limits"}}:
                                 - |source|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}} must not be a [=compressed format=].
                                 - |destination|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}} must not be a [=compressed format=].
+                                - |source|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/sampleCount}} and |destination|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/sampleCount}} must be 1
                         </div>
                     </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10726,7 +10726,7 @@ dictionary GPUCommandEncoderDescriptor
                                 {{GPUFeatureName/"core-features-and-limits"}}:
                                 - |source|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}} must not be a [=compressed format=].
                                 - |destination|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/format}} must not be a [=compressed format=].
-                                - |source|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/sampleCount}} and |destination|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/sampleCount}} must be 1
+                                - |source|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/sampleCount}} and |destination|.{{GPUTexelCopyTextureInfo/texture}}.{{GPUTexture/sampleCount}} must be 1.
                         </div>
                     </div>
 


### PR DESCRIPTION
Source and destination `sampleCount` must be 1.

This is [issue #12](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#12-disallow-copying-multisample-textures) in the Compatibility Mode proposal.