### PR TITLE
Add missing word `be`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8451,7 +8451,7 @@ Note: The [=attribute/const=] attribute cannot be applied to user-declared funct
 * A [=vertex=] shader [=shader-creation error|must=] return the [=built-in values/position=] [=built-in output value=].
 * An entry point [=shader-creation error|must=] never be the target of a [=function call=].
 * If a function has a return type, it [=shader-creation error|must=] be a [=constructible=] type.
-* A [=formal parameter|function parameter=] [=shader-creation error|must=] one the following types:
+* A [=formal parameter|function parameter=] [=shader-creation error|must=] be one the following types:
     * a constructible type
     * a pointer type
     * a texture type


### PR DESCRIPTION
Add a missing `be` in the function parameter section of the spec.