### PR TITLE
Add additional dstformat in copyExternalImageToTexture with Tier1

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13809,6 +13809,16 @@ GPUQueue includes GPUObjectBase;
                             - {{GPUTextureFormat/"rgb10a2unorm"}}
                             - {{GPUTextureFormat/"rgba16float"}}
                             - {{GPUTextureFormat/"rgba32float"}}
+                            or the additional formats if {{GPUFeatureName/"texture-formats-tier1"}} is enabled:
+                            - {{GPUTextureFormat/"r16unorm"}}
+                            - {{GPUTextureFormat/"rg16unorm"}}
+                            - {{GPUTextureFormat/"rgba16unorm"}}
+                            - {{GPUTextureFormat/"r16snorm"}}
+                            - {{GPUTextureFormat/"rg16snorm"}}
+                            - {{GPUTextureFormat/"rgba16snorm"}}
+                            - {{GPUTextureFormat/"r8snorm"}}
+                            - {{GPUTextureFormat/"rg8snorm"}}
+                            - {{GPUTextureFormat/"rgba8snorm"}}
                     </div>
 
                 1. If |copySize|.[=GPUExtent3D/depthOrArrayLayers=] is &gt; 0, issue the subsequent
@@ -16833,6 +16843,18 @@ Allows the {{GPUStorageTextureAccess/"read-only"}} or {{GPUStorageTextureAccess/
 - {{GPUTextureFormat/"rgb10a2uint"}}
 - {{GPUTextureFormat/"rgb10a2unorm"}}
 - {{GPUTextureFormat/"rg11b10ufloat"}}
+
+Allows the destination.texture.format in {{GPUQueue/copyExternalImageToTexture()}} to be one of
+the below GPUTextureFormats:
+- {{GPUTextureFormat/"r16unorm"}}
+- {{GPUTextureFormat/"r16snorm"}}
+- {{GPUTextureFormat/"rg16unorm"}}
+- {{GPUTextureFormat/"rg16snorm"}}
+- {{GPUTextureFormat/"rgba16unorm"}}
+- {{GPUTextureFormat/"rgba16snorm"}}
+- {{GPUTextureFormat/"r8snorm"}}
+- {{GPUTextureFormat/"rg8snorm"}}
+- {{GPUTextureFormat/"rgba8snorm"}}
 
 Enabling {{GPUFeatureName/"texture-formats-tier2"}} at device creation will also enable
 {{GPUFeatureName/"texture-formats-tier1"}}.


### PR DESCRIPTION
This commit adds additional destination.texture.format in copyExternalImageToTexture function with texture-formats-tier1 enabled. These additional formats are renderable with the feature. 