### PR TITLE
Match WGSL syntax and clean open questions

### DIFF
--- a/proposals/texture-component-swizzle.md
+++ b/proposals/texture-component-swizzle.md
@@ -21,29 +21,17 @@ partial enum GPUFeatureName {
 };
 ```
 
-The GPUTextureViewDescriptor `swizzle` option lets you rearrange or even replace the data from a texture's channels when creating a GPUTextureView. This is done by assigning a value from the GPUComponentSwizzle enum to each of the `r`, `g`, `b`, and `a` components in your texture view.
+A new `swizzle` option is added to the `GPUTextureViewDescriptor` which allows for rearranging or replacing the data from the texture's channels when creating a `GPUTextureView`. The `swizzle` value is a string of length four, with each character mapping to the view's red, green, blue, and alpha components, respectively. Each character can be either:
+- `"r"`: Take its value from the red channel of the texture.
+- `"g"`: Take its value from the green channel of the texture.
+- `"b"`: Take its value from the blue channel of the texture.
+- `"a"`: Take its value from the alpha channel of the texture.
+- `"0"`: Force its value to 0.
+- `"1"`: Force its value to 1.
 
 ```webidl
 partial dictionary GPUTextureViewDescriptor {
-    GPUTextureComponentSwizzle swizzle;
-};
-
-// Structure specifying a custom color component mapping for a texture view.
-dictionary GPUTextureComponentSwizzle {
-    GPUComponentSwizzle r = "r";
-    GPUComponentSwizzle g = "g";
-    GPUComponentSwizzle b = "b";
-    GPUComponentSwizzle a = "a";
-};
-
-// A set of options to choose from when specifying a component swizzle.
-enum GPUComponentSwizzle {
-    "zero",     // Force its value to 0.
-    "one",      // Force its value to 1.
-    "r",        // Take its value from the red channel of the texture.
-    "g",        // Take its value from the green channel of the texture.
-    "b",        // Take its value from the blue channel of the texture.
-    "a",        // Take its value from the alpha channel of the texture.
+    DOMString? swizzle;
 };
 ```
 
@@ -52,15 +40,13 @@ To reduce compatibility issues in practice, implementations *should* provide (V,
 
 ## Validation
 
-The `GPUTexture.createView(descriptor)` algorithm is extended with the following validation rules changes:
+The `GPUTexture.createView(descriptor)` algorithm is extended with the following changes:
 
-- If `descriptor.usage` includes the `RENDER_ATTACHMENT` or `STORAGE_BINDING` bit:
-  - `descriptor.swizzle.r` must be `"r"`.
-  - `descriptor.swizzle.g` must be `"g"`.
-  - `descriptor.swizzle.b` must be `"b"`.
-  - `descriptor.swizzle.a` must be `"a"`.
+- If `descriptor.swizzle` is not `null`, it must be a four-character string that only includes `"r"`, `"g"`, `"b"`, `"a"`, `"0"`, or `"1"`, otherwise a `TypeError` is raised.
 
-- If `descriptor.swizzle` is not the default, the `"texture-component-swizzle"` feature must be enabled.
+- If `descriptor.usage` includes the `RENDER_ATTACHMENT` or `STORAGE_BINDING` bit, `descriptor.swizzle` must be either `null` or `"rgba"`.
+
+- If `descriptor.swizzle` is neither null nor `"rgba"`, the `"texture-component-swizzle"` feature must be enabled.
 
 If the feature `"core-features-and-limits"` is not enabled on a device, a draw call may not bind two views of the same texture differing in swizzle. Only a single swizzle per texture is supported. This is enforced via validation at draw time.
 
@@ -80,19 +66,13 @@ const device = await adapter.requestDevice({
 
 // ... Assuming myTexture is a GPUTexture with a single red channel.
 
-const textureView = myTexture.createView({
-  swizzle: {
-    r: 'r',  // Map the view's red component to the texture's red channel
-    g: 'r',  // Map the view's green component to the texture's red channel
-    b: 'r',  // Map the view's blue component to the texture's red channel
-    a: 'one' // Force the view's alpha component to 1.0
-  }
-});
+// Map the view's red, green, blue components to the texture's red channel
+// and force the view's alpha component to 1.0.
+const textureView = myTexture.createView({ swizzle: "rrr1" });
 ```
 
 ## Open Questions
 
-- Are there new validation rules needed if the view is multisampled?
 - In Compatibility Mode, this could count against the [texture and sampler combination limit](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#21-limit-the-number-of-texturesampler-combinations-in-a-stage), or it might not be exposed at all.
 
 ## Resources

--- a/proposals/texture-component-swizzle.md
+++ b/proposals/texture-component-swizzle.md
@@ -42,7 +42,7 @@ To reduce compatibility issues in practice, implementations *should* provide (V,
 
 The `GPUTexture.createView(descriptor)` algorithm is extended with the following changes:
 
-- If `descriptor.swizzle` must be a four-character string that only includes `"r"`, `"g"`, `"b"`, `"a"`, `"0"`, or `"1"`, otherwise a `TypeError` is raised.
+- `descriptor.swizzle` must be a four-character string that only includes `"r"`, `"g"`, `"b"`, `"a"`, `"0"`, or `"1"`, otherwise a `TypeError` is raised.
 
 - If `descriptor.usage` includes the `RENDER_ATTACHMENT` or `STORAGE_BINDING` bit, `descriptor.swizzle` must be `"rgba"`.
 

--- a/proposals/texture-component-swizzle.md
+++ b/proposals/texture-component-swizzle.md
@@ -71,10 +71,6 @@ const device = await adapter.requestDevice({
 const textureView = myTexture.createView({ swizzle: "rrr1" });
 ```
 
-## Open Questions
-
-- In Compatibility Mode, this could count against the [texture and sampler combination limit](https://github.com/gpuweb/gpuweb/blob/main/proposals/compatibility-mode.md#21-limit-the-number-of-texturesampler-combinations-in-a-stage), or it might not be exposed at all.
-
 ## Resources
 
 - [Vkswizzle(3) Vulkan Manual Page](https://registry.khronos.org/vulkan/specs/latest/man/html/VkComponentMapping.html)

--- a/proposals/texture-component-swizzle.md
+++ b/proposals/texture-component-swizzle.md
@@ -31,7 +31,7 @@ A new `swizzle` option is added to the `GPUTextureViewDescriptor` which allows f
 
 ```webidl
 partial dictionary GPUTextureViewDescriptor {
-    DOMString? swizzle;
+    DOMString swizzle = "rgba";
 };
 ```
 
@@ -42,11 +42,11 @@ To reduce compatibility issues in practice, implementations *should* provide (V,
 
 The `GPUTexture.createView(descriptor)` algorithm is extended with the following changes:
 
-- If `descriptor.swizzle` is not `null`, it must be a four-character string that only includes `"r"`, `"g"`, `"b"`, `"a"`, `"0"`, or `"1"`, otherwise a `TypeError` is raised.
+- If `descriptor.swizzle` must be a four-character string that only includes `"r"`, `"g"`, `"b"`, `"a"`, `"0"`, or `"1"`, otherwise a `TypeError` is raised.
 
-- If `descriptor.usage` includes the `RENDER_ATTACHMENT` or `STORAGE_BINDING` bit, `descriptor.swizzle` must be either `null` or `"rgba"`.
+- If `descriptor.usage` includes the `RENDER_ATTACHMENT` or `STORAGE_BINDING` bit, `descriptor.swizzle` must be `"rgba"`.
 
-- If `descriptor.swizzle` is neither null nor `"rgba"`, the `"texture-component-swizzle"` feature must be enabled.
+- If `descriptor.swizzle` is not `"rgba"`, the `"texture-component-swizzle"` feature must be enabled.
 
 If the feature `"core-features-and-limits"` is not enabled on a device, a draw call may not bind two views of the same texture differing in swizzle. Only a single swizzle per texture is supported. This is enforced via validation at draw time.
 


### PR DESCRIPTION
According to [Agenda / Minutes for GPU Web WG Toronto F2F meeting 2025-09-16/17](https://docs.google.com/document/d/1WnEj8jwUxgEeoMhUf5AuSoGoaHsZAAGmEk_P8ktlzbY/edit?tab=t.0#heading=h.8for8njeuzoi), this PR updates the texture component swizzle proposal to match WGSL syntax and clean open questions.

FIX https://github.com/gpuweb/gpuweb/issues/5296