### PR TITLE
Allow lets of textures and samplers

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1952,7 +1952,7 @@ Extension names are not [=identifiers=]: they do not [=resolves|resolve=] to [=d
       [=extension/subgroups=] extension to be enabled.
   <tr><td><dfn for="language_extension">texture_and_sampler_let</dfn>
       <td>
-      Allows [=effective-value-type=] of a [=let-declaration=] to be a
+      Allows the [=effective-value-type=] of a [=let-declaration=] to be a
       [=texture types|texture=] or [=sampler types|sampler=] type.
 </table>
 


### PR DESCRIPTION
Refs #5339

* Add a language feature, `texture_and_sampler_let`, that allows the effective value type of a let to be a texture or sampler type