### PR TITLE
Disallow sample_mask and sample_index

### DIFF
--- a/proposals/compatibility-mode.md
+++ b/proposals/compatibility-mode.md
@@ -138,7 +138,7 @@ A bind group may not reference a subset of array layers. Only views of the entir
 
 ### 7. Disallow `sample_mask` and `sample_index` builtins in WGSL.
 
-Use of the `sample_mask` or `sample_index` builtins would cause a validation error at shader module creation time.
+Use of the `sample_mask` or `sample_index` builtins would cause a validation error at pipeline creation time.
 
 **Justification**: OpenGL ES 3.1 does not support `gl_SampleMask`, `gl_SampleMaskIn`, or `gl_SampleID`.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8423,8 +8423,8 @@ dictionary GPURenderPipelineDescriptor
 
                 <div class=compatmode>
                     - If |device|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}:
-                        - [=builtin/sample_mask=] builtin must not be a [=shader stage input=] or [=shader stage output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
-                        - [=builtin/sample_index=] builtin must not be a [=shader stage input=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
+                        - The [=builtin/sample_mask=] builtin must not be a [=shader stage input=] or [=shader stage output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
+                        - The [=builtin/sample_index=] builtin must not be a [=shader stage input=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
                 </div>
 
             - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|) succeeds.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -125,6 +125,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
             text: workgroup; url: address-spaces-workgroup
         for: builtin
             text: sample_mask; url: built-in-values-sample_mask
+            text: sample_index; url: built-in-values-sample_index
             text: frag_depth; url: built-in-values-frag_depth
             text: clip_distances; url: built-in-values-clip_distances
             text: vertex_index; url: built-in-values-vertex_index
@@ -8419,6 +8420,13 @@ dictionary GPURenderPipelineDescriptor
                         [=map/exist|provided=], and
                         |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.{{GPUDepthStencilState/format}}
                         must have a [=aspect/depth=] aspect.
+
+                <div class=compatmode>
+                    - If |device|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}:
+                        - [=builtin/sample_mask=] builtin must not be a [=shader stage input=] or [=shader stage output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
+                        - [=builtin/sample_index=] builtin must not be a [=shader stage input=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
+                </div>
+
             - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|) succeeds.
             - If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is [=map/exist|provided=]:
                 - [$validating GPUDepthStencilState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}},


### PR DESCRIPTION
Also modify the proposal doc to validate this at pipeline creation, not shader module creation.

This represents issue [7](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#7-disallow-sample_mask-and-sample_index-builtins-in-wgsl) in the proposal doc.