### PR TITLE
wgsl/Makefile: make "clean" should remove grammar.js.pre

### DIFF
--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -6,7 +6,7 @@ all: index.html nfkc validate test diagrams
 validate: lalr tspath_tests unit_tests validate-examples
 
 clean:
-	rm -f index.html index.bs.pre index.pre.html wgsl.recursive.bs.include.pre grammar/grammar.js wgsl.lalr.txt
+	rm -f index.html index.bs.pre index.pre.html wgsl.recursive.bs.include.pre grammar/grammar.js grammar/grammar.js.pre wgsl.lalr.txt
 	rm -rf grammar/build
 
 


### PR DESCRIPTION
The grammar.js.pre file is a snapshot of the generated grammar.js file the last time we ran "make".  It's used to avoid rebuilding the C code for the treesitter WGSL parser, in the case that the grammar has not changed since the last build.