### PR TITLE
Add new interstage builtins

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8508,7 +8508,7 @@ dictionary GPURenderPipelineDescriptor
     1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} [=map/exist|is provided=]:
         1. Let |maxFragmentShaderInputVariables| be
             |device|.limits.{{supported limits/maxInterStageShaderVariables}}.
-        1. If any of the `front_facing`, `sample_index`, or `sample_mask` [=builtins=] are an input of
+        1. For each of the [=Inter-Stage Builtins=] that are an input of
             |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
             1. Decrement |maxFragmentShaderInputVariables| by 1.
         1. Return `false` if any of the following requirements are unmet:
@@ -8526,6 +8526,16 @@ dictionary GPURenderPipelineDescriptor
             (This follows from the above rules.)
     1. Return `true`.
 </div>
+
+The following [=builtins=] are <dfn dfn>Inter-Stage Builtins</dfn>, and count towards the
+{{supported limits/maxInterStageShaderVariables}} limit when used in a fragment shader:
+
+  - `front_facing`
+  - `sample_index`
+  - `sample_mask`
+  - `primitive_index`
+  - `subgroup_invocation_id`
+  - `subgroup_size`
 
 <div class=example>
     Creating a simple {{GPURenderPipeline}}:


### PR DESCRIPTION
Fixes #5337

Adds new fragment input builtins that should count towards the interstage variable limit to the Validating inter-stage interfaces algorithim.

 - `primitive_index`
 - `subgroup_invocation_id`
 - `subgroup_size`

Also refactored how that list is presented to make it easier to expand in the future.