### PR TITLE
New per stage limits

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1402,7 +1402,7 @@ implicitly [$valid to use with|unusable$].
             1. Set |limits|[|key|] to |value|.
     1. Set |limits|.{{supported limits/maxStorageBuffersPerShaderStage}} to max(|limits|.{{supported limits/maxStorageBuffersPerShaderStage}}, |limits|.{{supported limits/maxStorageBuffersInVertexStage}}, |limits|.{{supported limits/maxStorageBuffersInFragmentStage}}).
     1. Set |limits|.{{supported limits/maxStorageTexturesPerShaderStage}} to max(|limits|.{{supported limits/maxStorageTexturesPerShaderStage}}, |limits|.{{supported limits/maxStorageTexturesInVertexStage}}, |limits|.{{supported limits/maxStorageTexturesInFragmentStage}}).
-    1. If |device|.{{device/[[features]]}} [=list/contains=] {{GPUFeatureName/"core-features-and-limits"}}:
+    1. If |features| [=list/contains=] {{GPUFeatureName/"core-features-and-limits"}}:
         1. Set |limits|.{{supported limits/maxStorageBuffersInVertexStage}} and |limits|.{{supported limits/maxStorageBuffersInFragmentStage}} to |limits|.{{supported limits/maxStorageBuffersPerShaderStage}}.
         1. Set |limits|.{{supported limits/maxStorageTexturesInVertexStage}} and |limits|.{{supported limits/maxStorageTexturesInFragmentStage}} to |limits|.{{supported limits/maxStorageTexturesPerShaderStage}}.
     1. Let |device| be a [=device=] object.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1402,6 +1402,9 @@ implicitly [$valid to use with|unusable$].
             1. Set |limits|[|key|] to |value|.
     1. Set |limits|.{{supported limits/maxStorageBuffersPerShaderStage}} to max(|limits|.{{supported limits/maxStorageBuffersPerShaderStage}}, |limits|.{{supported limits/maxStorageBuffersInVertexStage}}, |limits|.{{supported limits/maxStorageBuffersInFragmentStage}}).
     1. Set |limits|.{{supported limits/maxStorageTexturesPerShaderStage}} to max(|limits|.{{supported limits/maxStorageTexturesPerShaderStage}}, |limits|.{{supported limits/maxStorageTexturesInVertexStage}}, |limits|.{{supported limits/maxStorageTexturesInFragmentStage}}).
+    1. If |device|.{{device/[[features]]}} [=list/contains=] {{GPUFeatureName/"core-features-and-limits"}}:
+        1. Set |limits|.{{supported limits/maxStorageBuffersInVertexStage}} and |limits|.{{supported limits/maxStorageBuffersInFragmentStage}} to |limits|.{{supported limits/maxStorageBuffersPerShaderStage}}.
+        1. Set |limits|.{{supported limits/maxStorageTexturesInVertexStage}} and |limits|.{{supported limits/maxStorageTexturesInFragmentStage}} to |limits|.{{supported limits/maxStorageTexturesPerShaderStage}}.
     1. Let |device| be a [=device=] object.
     1. Set |device|.{{device/[[adapter]]}} to |adapter|.
     1. Set |device|.{{device/[[features]]}} to |features|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6066,12 +6066,20 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
                 : |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
                     is {{GPUBufferBindingType/"storage"}} or {{GPUBufferBindingType/"read-only-storage"}}
                 :: Consider 1 {{supported limits/maxStorageBuffersPerShaderStage}} slot to be used.
+                    : If |stage| is {{GPUShaderStage/VERTEX}},
+                    :: Consider 1 {{supported limits/maxStorageBuffersInVertexStage}} slot to be used.
+                    : Else if |stage| is {{GPUShaderStage/FRAGMENT}},
+                    :: Consider 1 {{supported limits/maxStorageBuffersInFragmentStage}} slot to be used.
                 : |entry|.{{GPUBindGroupLayoutEntry/sampler}} is [=map/exist|provided=]
                 :: Consider 1 {{supported limits/maxSamplersPerShaderStage}} slot to be used.
                 : |entry|.{{GPUBindGroupLayoutEntry/texture}} is [=map/exist|provided=]
                 :: Consider 1 {{supported limits/maxSampledTexturesPerShaderStage}} slot to be used.
                 : |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is [=map/exist|provided=]
                 :: Consider 1 {{supported limits/maxStorageTexturesPerShaderStage}} slot to be used.
+                    : If |stage| is {{GPUShaderStage/VERTEX}},
+                    :: Consider 1 {{supported limits/maxStorageTexturesInVertexStage}} slot to be used.
+                    : Else if |stage| is {{GPUShaderStage/FRAGMENT}},
+                    :: Consider 1 {{supported limits/maxStorageTexturesInFragmentStage}} slot to be used.
                 : |entry|.{{GPUBindGroupLayoutEntry/externalTexture}} is [=map/exist|provided=]
                 :: Consider
                     4 {{supported limits/maxSampledTexturesPerShaderStage}} slot,

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1400,6 +1400,8 @@ implicitly [$valid to use with|unusable$].
     1. For each (|key|, |value|) pair in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}:
         1. If |value| is not `undefined` and |value| is [=limit/better=] than |limits|[|key|]:
             1. Set |limits|[|key|] to |value|.
+    1. Set |limits|.{{supported limits/maxStorageBuffersPerShaderStage}} to max(|limits|.{{supported limits/maxStorageBuffersPerShaderStage}}, |limits|.{{supported limits/maxStorageBuffersInVertexStage}}, |limits|.{{supported limits/maxStorageBuffersInFragmentStage}}).
+    1. Set |limits|.{{supported limits/maxStorageTexturesPerShaderStage}} to max(|limits|.{{supported limits/maxStorageTexturesPerShaderStage}}, |limits|.{{supported limits/maxStorageTexturesInVertexStage}}, |limits|.{{supported limits/maxStorageTexturesInFragmentStage}}).
     1. Let |device| be a [=device=] object.
     1. Set |device|.{{device/[[adapter]]}} to |adapter|.
     1. Set |device|.{{device/[[features]]}} to |features|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6067,21 +6067,29 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
                 :: Consider 1 {{supported limits/maxUniformBuffersPerShaderStage}} slot to be used.
                 : |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
                     is {{GPUBufferBindingType/"storage"}} or {{GPUBufferBindingType/"read-only-storage"}}
-                :: Consider 1 {{supported limits/maxStorageBuffersPerShaderStage}} slot to be used.
-                    : If |stage| is {{GPUShaderStage/VERTEX}},
-                    :: Consider 1 {{supported limits/maxStorageBuffersInVertexStage}} slot to be used.
-                    : Else if |stage| is {{GPUShaderStage/FRAGMENT}},
-                    :: Consider 1 {{supported limits/maxStorageBuffersInFragmentStage}} slot to be used.
+                :: If |stage| is:
+                    <dl class=switch>
+                        : {{GPUShaderStage/VERTEX}}
+                        :: Consider 1 {{supported limits/maxStorageBuffersInVertexStage}} slot to be used.
+                        : {{GPUShaderStage/FRAGMENT}}
+                        :: Consider 1 {{supported limits/maxStorageBuffersInFragmentStage}} slot to be used.
+                        : {{GPUShaderStage/COMPUTE}}
+                        :: Consider 1 {{supported limits/maxStorageBuffersPerShaderStage}} slot to be used.
+                    </dl>
                 : |entry|.{{GPUBindGroupLayoutEntry/sampler}} is [=map/exist|provided=]
                 :: Consider 1 {{supported limits/maxSamplersPerShaderStage}} slot to be used.
                 : |entry|.{{GPUBindGroupLayoutEntry/texture}} is [=map/exist|provided=]
                 :: Consider 1 {{supported limits/maxSampledTexturesPerShaderStage}} slot to be used.
                 : |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is [=map/exist|provided=]
-                :: Consider 1 {{supported limits/maxStorageTexturesPerShaderStage}} slot to be used.
-                    : If |stage| is {{GPUShaderStage/VERTEX}},
-                    :: Consider 1 {{supported limits/maxStorageTexturesInVertexStage}} slot to be used.
-                    : Else if |stage| is {{GPUShaderStage/FRAGMENT}},
-                    :: Consider 1 {{supported limits/maxStorageTexturesInFragmentStage}} slot to be used.
+                :: If |stage| is:
+                    <dl class=switch>
+                        : {{GPUShaderStage/VERTEX}}
+                        :: Consider 1 {{supported limits/maxStorageTexturesInVertexStage}} slot to be used.
+                        : {{GPUShaderStage/FRAGMENT}}
+                        :: Consider 1 {{supported limits/maxStorageTexturesInFragmentStage}} slot to be used.
+                        : {{GPUShaderStage/COMPUTE}}
+                        :: Consider 1 {{supported limits/maxStorageTexturesPerShaderStage}} slot to be used.
+                    </dl>
                 : |entry|.{{GPUBindGroupLayoutEntry/externalTexture}} is [=map/exist|provided=]
                 :: Consider
                     4 {{supported limits/maxSampledTexturesPerShaderStage}} slot,

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1650,6 +1650,8 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
         which are storage buffers.
         See [=Exceeds the binding slot limits=].
 
+        Note: This limit applies to all stages. At [=a new device|device initialization=], it is normalized with {{supported limits/maxStorageBuffersInVertexStage}} and {{supported limits/maxStorageBuffersInFragmentStage}} so that in the validation algorithm, each stage can be checked against just one of the three limits.
+
     <tr><td><dfn>maxStorageBuffersInVertexStage</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8 <td>0
     <tr class=row-continuation><td colspan=5>
@@ -1671,6 +1673,8 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
         the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
         which are storage textures.
         See [=Exceeds the binding slot limits=].
+
+        Note: This limit applies to all stages. At [=a new device|device initialization=], it is normalized with {{supported limits/maxStorageTexturesInVertexStage}} and {{supported limits/maxStorageTexturesInFragmentStage}} so that in the validation algorithm, each stage can be checked against just one of the three limits.
 
     <tr><td><dfn>maxStorageTexturesInVertexStage</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8 <td>0

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1648,11 +1648,39 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
         which are storage buffers.
         See [=Exceeds the binding slot limits=].
 
+    <tr><td><dfn>maxStorageBuffersInVertexStage</dfn>
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8 <td>0
+    <tr class=row-continuation><td colspan=5>
+        For the vertex stage, the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
+        which are storage buffers.
+        See [=Exceeds the binding slot limits=].
+
+    <tr><td><dfn>maxStorageBuffersInFragmentStage</dfn>
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8 <td>4
+    <tr class=row-continuation><td colspan=5>
+        For the fragment stage, the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
+        which are storage buffers.
+        See [=Exceeds the binding slot limits=].
+
     <tr><td><dfn>maxStorageTexturesPerShaderStage</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td colspan=2>4
     <tr class=row-continuation><td colspan=5>
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
+        which are storage textures.
+        See [=Exceeds the binding slot limits=].
+
+    <tr><td><dfn>maxStorageTexturesInVertexStage</dfn>
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8 <td>0
+    <tr class=row-continuation><td colspan=5>
+        For the vertex stage, the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
+        which are storage textures.
+        See [=Exceeds the binding slot limits=].
+
+    <tr><td><dfn>maxStorageTexturesInFragmentStage</dfn>
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8 <td>4
+    <tr class=row-continuation><td colspan=5>
+        For the fragment stage, the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
         which are storage textures.
         See [=Exceeds the binding slot limits=].
 
@@ -1806,7 +1834,11 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxSampledTexturesPerShaderStage;
     readonly attribute unsigned long maxSamplersPerShaderStage;
     readonly attribute unsigned long maxStorageBuffersPerShaderStage;
+    readonly attribute unsigned long maxStorageBuffersInVertexStage;
+    readonly attribute unsigned long maxStorageBuffersInFragmentStage;
     readonly attribute unsigned long maxStorageTexturesPerShaderStage;
+    readonly attribute unsigned long maxStorageTexturesInVertexStage;
+    readonly attribute unsigned long maxStorageTexturesInFragmentStage;
     readonly attribute unsigned long maxUniformBuffersPerShaderStage;
     readonly attribute unsigned long long maxUniformBufferBindingSize;
     readonly attribute unsigned long long maxStorageBufferBindingSize;


### PR DESCRIPTION
Implement new storage buffer and texture limits.
    
Implement the new limits:
- maxStorageBuffersInVertexStage
- maxStorageBuffersInFragmentStage
- maxStorageTexturesInVertexStage
- maxStorageTexturesInFragmentStage
    
This represents restrictions
[18]https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#18-introduce-new-maxstoragebuffersinvertexstage-and-maxstoragetexturesinvertexstage-limits
and
[19]https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#19-introduce-new-maxstoragebuffersinfragmentstage-and-maxstoragetexturesinfragmentstage-limits
in the compatibility-mode proposal.