### PR TITLE
Fix template list discovery algorithm: missing continue

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1597,6 +1597,7 @@ Let |TemplateList| be a record type containing:
                     Skip over the `'='` (U+003D) code point so a later step does not mistake it for an assignment.
                 * Pop the top entry from the |Pending| stack.
                 * Advance |CurrentPosition| past this code point, and start the next iteration of the loop.
+        * Start the next iteration of the loop.
     * If `'>'` (U+003E) appears at |CurrentPosition| then:
         * Note: This code point is a candidate for being the end of a template list.
         * If |Pending| is not empty, then let |T| be its top entry, and if |T|.|depth| equals |NestingDepth| then:


### PR DESCRIPTION
At the end of the first 'if' clause, where '<' is matched, insert a 'Start the next iteration of the loop.'
Otherwise execution reaches the 'advance token' at the bottom of the loop.

For example, in parsing:  X < Y >
The '>' would be consumed too early, and template list discovery gets the wrong answer.

Fixes: #5246