### PR TITLE
Add `"texture-component-swizzle"` feature

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -16968,7 +16968,10 @@ This feature adds the following [=optional API surfaces=]:
 <h3 id=dom-gpufeaturename-texture-component-swizzle data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-component-swizzle"`
 </h3>
 
-Allows rearranging or replacing the color components from texture's red/green/blue/alpha channels.
+Allows {{GPUTextureView}}s to rearrange or replace the color components from texture's red/green/blue/alpha channels
+when used as a {{GPUTextureUsage/TEXTURE_BINDING}}.
+
+Also defines previously-implementation-defined behavior when [[#reading-depth-stencil]].
 
 This feature adds the following [=optional API surfaces=]:
 


### PR DESCRIPTION
This PR incorporates changes from the [texture component swizzle proposal](https://github.com/gpuweb/gpuweb/blob/main/proposals/texture-component-swizzle.md) into the spec as all sub-issues from https://github.com/gpuweb/gpuweb/issues/5179 have now been addressed.

A separate PR (https://github.com/gpuweb/gpuweb/pull/5362) has been sent for compat changes into the `featurebranch-compat` branch.