### PR TITLE
uniformity: fix analysis of break-if condition

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11707,16 +11707,21 @@ When several edges have to be created we use `X -> {Y, Z}` as a short-hand for `
       <td rowspan=3>
       <td rowspan=3>*CF*
       <td rowspan=3>
+
       Note: If x is a [=address spaces/function=] address space variable, *CF*
       is used as the zero value initializer in the
       [[#func-var-value-analysis|value analysis]].
   <tr><td class="nowrap">break;
   <tr><td class="nowrap">continue;
   <tr><td class="nowrap">break if *e*;
-      <td>
+      <td>*CFend*
       <td class="nowrap">(*CF*, *e*) => (*CF'*, *V*)
-      <td>*CF'*
-      <td>
+      <td>*CFend*
+      <td>*CFend* -> {*CF'*, *V*}
+
+          Note: The edge from *CFend* to *V* captures the fact that when
+          the condition value is non-uniform, then control flow resulting
+          from this `break if` statement is also non-uniform.
   <tr><td class="nowrap">return;
       <td>
       <td>
@@ -11754,7 +11759,9 @@ When several edges have to be created we use `X -> {Y, Z}` as a short-hand for `
       <td>
       <td>(*CF*, *e*) => (*CF'*, *V*)
       <td>*CF'*
-      <td>Note: If x is a [=address spaces/function=] address space variable,
+      <td>
+
+      Note: If x is a [=address spaces/function=] address space variable,
       *V* is used as the result value in the [[#func-var-value-analysis|value analysis]].
 </table>
 


### PR DESCRIPTION
In the break-if rule, add an edge from resulting control flow node CF' to the value node V for the condition.

In English: when the condition value is non-uniform, then the control flow of the entire break-if construct is itself non-uniform.

Fixed: #5277