### PR TITLE
Fix all "Otherwise" to be in the same step with corresponding "If"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3482,7 +3482,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                 1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
                     1. Set |b|.{{GPUBuffer/[[internal state]]}} to "[=GPUBuffer/[[internal state]]/unavailable=]".
 
-                    Else:
+                    Otherwise:
 
                     1. Set |b|.{{GPUBuffer/[[internal state]]}} to "[=GPUBuffer/[[internal state]]/available=]".
 
@@ -7453,7 +7453,7 @@ run the following [=device timeline=] steps:
 
                     - Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"depth"}}
 
-                    Else if the sampled type of |resource| is:
+                    Otherwise, if the sampled type of |resource| is:
 
                     <dl class=switch>
                         : `f32` and there exists a [=static use=] of |resource| by |stageDesc| in a texture builtin function call that also uses a sampler
@@ -14497,7 +14497,7 @@ interface GPUCanvasContext {
 
         1. Set |snapshot| to a copy of the |context|.{{GPUCanvasContext/[[drawingBuffer]]}}.
 
-        Else, if |context|.{{GPUCanvasContext/[[lastPresentedImage]]}} is not `null`:
+        Otherwise, if |context|.{{GPUCanvasContext/[[lastPresentedImage]]}} is not `null`:
 
         1. **Optionally**, set |snapshot| to a copy of |context|.{{GPUCanvasContext/[[lastPresentedImage]]}}.
 
@@ -16241,10 +16241,10 @@ outputs the fragment color, depth and stencil data to be written into the render
         1. If |fragment|.[=Fragment/stencilPassed=] is `false`:
             - Let |stencilOp| be |stencilState|.{{GPUStencilFaceState/failOp}}.
 
-            Else if |fragment|.[=Fragment/depthPassed=] is `false`:
+            Otherwise, if |fragment|.[=Fragment/depthPassed=] is `false`:
             - Let |stencilOp| be |stencilState|.{{GPUStencilFaceState/depthFailOp}}.
 
-            Else:
+            Otherwise:
             - Let |stencilOp| be |stencilState|.{{GPUStencilFaceState/passOp}}.
         1. Update the value of the stencil aspect of |state|.{{RenderState/[[depthStencilAttachment]]}} at
             |fragment|.[=Fragment/destination=] by performing the operation described by |stencilOp|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2357,7 +2357,8 @@ interface GPU {
                 1. If |adapter| is not `null`:
                     1. [=Resolve=] |promise| with a new {{GPUAdapter}} encapsulating |adapter|.
 
-                1. Otherwise, [=Resolve=] |promise| with `null`.
+                    Otherwise:
+                    1. [=Resolve=] |promise| with `null`.
             </div>
             <!-- If we add ways to make invalid adapter requests (aside from those
                 that violate IDL rules), specify that they reject the promise. -->
@@ -7525,9 +7526,9 @@ run the following [=device timeline=] steps:
 
                     1. Set |previousEntry|.|storageTexture|.{{GPUStorageTextureBindingLayout/access}} to {{GPUStorageTextureAccess/"read-write"}}.
 
-            1. Else
+                    Otherwise:
 
-                1. Append |entry| to |groupDescs|[|group|].
+                    1. Append |entry| to |groupDescs|[|group|].
 
     1. Let |groupLayouts| be a new [=list=].
     1. For each |i| from 0 to |groupCount| - 1, inclusive:
@@ -9140,11 +9141,15 @@ must be 0.
     1. Let |maxDepthSlope| be the maximum of the horizontal and vertical slopes of the fragment's depth value.
     1. If |format| is a **unorm** format:
         1. Let |bias| be <code>(float)|state|.{{GPUDepthStencilState/depthBias}} * |r| + |state|.{{GPUDepthStencilState/depthBiasSlopeScale}} * |maxDepthSlope|</code>.
-    1. Otherwise, if |format| is a **float** format:
+
+        Otherwise, if |format| is a **float** format:
+
         1. Let |bias| be <code>(float)|state|.{{GPUDepthStencilState/depthBias}} * 2^(exp(max depth in primitive) - |r|) + |state|.{{GPUDepthStencilState/depthBiasSlopeScale}} * |maxDepthSlope|</code>.
     1. If |state|.{{GPUDepthStencilState/depthBiasClamp}} &gt; `0`:
         1. Set |bias| to <code>min(|state|.{{GPUDepthStencilState/depthBiasClamp}}, |bias|)</code>.
-    1. Otherwise if |state|.{{GPUDepthStencilState/depthBiasClamp}} &lt; `0`:
+
+        Otherwise, if |state|.{{GPUDepthStencilState/depthBiasClamp}} &lt; `0`:
+
         1. Set |bias| to <code>max(|state|.{{GPUDepthStencilState/depthBiasClamp}}, |bias|)</code>.
     1. If |state|.{{GPUDepthStencilState/depthBias}} &ne; `0` or |state|.{{GPUDepthStencilState/depthBiasSlopeScale}} &ne; `0`:
         1. Set the fragment depth value to <code>fragment depth value + |bias|</code>
@@ -12202,7 +12207,8 @@ dictionary GPURenderPassLayout
         1. If |colorAttachment| is not `null`:
             1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}.
             1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}.
-        1. Otherwise:
+
+            Otherwise:
             1. Append `null` to |layout|.{{GPURenderPassLayout/colorFormats}}.
     1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
     1. If |depthStencilAttachment| is not `null`:
@@ -12935,7 +12941,8 @@ It must only be included by interfaces which also include those mixins.
                 1. |bindGroupSpaceUsed| + |vertexBufferSpaceUsed| must be &le;
                     |encoder|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}}.
         </div>
-    1. Otherwise return `true`.
+
+        Otherwise, return `true`.
 </div>
 
 <div algorithm data-timeline=device>
@@ -12952,7 +12959,8 @@ It must only be included by interfaces which also include those mixins.
                 - |encoder|.{{GPURenderCommandsMixin/[[index_format]]}} must equal
                     |encoder|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/stripIndexFormat}}.
         </div>
-    1. Otherwise return `true`.
+
+        Otherwise, return `true`.
 </div>
 
 ### Rasterization state ### {#render-pass-encoder-rasterization-state}
@@ -15153,7 +15161,8 @@ partial interface GPUDevice {
         1. If |scope| is not `undefined`:
             1. [=list/Append=] |error| to |scope|.{{GPU error scope/[[errors]]}}.
             1. Return.
-        1. Otherwise issue the following steps to the [=content timeline=]:
+
+            Otherwise, issue the following steps to the [=content timeline=]:
     </div>
     <div data-timeline=content>
         [=Content timeline=] steps:
@@ -15562,7 +15571,8 @@ a list of vertices to process for each instance.
                 Note: Implementations may choose to display a warning when this occurs,
                 especially when it is easy to detect (like in non-indirect indexed draw calls).
             1. Append |drawCall|.`baseVertex` + |relativeVertexIndex| to the |vertexIndexList|.
-    1. Otherwise:
+
+        Otherwise:
         1. Initialize the |vertexIndexList| with |drawCall|.vertexCount integers.
         1. Set each |vertexIndexList| item |i| to the value |drawCall|.firstVertex + |i|.
     1. Return |vertexIndexList|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14507,21 +14507,17 @@ interface GPUCanvasContext {
             Implementations may choose to skip it even if do they still have access to that image.
 
     1. Let |alphaMode| be |configuration|.{{GPUCanvasConfiguration/alphaMode}}.
-    1.
-        <dl class=switch>
-            : If |alphaMode| is {{GPUCanvasAlphaMode/"opaque"}}:
-            ::
-                1. Clear the alpha channel of |snapshot| to 1.0.
-                1. Tag |snapshot| as being opaque.
+    1. If |alphaMode| is {{GPUCanvasAlphaMode/"opaque"}}:
+        1. Clear the alpha channel of |snapshot| to 1.0.
 
-                Note:
-                If the {{GPUCanvasContext/[[currentTexture]]}}, if any, has been destroyed
-                (for example in "[$Expire the current texture$]"), the alpha channel is unobservable,
-                and implementations may clear the alpha channel in-place.
+            Note:
+            If the {{GPUCanvasContext/[[currentTexture]]}}, if any, has been destroyed
+            (for example in "[$Expire the current texture$]"), the alpha channel is unobservable,
+            and implementations may clear the alpha channel in-place.
+        1. Tag |snapshot| as being opaque.
 
-            : Otherwise:
-            :: Tag |snapshot| with |alphaMode|.
-        </dl>
+        Otherwise:
+        1. Tag |snapshot| with |alphaMode|.
     1. Tag |snapshot| with the {{GPUCanvasConfiguration/colorSpace}} and
         {{GPUCanvasConfiguration/toneMapping}} of |configuration|.
     1. Return |snapshot|.


### PR DESCRIPTION
Helps make it clear which "If" the "Otherwise" is associated with.

Also:
- Else -> Otherwise (reads more naturally)
- Reformat one if-otherwise from a switch to the usual way