### PR TITLE
Implement depth texturing restrictions

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6993,7 +6993,14 @@ dictionary GPUShaderModuleDescriptor
                         - For each `enable` extension in |descriptor|.{{GPUShaderModuleDescriptor/code}},
                             the corresponding {{GPUFeatureName}} must be enabled
                             (see the [[#feature-index|Feature Index]]).
-                    </div>
+
+                        <div class=compatmode>
+                            - If |this|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}:
+                                - If |sm| contains a call to the `textureLoad` built-in function, its texture argument must not be of type `texture_depth`, `texture_depth_2d_array`, or `texture_depth_cube`
+                                - If |sm| contains a built-in texture function that accepts a |sampler| and its texture argument is of type `texture_depth`, `texture_depth_2d_array_`, or `texture_depth_cube`, |sampler| must be a `comparison_sampler`
+                        </div>
+
+                   </div>
 
                     Note: [=Uncategorized errors=] cannot arise from shader module creation.
                     Implementations which detect such errors during shader module creation


### PR DESCRIPTION
This represents restrictions
[16](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#16-disallow-textureload-with-texture_depth-textures) and
[20](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#20-disallow-using-a-depth-texture-with-a-non-comparison-sampler) from the compatibility-mode proposal.