### PR TITLE
copyExternalImageToTexture: allow all unorm/unorm-srgb/float/ufloat textures

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13794,32 +13794,9 @@ GPUQueue includes GPUObjectBase;
                             {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/COPY_DST}}.
                         - |texture|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                         - |texture|.{{GPUTexture/sampleCount}} must be 1.
-                        - |texture|.{{GPUTexture/format}} must be one of the following
-                            formats (which all support {{GPUTextureUsage/RENDER_ATTACHMENT}} usage):
-                            - {{GPUTextureFormat/"r8unorm"}}
-                            - {{GPUTextureFormat/"r16float"}}
-                            - {{GPUTextureFormat/"r32float"}}
-                            - {{GPUTextureFormat/"rg8unorm"}}
-                            - {{GPUTextureFormat/"rg16float"}}
-                            - {{GPUTextureFormat/"rg32float"}}
-                            - {{GPUTextureFormat/"rgba8unorm"}}
-                            - {{GPUTextureFormat/"rgba8unorm-srgb"}}
-                            - {{GPUTextureFormat/"bgra8unorm"}}
-                            - {{GPUTextureFormat/"bgra8unorm-srgb"}}
-                            - {{GPUTextureFormat/"rgb10a2unorm"}}
-                            - {{GPUTextureFormat/"rgba16float"}}
-                            - {{GPUTextureFormat/"rgba32float"}}
-                            or the below formats if {{GPUFeatureName/"texture-formats-tier1"}} is enabled:
-                            - {{GPUTextureFormat/"r16unorm"}}
-                            - {{GPUTextureFormat/"r16snorm"}}
-                            - {{GPUTextureFormat/"rg16unorm"}}
-                            - {{GPUTextureFormat/"rg16snorm"}}
-                            - {{GPUTextureFormat/"rgba16unorm"}}
-                            - {{GPUTextureFormat/"rgba16snorm"}}
-                            - {{GPUTextureFormat/"r8snorm"}}
-                            - {{GPUTextureFormat/"rg8snorm"}}
-                            - {{GPUTextureFormat/"rgba8snorm"}}
-                            - {{GPUTextureFormat/"rg11b10ufloat"}}
+                        - |texture|.{{GPUTexture/format}} must be a [[#plain-color-formats|plain color format]]
+                            supporting {{GPUTextureUsage/RENDER_ATTACHMENT}} and be a
+                            `unorm`/`unorm-srgb` or `float`/`ufloat` format (not `snorm`, `uint`, or `sint`).
                     </div>
 
                 1. If |copySize|.[=GPUExtent3D/depthOrArrayLayers=] is &gt; 0, issue the subsequent
@@ -16740,6 +16717,8 @@ This feature adds the following [=optional API surfaces=]:
 Allows the {{GPUTextureUsage/RENDER_ATTACHMENT}} usage on textures with format {{GPUTextureFormat/"rg11b10ufloat"}},
 and also allows textures of that format to be blended, multisampled, and resolved.
 
+Implicitly allows {{GPUTextureFormat/"rg11b10ufloat"}} as a destination format in {{GPUQueue/copyExternalImageToTexture()}}.
+
 This feature adds no [=optional API surfaces=].
 
 Enabling {{GPUFeatureName/"texture-formats-tier1"}} at device creation will also enable
@@ -16845,18 +16824,10 @@ Allows the {{GPUStorageTextureAccess/"read-only"}} or {{GPUStorageTextureAccess/
 - {{GPUTextureFormat/"rgb10a2unorm"}}
 - {{GPUTextureFormat/"rg11b10ufloat"}}
 
-Allows the destination.texture.format in {{GPUQueue/copyExternalImageToTexture()}} to be one of
-the below GPUTextureFormats:
+Implicitly allows the following new destination formats in {{GPUQueue/copyExternalImageToTexture()}}:
 - {{GPUTextureFormat/"r16unorm"}}
-- {{GPUTextureFormat/"r16snorm"}}
 - {{GPUTextureFormat/"rg16unorm"}}
-- {{GPUTextureFormat/"rg16snorm"}}
 - {{GPUTextureFormat/"rgba16unorm"}}
-- {{GPUTextureFormat/"rgba16snorm"}}
-- {{GPUTextureFormat/"r8snorm"}}
-- {{GPUTextureFormat/"rg8snorm"}}
-- {{GPUTextureFormat/"rgba8snorm"}}
-- {{GPUTextureFormat/"rg11b10ufloat"}}
 
 Enabling {{GPUFeatureName/"texture-formats-tier2"}} at device creation will also enable
 {{GPUFeatureName/"texture-formats-tier1"}}.
@@ -17587,6 +17558,8 @@ All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsa
 and {{GPUTextureUsage/TEXTURE_BINDING}} usages.
 All of these formats are [=filterable=].
 None of these formats are [=renderable=] or support multisampling.
+<!-- POSTV1: If adding renderability to rgb9e5ufloat, be sure to consider whether it should be
+allowed in copyExternalImageToTexture. -->
 
 A <dfn dfn>compressed format</dfn> is any format with a block size greater than 1&times;1.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13809,16 +13809,17 @@ GPUQueue includes GPUObjectBase;
                             - {{GPUTextureFormat/"rgb10a2unorm"}}
                             - {{GPUTextureFormat/"rgba16float"}}
                             - {{GPUTextureFormat/"rgba32float"}}
-                            or the additional formats if {{GPUFeatureName/"texture-formats-tier1"}} is enabled:
+                            or the below formats if {{GPUFeatureName/"texture-formats-tier1"}} is enabled:
                             - {{GPUTextureFormat/"r16unorm"}}
-                            - {{GPUTextureFormat/"rg16unorm"}}
-                            - {{GPUTextureFormat/"rgba16unorm"}}
                             - {{GPUTextureFormat/"r16snorm"}}
+                            - {{GPUTextureFormat/"rg16unorm"}}
                             - {{GPUTextureFormat/"rg16snorm"}}
+                            - {{GPUTextureFormat/"rgba16unorm"}}
                             - {{GPUTextureFormat/"rgba16snorm"}}
                             - {{GPUTextureFormat/"r8snorm"}}
                             - {{GPUTextureFormat/"rg8snorm"}}
                             - {{GPUTextureFormat/"rgba8snorm"}}
+                            - {{GPUTextureFormat/"rg11b10ufloat"}}
                     </div>
 
                 1. If |copySize|.[=GPUExtent3D/depthOrArrayLayers=] is &gt; 0, issue the subsequent
@@ -16855,6 +16856,7 @@ the below GPUTextureFormats:
 - {{GPUTextureFormat/"r8snorm"}}
 - {{GPUTextureFormat/"rg8snorm"}}
 - {{GPUTextureFormat/"rgba8snorm"}}
+- {{GPUTextureFormat/"rg11b10ufloat"}}
 
 Enabling {{GPUFeatureName/"texture-formats-tier2"}} at device creation will also enable
 {{GPUFeatureName/"texture-formats-tier1"}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -16721,8 +16721,8 @@ Implicitly allows {{GPUTextureFormat/"rg11b10ufloat"}} as a destination format i
 
 This feature adds no [=optional API surfaces=].
 
-Enabling {{GPUFeatureName/"texture-formats-tier1"}} at device creation will also enable
-{{GPUFeatureName/"rg11b10ufloat-renderable"}}.
+Note: This feature is automatically enabled by {{GPUFeatureName/"texture-formats-tier1"}},
+which is automatically enabled by {{GPUFeatureName/"texture-formats-tier2"}}.
 
 <h3 id=bgra8unorm-storage data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"bgra8unorm-storage"`
 </h3>
@@ -16787,6 +16787,9 @@ expose real values whenever the feature is available on the adapter:
 <h3 id=texture-formats-tier1 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-formats-tier1"`
 </h3>
 
+Enabling {{GPUFeatureName/"texture-formats-tier1"}} at device creation will enable
+{{GPUFeatureName/"rg11b10ufloat-renderable"}}. The following items are in addition to that.
+
 Supports the below new {{GPUTextureFormat}}s with the {{GPUTextureUsage/RENDER_ATTACHMENT}},
 [=blendable=], `multisampling` capabilities and the {{GPUTextureUsage/STORAGE_BINDING}} capability
 with the {{GPUStorageTextureAccess/"read-only"}} and {{GPUStorageTextureAccess/"write-only"}}
@@ -16829,14 +16832,13 @@ Implicitly allows the following new destination formats in {{GPUQueue/copyExtern
 - {{GPUTextureFormat/"rg16unorm"}}
 - {{GPUTextureFormat/"rgba16unorm"}}
 
-Enabling {{GPUFeatureName/"texture-formats-tier2"}} at device creation will also enable
-{{GPUFeatureName/"texture-formats-tier1"}}.
-
-Enabling {{GPUFeatureName/"texture-formats-tier1"}} at device creation will also enable
-{{GPUFeatureName/"rg11b10ufloat-renderable"}}.
+Note: This feature is automatically enabled by {{GPUFeatureName/"texture-formats-tier2"}}.
 
 <h3 id=texture-formats-tier2 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-formats-tier2"`
 </h3>
+
+Enabling {{GPUFeatureName/"texture-formats-tier2"}} at device creation will enable
+{{GPUFeatureName/"texture-formats-tier1"}}. The following items are in addition to that.
 
 Allows the {{GPUStorageTextureAccess/"read-write"}} {{GPUStorageTextureAccess}} on below
 {{GPUTextureFormat}}s:
@@ -16855,9 +16857,6 @@ Allows the {{GPUStorageTextureAccess/"read-write"}} {{GPUStorageTextureAccess}} 
 - {{GPUTextureFormat/"rgba32uint"}}
 - {{GPUTextureFormat/"rgba32sint"}}
 - {{GPUTextureFormat/"rgba32float"}}
-
-Enabling {{GPUFeatureName/"texture-formats-tier2"}} at device creation will also enable
-{{GPUFeatureName/"texture-formats-tier1"}}.
 
 <h3 id=dom-gpufeaturename-primitive-index data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"primitive-index"`
 </h3>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13809,6 +13809,16 @@ GPUQueue includes GPUObjectBase;
                             - {{GPUTextureFormat/"rgb10a2unorm"}}
                             - {{GPUTextureFormat/"rgba16float"}}
                             - {{GPUTextureFormat/"rgba32float"}}
+                            or the additional formats if {{GPUFeatureName/"texture-formats-tier1"}} is enabled:
+                            - {{GPUTextureFormat/"r16unorm"}}
+                            - {{GPUTextureFormat/"rg16unorm"}}
+                            - {{GPUTextureFormat/"rgba16unorm"}}
+                            - {{GPUTextureFormat/"r16snorm"}}
+                            - {{GPUTextureFormat/"rg16snorm"}}
+                            - {{GPUTextureFormat/"rgba16snorm"}}
+                            - {{GPUTextureFormat/"r8snorm"}}
+                            - {{GPUTextureFormat/"rg8snorm"}}
+                            - {{GPUTextureFormat/"rgba8snorm"}}
                     </div>
 
                 1. If |copySize|.[=GPUExtent3D/depthOrArrayLayers=] is &gt; 0, issue the subsequent
@@ -16833,6 +16843,18 @@ Allows the {{GPUStorageTextureAccess/"read-only"}} or {{GPUStorageTextureAccess/
 - {{GPUTextureFormat/"rgb10a2uint"}}
 - {{GPUTextureFormat/"rgb10a2unorm"}}
 - {{GPUTextureFormat/"rg11b10ufloat"}}
+
+Allows the destination.texture.format in {{GPUQueue/copyExternalImageToTexture()}} to be one of
+the below GPUTextureFormats:
+- {{GPUTextureFormat/"r16unorm"}}
+- {{GPUTextureFormat/"r16snorm"}}
+- {{GPUTextureFormat/"rg16unorm"}}
+- {{GPUTextureFormat/"rg16snorm"}}
+- {{GPUTextureFormat/"rgba16unorm"}}
+- {{GPUTextureFormat/"rgba16snorm"}}
+- {{GPUTextureFormat/"r8snorm"}}
+- {{GPUTextureFormat/"rg8snorm"}}
+- {{GPUTextureFormat/"rgba8snorm"}}
 
 Enabling {{GPUFeatureName/"texture-formats-tier2"}} at device creation will also enable
 {{GPUFeatureName/"texture-formats-tier1"}}.


### PR DESCRIPTION
Per [today's WG discussion](https://github.com/gpuweb/gpuweb/wiki/GPU-Web-2025%E2%80%9010-01#allow-copyexternalimagetotexture-for-all-renderable-formats-5323).

Fixes #5289
Closes #5323
Closes #5299 by superseding it. (This PR is based on that one.)