### PR TITLE
Limit texture/sampler combinations

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7883,7 +7883,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
             1. Let |sum| be 0.
             1. For each unique texture or external texture binding |textureBinding| that is used in any call to a texture builtin in any of the [=functions in the shader stage=] rooted at |entryPoint|:
                 1. Let |samplerBindings| be the set of sampler bindings used together with |textureBinding| in any call to a texture builtin in any of the [=functions in the shader stage=] rooted at |entryPoint|.
-                1. Let |numPairs| be <code>max(1, number of elements of |samplerBindings|)</code>
+                1. Let |numPairs| be <code>max(1, number of elements of |samplerBindings|)</code>.
                 1. If |textureBinding| is an external texture binding:
                     1. Let |numPairs| be <code>1 + 3 * |numPairs|</code>.
                 1. Let |sum| be <code>|sum| + |numPairs|</code>.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7880,13 +7880,16 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         result from the rules of the [[WGSL]] specification.
     1. If |device|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}:
         <div class=compatmode>
-            1. let |numCombos| be 0.
-            1. For each texture builtin function call in any of the [=functions in the shader stage=] rooted at |entryPoint|, with a |textureBinding| together with a |samplerBinding| of `sampler` type:
-                1. If the tuple |textureBinding|, |samplerBinding| has not been seen previously,
+            1. Let |maxCombos| be min(limits.maxSampledTexturesPerShaderStage, limits.maxSamplersPerShaderStage).
+            1. Let |numCombos| be 0.
+            1. For each texture builtin function call in any of the [=functions in the shader stage=] rooted at |entryPoint|, with a |textureBinding| together with a |samplerBinding|:
+                1. If the tuple |textureBinding|, |samplerBinding| has not been seen previously in this loop,
                     1. If |textureBinding| is of `texture_external` type:
                         - Add 3 to |numCombos|.
-                            Else, Add 1 to |numCombos|.
-            1. Let |maxCombos| be min(limits.maxSampledTexturesPerShaderStage, limits.maxSamplersPerShaderStage).
+
+                        Else:
+
+                        - Add 1 to |numCombos|.
             1. |numCombos| must be <= |maxCombos|.
         </div>
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7882,14 +7882,21 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         <div class=compatmode>
             1. Let |maxCombos| be min(limits.maxSampledTexturesPerShaderStage, limits.maxSamplersPerShaderStage).
             1. Let |numCombos| be 0.
-            1. For each texture builtin function call in any of the [=functions in the shader stage=] rooted at |entryPoint|, with a |textureBinding| together with a |samplerBinding|:
-                1. If the tuple |textureBinding|, |samplerBinding| has not been seen previously in this loop,
-                    1. If |textureBinding| is of `texture_external` type:
-                        - Add 3 to |numCombos|.
+            1. Let |samplerTexturePairs| be the empty set.
+            1. For each call |call| to a texture builtin function in any of the
+                [=functions in the shader stage=] rooted at |entryPoint|:
+                1. Let |textureBinding| be the texture binding used in |call|.
+                1. If |call| uses a sampler binding |samplerBinding|:
+                    1. Let |pair| be |textureBinding|, |samplerBinding| pair.
+                    1. If |pair| is not found in |samplerTexturePairs|:
+                        1. If |textureBinding| is of `texture_external` type:
+                            1. If |textureBinding| is not found in any pair in |samplerTexturePairs|, add 3 to |numCombos|.
+                        1. Add 1 to |numCombos|.
+                        1. Insert |pair| into |samplerTexturePairs|.
 
-                        Else:
+                    Else:
 
-                        - Add 1 to |numCombos|.
+                    1. If |textureBinding| is not found in any pair in |samplerTexturePairs|, add 1 to |numCombos|.
             1. |numCombos| must be <= |maxCombos|.
         </div>
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7880,7 +7880,6 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         result from the rules of the [[WGSL]] specification.
     1. If |device|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}:
         <div class=compatmode>
-            1. Let |maxCombos| be min(limits.maxSampledTexturesPerShaderStage, limits.maxSamplersPerShaderStage).
             1. Let |numCombos| be 0.
             1. Let |samplerTexturePairs| be the empty set.
             1. For each call |call| to a texture builtin function in any of the
@@ -7897,7 +7896,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                     Else:
 
                     1. If |textureBinding| is not found in any pair in |samplerTexturePairs|, add 1 to |numCombos|.
-            1. |numCombos| must be <= |maxCombos|.
+            1. |numCombos| must be &le; |device|.limits.{{supported limits/maxSampledTexturesPerShaderStage}}.
+            1. |numCombos| must be &le; |device|.limits.{{supported limits/maxSamplersPerShaderStage}}.
         </div>
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7878,6 +7878,16 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
             |descriptor|.{{GPUProgrammableStage/constants}} |must| [=map/contain=] |key|.
     1. [=pipeline-creation error|Pipeline-creation=] [=program errors=] |must| not
         result from the rules of the [[WGSL]] specification.
+    1. If |device|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}:
+        <div class=compatmode>
+            1. let |numCombos| be 0.
+            1. For each |textureBinding| in all bindings.
+               1. For each |samplerBinding| in all bindings.
+                   1. Let |combo| be |textureBinding|, |samplerBinding|.
+                   1. If |combo| hasn't been seen before, add 1 to |numCombos|.
+            1. Let |maxCombos| be min(limits.maxSampledTexturesPerShaderStage, limits.maxSamplersPerShaderStage).
+            1. |numCombos| must be <= |maxCombos|.
+        </div>
 </div>
 
 <div algorithm data-timeline=const>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7881,22 +7881,12 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     1. If |device|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}:
         <div class=compatmode>
             1. Let |sum| be 0.
-            1. Let |textureBindings| be an empty list.
-            1. For each call |call| to a texture builtin function in any of the
-                [=functions in the shader stage=] rooted at |entryPoint|:
-                1. Let |textureBinding| be the texture binding used in |call|.
-                1. If |textureBinding| is not in |textureBindings|,
-                    1. Append |textureBinding| to |textureBindings|.
-                    1. Let |samplerBindings| be an empty list.
-                    1. For each call |call| to a texture builtin function in any of the
-                        [=functions in the shader stage=] rooted at |entryPoint|:
-                        1. If the texture binding in |call| is equal to |textureBinding| and uses a sampler binding |samplerBinding|:
-                            1. If |samplerBinding| is not contained in |samplerBindings|:
-                                1. Insert |samplerBinding| into |samplerBindings|.
-                    1. Let |numPairs| be <code>max(1, number of elements of |samplerBindings|)</code>
-                    1. If |textureBinding| is an external texture binding:
-                        1. Let |numPairs| be <code>1 + 3 * |numPairs|</code>
-                    1. Let |sum| be <code>|sum| + |numPairs|</code>.
+            1. For each unique texture or external texture binding |textureBinding| that is used in any call to a texture builtin in any of the [=functions in the shader stage=] rooted at |entryPoint|:
+                1. Let |samplerBindings| be the set of sampler bindings used together with |textureBinding| in any call to a texture builtin in any of the [=functions in the shader stage=] rooted at |entryPoint|.
+                1. Let |numPairs| be <code>max(1, number of elements of |samplerBindings|)</code>
+                1. If |textureBinding| is an external texture binding:
+                    1. Let |numPairs| be <code>1 + 3 * |numPairs|</code>.
+                1. Let |sum| be <code>|sum| + |numPairs|</code>.
             1. |sum| |must| be &le; |device|.limits.{{supported limits/maxSampledTexturesPerShaderStage}}.
             1. |sum| |must| be &le; |device|.limits.{{supported limits/maxSamplersPerShaderStage}}.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7880,25 +7880,25 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         result from the rules of the [[WGSL]] specification.
     1. If |device|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}:
         <div class=compatmode>
-            1. Let |numCombos| be 0.
-            1. Let |samplerTexturePairs| be the empty set.
+            1. Let |sum| be 0.
+            1. Let |textureBindings| be an empty list.
             1. For each call |call| to a texture builtin function in any of the
                 [=functions in the shader stage=] rooted at |entryPoint|:
                 1. Let |textureBinding| be the texture binding used in |call|.
-                1. If |call| uses a sampler binding |samplerBinding|:
-                    1. Let |pair| be |textureBinding|, |samplerBinding| pair.
-                    1. If |pair| is not found in |samplerTexturePairs|:
-                        1. If |textureBinding| is of `texture_external` type:
-                            1. If |textureBinding| is not found in any pair in |samplerTexturePairs|, add 3 to |numCombos|.
-                        1. Add 1 to |numCombos|.
-                        1. Insert |pair| into |samplerTexturePairs|.
-
-                    Else:
-
-                    1. If |textureBinding| is not found in any pair in |samplerTexturePairs|, add 1 to |numCombos|.
-            1. |numCombos| must be &le; |device|.limits.{{supported limits/maxSampledTexturesPerShaderStage}}.
-            1. |numCombos| must be &le; |device|.limits.{{supported limits/maxSamplersPerShaderStage}}.
-        </div>
+                1. If |textureBinding| is not in |textureBindings|,
+                    1. Append |textureBinding| to |textureBindings|.
+                    1. Let |samplerBindings| be an empty list.
+                    1. For each call |call| to a texture builtin function in any of the
+                        [=functions in the shader stage=] rooted at |entryPoint|:
+                        1. If the texture binding in |call| is equal to |textureBinding| and uses a sampler binding |samplerBinding|:
+                            1. If |samplerBinding| is not contained in |samplerBindings|:
+                                1. Insert |samplerBinding| into |samplerBindings|.
+                    1. Let |numPairs| be <code>max(1, number of elements of |samplerBindings|)</code>
+                    1. If |textureBinding| is an external texture binding:
+                        1. Let |numPairs| be <code>1 + 3 * |numPairs|</code>
+                    1. Let |sum| be <code>|sum| + |numPairs|</code>.
+            1. |sum| |must| be &le; |device|.limits.{{supported limits/maxSampledTexturesPerShaderStage}}.
+            1. |sum| |must| be &le; |device|.limits.{{supported limits/maxSamplersPerShaderStage}}.
 </div>
 
 <div algorithm data-timeline=const>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7881,10 +7881,11 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     1. If |device|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}:
         <div class=compatmode>
             1. let |numCombos| be 0.
-            1. For each |textureBinding| in all bindings.
-               1. For each |samplerBinding| in all bindings.
-                   1. Let |combo| be |textureBinding|, |samplerBinding|.
-                   1. If |combo| hasn't been seen before, add 1 to |numCombos|.
+            1. For each texture builtin function call in any of the [=functions in the shader stage=] rooted at |entryPoint|, with a |textureBinding| together with a |samplerBinding| of `sampler` type:
+                1. If the tuple |textureBinding|, |samplerBinding| has not been seen previously,
+                    1. If |textureBinding| is of `texture_external` type:
+                        - Add 3 to |numCombos|.
+                            Else, Add 1 to |numCombos|.
             1. Let |maxCombos| be min(limits.maxSampledTexturesPerShaderStage, limits.maxSamplersPerShaderStage).
             1. |numCombos| must be <= |maxCombos|.
         </div>


### PR DESCRIPTION
Limit maximum texture/sampler combinations
    
This represents restriction
[11](https://github.com/SenorBlanco/gpuweb/blob/featurebranch-compat/proposals/compatibility-mode.md#21-limit-the-number-of-texturesampler-combinations-in-a-stage)
in the compatibility-mode proposal.