### PR TITLE
wgsl:copyediting: type aliases can be used as value constructors

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4586,6 +4586,10 @@ The declaration [=shader-creation error|must=] appear at [=module scope=], and i
 When type *T* is defined as a [=type alias=] for a structure type *S*,
 all properties of the members of *S*, including attributes, carry over to the members of *T*.
 
+Note: If the type being aliased supports [=value constructor=] built-in functions,
+then those functions can be called via the alias name instead of the original
+type specifier name, when the type alias is [=in scope=] and it is otherwise valid to call the function.
+
 <pre class=include>
 path: syntax/type_alias_decl.syntax.bs.include
 </pre>
@@ -13324,9 +13328,9 @@ value of a given type.
 
 WGSL provides value constructors for all [=predeclared=] types and all
 [=constructible=] [=structure=] types.
-The constructor built-in functions have the same spelling as the types.
+Such a constructor built-in function has the same spelling as the type, or a [=type alias=] for the type.
 Wherever such a built-in function is used, the [=identifier=]
-[=shader-creation error|must=] be [=in scope=] of the type and the [=identifier=]
+[=shader-creation error|must=] be [=in scope=] of the type or the type alias, and the [=identifier=]
 [=shader-creation error|must not=] [=resolve=] to another declaration.
 
 Note: The structure types returned by [[#frexp-builtin|frexp]],


### PR DESCRIPTION
Fixed: #5014