### PR TITLE
Fix table visual quirks

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -470,7 +470,7 @@ th.vertical span {
     /* position: sticky doesn't work inside scrollable elements. */
     overflow-x: unset;
 }
-thead.stickyheader th, th.stickyheader {
+thead.stickyheader, th.stickyheader {
     position: sticky;
     top: 0;
     background: #f8f8f8;
@@ -17267,9 +17267,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
     <tr>
         <td>{{GPUTextureFormat/r32float}}
         <td>
-        <td>{{GPUTextureSampleType/"unfilterable-float"}}
-
-            - {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled
+        <td>{{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled,<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td>&checkmark;
@@ -17305,9 +17303,8 @@ The [=texel block memory cost=] of each of these formats is the same as its
     <tr>
         <td>{{GPUTextureFormat/rg32float}}
         <td>
-        <td>{{GPUTextureSampleType/"unfilterable-float"}}
 
-            - {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled
+        <td>{{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled,<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td><!-- Metal -->
@@ -17343,9 +17340,8 @@ The [=texel block memory cost=] of each of these formats is the same as its
     <tr>
         <td>{{GPUTextureFormat/rgba32float}}
         <td>
-        <td>{{GPUTextureSampleType/"unfilterable-float"}}
 
-            - {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled
+        <td>{{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled,<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td><!-- Metal -->

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17267,7 +17267,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
     <tr>
         <td>{{GPUTextureFormat/r32float}}
         <td>
-        <td>{{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled,<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>- {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled<br/>- {{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td>&checkmark;
@@ -17304,7 +17304,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureFormat/rg32float}}
         <td>
 
-        <td>{{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled,<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>- {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled<br/>- {{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td><!-- Metal -->
@@ -17341,7 +17341,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureFormat/rgba32float}}
         <td>
 
-        <td>{{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled,<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>- {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled<br/>- {{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td><!-- Metal -->

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17267,7 +17267,9 @@ The [=texel block memory cost=] of each of these formats is the same as its
     <tr>
         <td>{{GPUTextureFormat/r32float}}
         <td>
-        <td>- {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled<br/>- {{GPUTextureSampleType/"unfilterable-float"}}
+        <td>
+            <p>{{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled
+            <p>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td>&checkmark;
@@ -17303,8 +17305,9 @@ The [=texel block memory cost=] of each of these formats is the same as its
     <tr>
         <td>{{GPUTextureFormat/rg32float}}
         <td>
-
-        <td>- {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled<br/>- {{GPUTextureSampleType/"unfilterable-float"}}
+        <td>
+            <p>{{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled
+            <p>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td><!-- Metal -->
@@ -17340,8 +17343,9 @@ The [=texel block memory cost=] of each of these formats is the same as its
     <tr>
         <td>{{GPUTextureFormat/rgba32float}}
         <td>
-
-        <td>- {{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled<br/>- {{GPUTextureSampleType/"unfilterable-float"}}
+        <td>
+            <p>{{GPUTextureSampleType/"float"}} if {{GPUFeatureName/"float32-filterable"}} is enabled
+            <p>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>If {{GPUFeatureName/"float32-blendable"}} is enabled
         <td><!-- Metal -->


### PR DESCRIPTION
The table in https://gpuweb.github.io/gpuweb/#plain-color-formats is behaving weirdly as you can see below. This PR fixes this:

Before:
<img width="1311" height="439" alt="Screenshot 2025-08-08 at 14 55 03" src="https://github.com/user-attachments/assets/6e69d5f7-9082-423e-90cc-3e9d90921fee" />
After:
<img width="1308" height="520" alt="Screenshot 2025-08-08 at 14 55 19" src="https://github.com/user-attachments/assets/8aff959a-bf4a-4887-abce-705f2c214173" />

I tried this PR in Chrome, Safari, and Firefox browsers.