### PR TITLE
README: document Python venv for building WGSL spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,14 +64,29 @@ the Bikeshed API will be used to generate the specification
 Diagrams generated using [Mermaid](https://mermaid-js.github.io/mermaid/).
 This isn't required unless you're modifying or creating diagrams.
 
-The WGSL spec uses some additional tools for language parsing;
-see [wgsl/README.md](wgsl/README.md) if you want to know more.
+The WGSL spec uses some additional tools for language parsing.
+See [wgsl/README.md](wgsl/README.md) if you want to know more.
+
+Some build steps for the WGSL spec modify the Python environment.
+If this is undesirable or not allowed in your situation, then create and use
+a [venv](https://docs.python.org/3/library/venv.html) virtual Python environment:
+
+* As a one-time setup step, create a `venv` environment in a subdirectory:
+
+    # Run this from the root directory of the repository. Creates a subdir named `myenv`
+    python -m venv myenv
+
+* Then enter the virtual environment before running the WGSL build:
+
+    . myenv/bin/activate
+    # Now you can build the WGSL spec in this shell
 
 ## Building this spec
 
 To build all documents:
 
 ```bash
+. myenv/bin/activate   # Required only if using a Python virtual environment
 make -j
 ```
 
@@ -84,6 +99,7 @@ make -C spec index.html
 To build just the WGSL specification (`wgsl/index.html`):
 
 ```bash
+. myenv/bin/activate   # Required only if using a Python virtual environment
 make -C wgsl index.html
 ```
 

--- a/wgsl/README.md
+++ b/wgsl/README.md
@@ -26,6 +26,20 @@ To install the necessary tools, run:
 
 Alternatively, invoke `pip3`/`npx` directly, using the commands in [that script](../tools/install-dependencies.sh).
 
+Some build steps for the WGSL spec modify the Python environment.
+If this is undesirable or not allowed in your situation, then create and use
+a [venv](https://docs.python.org/3/library/venv.html) virtual Python environment:
+
+* As a one-time setup step, create a `venv` environment in a subdirectory:
+
+    # Run this from the root directory of the repository. Creates a subdir named `myenv`
+    python -m venv myenv
+
+* Then enter the virtual environment before running the WGSL build:
+
+    . myenv/bin/activate
+    # Now you can build the WGSL spec in this shell
+
 ## Building the specification
 
 When the specification is generated, it is written to `index.html`.
@@ -33,6 +47,7 @@ When the specification is generated, it is written to `index.html`.
 ### Generating specification, validating the grammar and code samples (recommended)
 
 ```bash
+. myenv/bin/activate   # Required only if using a Python virtual environment
 make
 ```
 
@@ -41,12 +56,14 @@ make
 To generate the specification only, run:
 
 ```bash
+. myenv/bin/activate   # Required only if using a Python virtual environment
 make index.html
 ```
 
 ### Validating the code samples can be parsed
 
 ```bash
+. myenv/bin/activate   # Required only if using a Python virtual environment
 make validate-examples
 ```
 
@@ -56,6 +73,7 @@ grammar, and then ensures that code samples from the specification can be parsed
 ### Validating the grammar is LALR(1)
 
 ```bash
+. myenv/bin/activate   # Required only if using a Python virtual environment
 make lalr
 ```
 


### PR DESCRIPTION
Building the WGSL spec locally assumes you can modify the Python environment. In some installations this is not permitted. Instead, use a Python virtual environment (venv).

Update the READMEs to describe how to do this.

There is some redundancy between the top-leve README.md and wgsl/README.md. I'll leave that for future work.