### PR TITLE
Fix typo in the main compute algorithm

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15413,7 +15413,7 @@ These operations are encoded within {{GPUComputePassEncoder}} as:
 The main compute algorithm:
 
 <div algorithm data-timeline=queue>
-    <dfn abstract-op>compute</dfn>(descriptor, drawCall, state)
+    <dfn abstract-op>compute</dfn>(descriptor, dispatchCall)
 
     **Arguments:**
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -15413,7 +15413,7 @@ These operations are encoded within {{GPUComputePassEncoder}} as:
 The main compute algorithm:
 
 <div algorithm data-timeline=queue>
-    <dfn abstract-op>compute</dfn>(descriptor, dispatchCall)
+    <dfn abstract-op>compute</dfn>(|descriptor|, |dispatchCall|)
 
     **Arguments:**
 


### PR DESCRIPTION
This PR fix the wrong arguments of compute algorithm in Ch.23 detailed operations.