### PR TITLE
Disallow several texture capabilities in Compat mode.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17162,10 +17162,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
         <td>
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
-        <td>&checkmark;
-        <td>&checkmark;
-        <td>&checkmark;
-        <td>&checkmark;
+        <td colspan=4>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td>
         <td>
         <td>
@@ -17340,8 +17337,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>&checkmark;
-        <td>&checkmark;
+        <td colspan=2>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td>&checkmark;
         <td>&checkmark;
         <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
@@ -17379,7 +17375,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
             - {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled
         <td>&checkmark;
         <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17160,9 +17160,12 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>8
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
-        <td>
+        <td>{{GPUFeatureName/"core-features-and-limits"}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
-        <td colspan=4>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>&checkmark;
         <td>
         <td>
         <td>


### PR DESCRIPTION
- bgra8unorm-srgb
- multisampled r32float and rgba16float.

This represents issues [15](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#15-disallow-bgra8unorm-srgb-textures) and [22](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#22-disallow-multisampled-rgba16float-and-r32float-textures) in the proposal doc.