### PR TITLE
wgsl: rename "software_extension*" grammar element

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1448,7 +1448,7 @@ The [=enable-extension=] names are:
 The valid [=language extension=] names are listed in [[#language-extensions-sec]] but in general have the same form as an [=identifier=]:
 
 <pre class=include>
-path: syntax/software_extension_name.syntax.bs.include
+path: syntax/language_extension_name.syntax.bs.include
 </pre>
 
 The [=language extension=] names are:
@@ -1859,7 +1859,7 @@ program are covered by [=requires-directives=] in the program.
 path: syntax/requires_directive.syntax.bs.include
 </pre>
 <pre class=include>
-path: syntax/software_extension_list.syntax.bs.include
+path: syntax/language_extension_list.syntax.bs.include
 </pre>
 
 Like other directives, if a [=requires-directive=] is present, it must appear before all [=declarations=] and [[#assertions|const assertions]].

--- a/wgsl/syntax.bnf
+++ b/wgsl/syntax.bnf
@@ -579,18 +579,18 @@ enable_extension_list :
 ;
 
 requires_directive :
-  'requires' software_extension_list ';'
+  'requires' language_extension_list ';'
 ;
 
-software_extension_list :
-  software_extension_name ( ',' software_extension_name ) * ',' ?
+language_extension_list :
+  language_extension_name ( ',' language_extension_name ) * ',' ?
 ;
 
 enable_extension_name :
   ident_pattern_token
 ;
 
-software_extension_name :
+language_extension_name :
   ident_pattern_token
 ;
 

--- a/wgsl/syntax/language_extension_list.syntax.bs.include
+++ b/wgsl/syntax/language_extension_list.syntax.bs.include
@@ -1,0 +1,5 @@
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>language_extension_list</dfn> :
+
+    <span class="choice"></span> [=syntax/language_extension_name=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/language_extension_name=] ) * <a for=syntax_sym lt=comma>`','`</a> ?
+</div>

--- a/wgsl/syntax/language_extension_name.syntax.bs.include
+++ b/wgsl/syntax/language_extension_name.syntax.bs.include
@@ -1,5 +1,5 @@
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>software_extension_name</dfn> :
+  <dfn for=syntax>language_extension_name</dfn> :
 
     <span class="choice"></span> [=syntax/ident_pattern_token=]
 </div>

--- a/wgsl/syntax/requires_directive.syntax.bs.include
+++ b/wgsl/syntax/requires_directive.syntax.bs.include
@@ -1,5 +1,5 @@
 <div class='syntax' noexport='true'>
   <dfn for=syntax>requires_directive</dfn> :
 
-    <span class="choice"></span> `'requires'` [=syntax/software_extension_list=] <a for=syntax_sym lt=semicolon>`';'`</a>
+    <span class="choice"></span> `'requires'` [=syntax/language_extension_list=] <a for=syntax_sym lt=semicolon>`';'`</a>
 </div>

--- a/wgsl/syntax/software_extension_list.syntax.bs.include
+++ b/wgsl/syntax/software_extension_list.syntax.bs.include
@@ -1,5 +1,0 @@
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>software_extension_list</dfn> :
-
-    <span class="choice"></span> [=syntax/software_extension_name=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/software_extension_name=] ) * <a for=syntax_sym lt=comma>`','`</a> ?
-</div>


### PR DESCRIPTION
"Language extension" is used in the prose, but "software_extension*" is used in the grammar. Update the grammar to match the prose.