### PR TITLE
Include `externalTexture` in `createBindGroupLayout` validation.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6176,8 +6176,9 @@ A {{GPUBindGroupLayout}} object has the following [=device timeline properties=]
                             - Exactly one of
                                 |entry|.{{GPUBindGroupLayoutEntry/buffer}},
                                 |entry|.{{GPUBindGroupLayoutEntry/sampler}},
-                                |entry|.{{GPUBindGroupLayoutEntry/texture}}, and
-                                |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is [=map/exist|provided=].
+                                |entry|.{{GPUBindGroupLayoutEntry/texture}},
+                                |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}, and
+                                |entry|.{{GPUBindGroupLayoutEntry/externalTexture}} is [=map/exist|provided=].
 
                             - |entry|.{{GPUBindGroupLayoutEntry/visibility}} contains only bits defined in {{GPUShaderStage}}.
 


### PR DESCRIPTION
In the device timeline validation steps for `GPUDevice.createBindGroupLayout`, include `externalTexture` in the list of mutually exclusive dictionary members that specify what sort of resource may appear at this binding.