### PR TITLE
wgsl: clarify desugaring of for loop without condition

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7535,16 +7535,47 @@ path: syntax/for_init.syntax.bs.include
 path: syntax/for_update.syntax.bs.include
 </pre>
 
-The <dfn dfn-for="statement">for</dfn> statement takes the form
-`for (initializer; condition; update_part) { body }` and is syntactic sugar on top of a [=statement/loop=] statement with the same `body`.
+The <dfn dfn-for="statement">for</dfn> statement is syntactic sugar over a [=compound statement=] 
+containing a [=statement/loop=] statement.
+In general, the `for` statement takes the form 
+
+  > `for (` *initializer* `;` *condition* `;` *update_part* `) {` *body* `}`
+
+When the condition expression is present, the `for` statement desugars to a loop of the form:
+
+<blockquote>
+   {                                   <br> &nbsp; &nbsp; 
+       *initializer* ;                 <br> &nbsp; &nbsp; 
+       loop {                          <br> &nbsp; &nbsp; &nbsp; &nbsp;
+          if !(*condition*) { break; } <br> &nbsp; &nbsp; &nbsp; &nbsp;
+          *body*                       <br> &nbsp; &nbsp; &nbsp; &nbsp;
+          continuing { *update_part* } <br> &nbsp; &nbsp;
+       }                               <br>
+   }
+</blockquote>
+When the condition expression is absent, the `for` statement desugars to a loop of the form:
+
+<blockquote>
+   {                                   <br> &nbsp; &nbsp; 
+       *initializer* ;                 <br> &nbsp; &nbsp; 
+       loop {                          <br> &nbsp; &nbsp; &nbsp; &nbsp;
+          *body*                       <br> &nbsp; &nbsp; &nbsp; &nbsp;
+          continuing { *update_part* } <br> &nbsp; &nbsp;
+       }                               <br>
+   }
+</blockquote>
+
 Additionally:
 * If `initializer` is non-empty, it is executed inside an additional [=scope=] before the first [=iteration=].
     The scope of a declaration in the initializer extends to the end of the loop body.
 * [=Type rule precondition=]: If the condition is non-empty, it [=shader-creation error|must=] be an expression of [=bool=] type.
-    * If present, the condition is evaluated immediately before executing the loop body.
+    * If present, the condition is evaluated immediately before executing the for-loop body.
         If the condition is false, then a [[#break-statement]] is executed, finishing execution of the loop.
         This check is performed at the start of each loop iteration.
-* If `update_part` is non-empty, it becomes a [=statement/continuing=] statement at the end of the loop body.
+* If `update_part` is non-empty, it becomes a [=statement/continuing=] statement at the end of the loop construct.
+* Desugaring [=behavioral requirement|will=] rename identifiers declared in the `body` as needed to ensure
+    all identifiers in the `update_part` still [=resolves|resolve=] to the same declarations they did
+    before desugaring occurred.
 
 The `initializer` of a for loop is executed once prior to executing the loop.
 When a [=declaration=] appears in the initializer, its [=identifier=] is [=in scope=] until the end of the `body`.
@@ -7557,7 +7588,7 @@ the next statement until the end of the `body`.
 The declaration is executed each time it is reached, so each new iteration
 creates a new instance of the variable or constant, and re-initializes it.
 
-<div class='example wgsl function-scope' heading="For to Loop transformation: before">
+<div class='example wgsl function-scope' heading="For to Loop transformation, with a condition: before">
   <xmp highlight=wgsl>
     var a: i32 = 2;
     for (var i: i32 = 0; i < 4; i++) {
@@ -7571,7 +7602,7 @@ creates a new instance of the variable or constant, and re-initializes it.
 
 Converts to:
 
-<div class='example wgsl function-scope' heading="For to Loop transformation: after">
+<div class='example wgsl function-scope' heading="For to Loop transformation, with a condition: after">
   <xmp highlight=wgsl>
     var a: i32 = 2;
     { // Introduce new scope for loop variable i
@@ -7584,6 +7615,43 @@ Converts to:
         if a == 0 {
           continue;
         }
+        a = a + 2;
+
+        continuing {
+          i++;
+        }
+      }
+    }
+  </xmp>
+</div>
+
+<div class='example wgsl function-scope' heading="For to Loop transformation, without a condition: before">
+  <xmp highlight=wgsl>
+    var a: i32 = 2;
+    for (var i: i32 = 0; ; i++) {
+      if a == 0 {
+        continue;
+      }
+      if i == 4 { break; }
+      a = a + 2;
+    }
+  </xmp>
+</div>
+
+Converts to:
+
+<div class='example wgsl function-scope' heading="For to Loop transformation, without a condition: after">
+  <xmp highlight=wgsl>
+    var a: i32 = 2;
+    { // Introduce new scope for loop variable i
+      var i: i32 = 0;
+      loop {
+        // Note: Desugaring does not introduce an if clause here.
+
+        if a == 0 {
+          continue;
+        }
+        if i == 4 { break; }
         a = a + 2;
 
         continuing {


### PR DESCRIPTION
A for loop with an empty condition clause is desugared to a `loop` without any initial if-break clause.

When the for loop body behaviour is exactly {Return}, then the resulting desugared loop should also have behaviour exactly {Return}.

Fixed: #5397