### PR TITLE
[bugfix] Fix copyExternalImageToTexture steps to handle *-srgb formats

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13829,14 +13829,26 @@ GPUQueue includes GPUObjectBase;
                     1. Let |srcY| be |y| if |source|.{{GPUCopyExternalImageSourceInfo/flipY}} is `false` and
                         (|copySize|.[=GPUExtent3D/height=] &minus; 1 &minus; |y|) otherwise.
                     1. For each |x| in the range [0, |copySize|.[=GPUExtent3D/width=] &minus; 1]:
-                        1. Set [=texel block=]
-                            (|dstOrigin|.[=GPUOrigin3D/x=] &plus; |x|, |dstOrigin|.[=GPUOrigin3D/y=] &plus; |y|) of
-                            |dstSubregion| to be an [=equivalent texel representation=] of the pixel at
+                        1. Let |srcColor| be the [[#color-spaces|color-managed color value]] of the pixel at
                             (|srcOrigin|.[=GPUOrigin2D/x=] &plus; |x|, |srcOrigin|.[=GPUOrigin2D/y=] &plus; |srcY|) of
-                            |source|.{{GPUCopyExternalImageSourceInfo/source}} after applying any
+                            |source|.{{GPUCopyExternalImageSourceInfo/source}}.
+                        1. Let |dstColor| be the numeric RGBA value resulting from applying any
                             [[#color-space-conversions|color encoding]] required by
                             |destination|.{{GPUCopyExternalImageDestInfo/colorSpace}} and
-                            |destination|.{{GPUCopyExternalImageDestInfo/premultipliedAlpha}}.
+                            |destination|.{{GPUCopyExternalImageDestInfo/premultipliedAlpha}}
+                            to |srcColor|.
+                        1. If |texture|.{{GPUTexture/format}} is an `-srgb` format:
+                            1. Set |dstColor| to the result of applying the sRGB non-linear-to-linear conversion to it.
+
+                            Note:
+                            This cancels out the sRGB linear-to-non-linear conversion that occurs
+                            when writing an `-srgb` format in the next step, so that precision
+                            from an sRGB-like input image is not lost and the *linear* color values
+                            of the original image can be read from the texture
+                            (as is generally the purpose of using `-srgb` formats).
+                        1. Set [=texel block=]
+                            (|dstOrigin|.[=GPUOrigin3D/x=] &plus; |x|, |dstOrigin|.[=GPUOrigin3D/y=] &plus; |y|) of
+                            |dstSubregion| to an [=equivalent texel representation=] of |dstColor|.
             </div>
         </div>
 


### PR DESCRIPTION
This was already described in the prose and covered in CTS, but the algorithm didn't handle it.