### PR TITLE
Validate textureBindingViewDimension

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4498,6 +4498,14 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                         - |descriptor|.{{GPUTextureDescriptor/format}} must support {{GPUTextureDimension/"3d"}}
                             textures according to [[#texture-format-caps]].
                 </dl>
+
+            - If |this|.{{device/[[features]]}} does not [=list/contain=]
+                {{GPUFeatureName/"core-features-and-limits"}}:
+
+                <div class=compatmode>
+                    1. If |descriptor|.{{GPUTextureDescriptor/textureBindingViewDimension}} is {{GPUTextureViewDimension/"2d"}}, |this|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be 1.
+                    1. if |descriptor|.{{GPUTextureDescriptor/textureBindingViewDimension}} is {{GPUTextureViewDimension/"cube"}}, |this|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be 6.
+                </div>
             - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be multiple of [=texel block width=].
             - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be multiple of [=texel block height=].
             - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
@@ -4517,7 +4525,6 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
             - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
                 |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
                 [=texture view format compatible=] on device |this|.
-
                 <div class=note heading>
                     Implementations may consider issuing a developer-visible warning if |viewFormat| is not compatible with any of the
                     given {{GPUTextureDescriptor/usage}} bits, as that |viewFormat| will be unusable.


### PR DESCRIPTION
2D textures must have a single layer.
Cube textures must have 6 layers.

This represents issue
[14](https://github.com/SenorBlanco/gpuweb/blob/featurebranch-compat/proposals/compatibility-mode.md#14-require-depthorarraylayers-to-be-compatible-with-texturebindingviewdimension-in-createtexture) in the compatibility-mode proposal.