### PR TITLE
uniformity: fix editorial issues

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7996,7 +7996,7 @@ For the purpose of this analysis:
 - `for` loops get desugared (see [[#for-statement]])
 - `while` loops get desugared (see [[#while-statement]])
 - `loop {s}` is treated as `loop {s continuing {}}`
-- `if` statements without an `else` branch are treated as if they had an empty else branch (which adds Next to their [=behavior=])
+- `if` statements without an `else` branch are treated as if they had an empty else branch, i.e. ended in `else {}`; this adds Next to their [=behavior=]
 - `if` statements with `else if` branches are treated as if they were nested simple `if/else` statements
 - a [=syntax/switch_clause=] starting with `default` behaves just like a [=syntax/switch_clause=] starting with `case _:`
 
@@ -11637,6 +11637,11 @@ When several edges have to be created we use `X -> {Y, Z}` as a short-hand for `
   <thead>
     <tr><th>Statement<th>New nodes<th>Recursive analyses<th>Resulting control flow node<th>New edges
   </thead>
+  <tr><td class="nowrap">*empty statement*
+      <td>
+      <td>
+      <td>*CF*
+      <td>
   <tr><td class="nowrap">{*s*}
       <td>
       <td class="nowrap">(*CF*, *s*) => *CF'*
@@ -11763,12 +11768,27 @@ When several edges have to be created we use `X -> {Y, Z}` as a short-hand for `
 
       Note: If x is a [=address spaces/function=] address space variable,
       *V* is used as the result value in the [[#func-var-value-analysis|value analysis]].
+  <tr><td>*f*`()`<br>Function call statement without arguments
+      <td>
+      <td>Invoke [[#uniformity-function-calls|function call analysis]]:
+                (*CF*, *f*()) => ([=CF_after=], [=Result=])
+      <td>*CF_after*
+      <td>
+  <tr><td>*f*`(`*e1*,...,*eN*`)`<br>Function call statement with arguments
+      <td>
+      <td>Invoke [[#uniformity-function-calls|function call analysis]]:
+                (*CF*, *f*(*e1*,...,*eN*)) => ([=CF_after=], [=Result=])
+      <td>*CF_after*
+      <td>
 </table>
 
-Analysis of [[#for-statement|for]] and [[#while-statement|while]] loops follows
-from their respective desugaring translations to [[#loop-statement|loop]] statements.
-
-In [[#switch-statement|switch]], a [=default-alone clause=] block is treated exactly like a [=case clause=] with regards to uniformity.
+For the purpose of this analysis:
+- `for` loops get desugared (see [[#for-statement]])
+- `while` loops get desugared (see [[#while-statement]])
+- `loop {s}` is treated as `loop {s continuing {}}`
+- `if` statements without an `else` branch are treated as if they had an empty else branch, i.e. ended in `else {}`
+- `if` statements with `else if` branches are treated as if they were nested simple `if/else` statements
+- a [=syntax/switch_clause=] starting with `default` behaves just like a [=syntax/switch_clause=] starting with `case _:`
 
 To maximize performance, implementations often try to minimize the amount of
 [=uniform control flow|non-uniform control flow=].
@@ -11990,11 +12010,12 @@ The rules for analyzing expressions take as argument both the expression itself 
       <td>
       <td class="nowrap">*CF*,*CF*
       <td>
+   <tr><td class="nowrap">( *e* )
+      <td rowspan=3>
+      <td rowspan=3 class="nowrap">(*CF*, *e*) => (*CF'*, *V*)
+      <td rowspan=3 class="nowrap">*CF'*, *V*
+      <td rowspan=3>
    <tr><td class="nowrap">*op* *e*,<br> where *op* is a unary operator
-      <td rowspan=2>
-      <td rowspan=2 class="nowrap">(*CF*, *e*) => (*CF'*, *V*)
-      <td rowspan=2 class="nowrap">*CF'*, *V*
-      <td rowspan=2>
    <tr><td class="nowrap">*e*.field
    <tr><td>*e1* *op* *e2*,<br> where *op* is a non-short-circuiting binary operator
       <td rowspan=2> *Result*
@@ -12003,6 +12024,18 @@ The rules for analyzing expressions take as argument both the expression itself 
       <td rowspan=2 class="nowrap">*CF2*, *Result*
       <td rowspan=2 class="nowrap">*Result* -> {*V1*, *V2*}
    <tr><td class="nowrap">e1[e2]
+   <tr><td>*f*`()`<br>Function call expression without arguments
+       <td>
+       <td>Invoke [[#uniformity-function-calls|function call analysis]]:<br>
+                (*CF*, *f*()) => ([=CF_after=], [=Result=])
+       <td>*CF_after*, *Result*
+       <td>
+   <tr><td>*f*`(`*e1*,...,*eN*`)`<br>Function call expression with arguments
+       <td>
+       <td>Invoke [[#uniformity-function-calls|function call analysis]]:
+                (*CF*, *f*(*e1*,...,*eN*)) => ([=CF_after=], [=Result=])
+       <td>*CF_after*, *Result*
+       <td>
 </table>
 
 The following built-in input variables are considered uniform:


### PR DESCRIPTION
- add rule for parenthesized expression
- add rule for empty statement
- add rule for braced statement
- link to function call expression from expression uniformity rules
- link to function call statement from statement uniformity rules
- rewrite desugaring rules for statement uniformity (expanding various kinds of loops, if-elses, etc.), mimicing the structure used when describing desugaring of statemetn behaviour analysis.

Fixes: #5121 #5122 #5123 #5129 #5128