### PR TITLE
move the webgpu logo below the W3C one

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -182,11 +182,13 @@ spec: Khronos Data Format Specification; urlPrefix: https://registry.khronos.org
 <link rel="icon" type="image/png" sizes="96x96" href="img/favicon-96x96.png">
 
 <style>
-/* Displays the WebGPU logo next to the W3C logo */
-.head h1:after {
+/* Displays the WebGPU logo below the W3C logo */
+.head h1:before {
     content: url(img/logo.png);
     content: url(img/logo.png) / "WebGPU logo"; /* alt text */
     float: right;
+    clear: right;
+    margin-right: 34px;
 }
 
 /* Make <dl> blocks more distinct from their surroundings. */


### PR DESCRIPTION
With the new W3C logo in place and being wider than the previous version, we now suggest specs with a second logo to have it below the W3C one.