### PR TITLE
Disallow multisampling of integer texture formats

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17028,7 +17028,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
         <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
@@ -17039,7 +17039,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
         <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
@@ -17069,7 +17069,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
         <td>
@@ -17080,7 +17080,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
         <td>
@@ -17127,7 +17127,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
@@ -17139,7 +17139,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
@@ -17202,7 +17202,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
         <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
@@ -17213,7 +17213,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
         <td>If {{GPUFeatureName/"texture-formats-tier2"}} is enabled
@@ -17259,7 +17259,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
         <td>
@@ -17270,7 +17270,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
         <td>
@@ -17316,7 +17316,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
@@ -17328,7 +17328,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td><!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
@@ -17465,7 +17465,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"core-features-and-limits"}} is enabled
         <td>
         <td colspan=2>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
         <td>


### PR DESCRIPTION
This represents restriction [23](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#23-disallow-all-multisampled-integer-textures) in the compatibility-mode proposal.