### PR TITLE
Remove roadmap note for texture component swizzle

### DIFF
--- a/proposals/texture-component-swizzle.md
+++ b/proposals/texture-component-swizzle.md
@@ -1,7 +1,5 @@
 # Texture component swizzle 🥤
 
-**Roadmap:** This proposal is **under active development, but has not been standardized for inclusion in the WebGPU specification. The proposal is likely to change before it is standardized.** WebGPU implementations **must not** expose this functionality; doing so is a spec violation. Note however, an implementation might provide an option (e.g. command line flag) to enable a draft implementation, for developers who want to test this proposal.
-
 Issue:
 
 - https://github.com/gpuweb/gpuweb/issues/5179


### PR DESCRIPTION
As texture component swizzle has been added to the spec, this PR removes the roadmap note to avoid [confusion](https://groups.google.com/a/chromium.org/g/blink-dev/c/JgYQuS8mtOo/m/m5k97HsSAgAJ).