### PR TITLE
Disallow invalid interpolation modes

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8469,6 +8469,13 @@ dictionary GPURenderPipelineDescriptor
         - The [=location=] of each user-defined output of
             |descriptor|.{{GPURenderPipelineDescriptor/vertex}} must be
             &le; |maxVertexShaderOutputLocation|.
+    1. If |device|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}:
+            <div class="compatmode">
+        - For each user-defined |output| of |descriptor|.{{GPURenderPipelineDescriptor/vertex}}:
+            - If the [=interpolation=] of the |output| is [=interpolation type/linear=], return `false`.
+            - If the [=interpolation=] of the |output| is [=interpolation type/flat=] and the [=interpolation sampling=] is not [=interpolation sampling/either=], return `false`.
+            - If the [=interpolation sampling=] of the |output| is [=interpolation sampling/sample=] or [=interpolation sampling/first=], return `false`.
+                </div>
     1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} [=map/exist|is provided=]:
         1. Let |maxFragmentShaderInputVariables| be
             |device|.limits.{{supported limits/maxInterStageShaderVariables}}.
@@ -8488,6 +8495,13 @@ dictionary GPURenderPipelineDescriptor
             |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is less
             than |device|.limits.{{supported limits/maxInterStageShaderVariables}}.
             (This follows from the above rules.)
+        1. If |device|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}:
+                <div class="compatmode">
+            - For each user-defined |input| of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+                - If the [=interpolation=] of the |input| is [=interpolation type/linear=], return `false`.
+                - If the [=interpolation=] of the |input| is [=interpolation type/flat=] and the [=interpolation sampling=] is not [=interpolation sampling/either=], return `false`.
+                - If the [=interpolation sampling=] of the |input| is [=interpolation sampling/sample=] or [=interpolation sampling/first=], return `false`.
+                    </div>
     1. Return `true`.
 </div>
 


### PR DESCRIPTION
In Compatibility Mode, disallow interpolation type "linear", and interpolation sampling "sample" and "first".
When interpolation type is "flat", allow only interpolation sampling "either".

This represents restrictions
[11](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#11-disallow-linear-and-sample-interpolation-options) and
[17](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#17-disallow-interpolationflat-and-interpolationflat-first) in the compatibility-mode proposal.