### PR TITLE
[editorial] Clarify "equivalent texel representation"

### DIFF
--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -31,13 +31,14 @@ and "immediate" {{GPUQueue}} operations:
 - {{GPUQueue/copyExternalImageToTexture()}}, for copies from Web Platform image sources to textures
 
 <div algorithm>
-    In a texel copy, destination texel blocks are written with some value with an
+    In a texel copy, the bytes written to the destination texel blocks will have an
     <dfn dfn>equivalent texel representation</dfn> to the source value.
 
     Texel copies only guarantee that valid, finite, non-subnormal numeric values
     in the source have the same numeric value in the destination.
     Specifically, the texel block may be decoded and re-encoded in a way that
     preserves only those values.
+    Where multiple byte representations are possible, the choice of representation is implementation-defined.
 
     - Any floating-point zero value may be represented as either -0.0 or +0.0.
     - Any floating-point subnormal value may be either preserved or replaced by -0.0 or +0.0.


### PR DESCRIPTION
Explain this more explicitly as decoding and re-encoding. Specifically wanted to note that "rgb9e5ufloat" could change representation (no particular reason, I just noticed that it wasn't mentioned).