### PR TITLE
Disallow texture format reinterpretation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4233,7 +4233,7 @@ dictionary GPUTextureDescriptor
         Formats in this list must be [=texture view format compatible=] with the texture format.
 
         <div algorithm data-timeline=const>
-            Two {{GPUTextureFormat}}s |format| and |viewFormat| are <dfn dfn for="">texture view format compatible</dfn> for a given |device| if:
+            Two {{GPUTextureFormat}}s |format| and |viewFormat| are <dfn dfn for="">texture view format compatible</dfn> on a given |device| if:
 
             - |format| equals |viewFormat|, or
             - |format| and |viewFormat| differ only in whether they are `srgb` formats (have the `-srgb` suffix) and |device|.{{device/[[features]]}} [=list/contains=] {{GPUFeatureName/"core-features-and-limits"}}.
@@ -4469,7 +4469,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                     with {{GPUTextureUsage/STORAGE_BINDING}} capability for at least one access mode.
             - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
                 |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
-                [=texture view format compatible=].
+                [=texture view format compatible=] on device |this|.
 
                 <div class=note heading>
                     Implementations may consider issuing a developer-visible warning if |viewFormat| is not compatible with any of the


### PR DESCRIPTION
All members of viewFormats must be equal to the texture's format.

This is achieved by changing the definition of "texture view format compatible" to be strict equality in Compatibility mode.

This corresponds to [restriction 13](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#13-disallow-texture-format-reinterpretation) in the compatibility-mode proposal.