### PR TITLE
Use new generally available arm64 runners for building architecture image

### DIFF
--- a/.github/workflows/build-push-custom-image.yml
+++ b/.github/workflows/build-push-custom-image.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build-amd64:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-push-custom-image.yml
+++ b/.github/workflows/build-push-custom-image.yml
@@ -17,7 +17,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  build-amd64:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -28,9 +28,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -47,13 +44,92 @@ jobs:
         uses: docker/metadata-action@v5.3.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-amd64
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.1.0
         with:
           context: .
           file: tools/custom-action/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.3.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-arm64
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5.1.0
+        with:
+          context: .
+          file: tools/custom-action/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  create-manifest:
+    needs: [build-amd64, build-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.3.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          TAGS="${{ steps.meta.outputs.tags }}"
+          for TAG in $TAGS; do
+            docker buildx imagetools create \
+              --tag "$TAG" \
+              "${TAG}-amd64" \
+              "${TAG}-arm64"
+          done


### PR DESCRIPTION
For Docker image building, which is an essential component of CI and provides a consistent & one-button DX for spec dev & iteration, usage of QEMU to build arm64 variant from amd64 runner was (naturally) causing and is still causing a very prolonged workflow time (>65 minutes). Previously, GH Actions’ arm64 runners didn’t support nested virtualization for build, required further divergence from the amd64 counterpart, or were runners that might be less available. Now [^0], announced today, there is ubuntu-24.04-arm generally available. For one project, it transformed >120 minutes to just 10 minutes, and concretely for gpuweb, it completes in less than 8 minutes total when I try with my fork [^1]. This CI updates the Ubuntu runners for Docker image to 24.04 (which streamlines with the built image itself) and extracts arm64 to its own runner. Thank you very much in advance!



[^0]: https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/
[^1]: https://github.com/mehmetoguzderin/gpuweb/actions/runs/16812721261
