### PR TITLE
Fix typo in #render-pass-encoder-finalization: loadOp -> storeOp

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12304,7 +12304,7 @@ called the render pass encoder can no longer be used.
                         1. Resolve the multiple samples of every [=texel block|texel=] of |colorSubregion| to a single
                             sample and copy to |colorAttachment|.{{GPURenderPassColorAttachment/resolveTarget}}.
 
-                    1. If |colorAttachment|.{{GPURenderPassColorAttachment/loadOp}} is:
+                    1. If |colorAttachment|.{{GPURenderPassColorAttachment/storeOp}} is:
                         <dl class=switch>
                             : {{GPUStoreOp/"store"}}
                             ::
@@ -12318,7 +12318,7 @@ called the render pass encoder can no longer be used.
 
                 1. Let |depthStencilAttachment| be |renderState|.{{RenderState/[[depthStencilAttachment]]}}.
                 1. If |depthStencilAttachment| is not `null`:
-                    1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} is:
+                    1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} is:
                         <dl class=switch>
                             : Not [=map/exist|provided=]
                             ::
@@ -12337,7 +12337,7 @@ called the render pass encoder can no longer be used.
                                 of |depthStencilView| to zero.
                         </dl>
 
-                    1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilLoadOp}} is:
+                    1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} is:
                         <dl class=switch>
                             : Not [=map/exist|provided=]
                             ::


### PR DESCRIPTION
Fixes a simple typo changing `*loadOp` to `*storeOp` during `RenderPass` finalization.