### PR TITLE
uniformity: fix analysis for loop bodies that only return

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7956,11 +7956,19 @@ non-empty [=behavior=] for each statement, and function.
         |s1|: |B1|<br>
         |s2|: |B2|
     <td class="nowrap">|B1| &cup; |B2|
-  <tr algorithm="loop with continuing without break behavior">
-    <td class="nowrap" rowspan=2>loop {|s1| continuing {|s2|}}
+  <tr algorithm="loop with exactly return behaviour before the continuing block">
+    <td class="nowrap" rowspan=3>loop {|s1| continuing {|s2|}}
     <td class="nowrap">
         |s1|: |B1|<br>
         |s2|: |B2|<br>
+        |B1| &equals; {Return}<br>
+        None of {Continue, Return} are in |B2|<br>
+    <td class="nowrap">{Return}
+  <tr algorithm="loop with continuing without break behavior">
+    <td class="nowrap">
+        |s1|: |B1|<br>
+        |s2|: |B2|<br>
+        |B1| &ne; {Return}<br>
         None of {Continue, Return} are in |B2|<br>
         Break is not in (|B1| &cup; |B2|)
     <td class="nowrap">(|B1| &cup; |B2|)&#x2216;{Continue, Next}
@@ -7968,6 +7976,7 @@ non-empty [=behavior=] for each statement, and function.
     <td class="nowrap">
         |s1|: |B1|<br>
         |s2|: |B2|<br>
+        |B1| &ne; {Return}<br>
         None of {Continue, Return} are in |B2|<br/>
         Break is in (|B1| &cup; |B2|)
     <td class="nowrap">(|B1| &cup; |B2| &cup; {Next})&#x2216;{Break, Continue}


### PR DESCRIPTION
Consider:  loop { s1  continuing { s2 } }

If the statement behaviour of s1 is exactly {Return}, then the statement behaviour of the entire loop is {Return}. In particular, nonuniformity effects do not leak out from s2 to the context after or outside of the whole loop.

Fixed: #5100