### PR TITLE
Validate fragment shader output locations

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8790,6 +8790,8 @@ dictionary GPUFragmentState
             - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}}, |descriptor|, |layout|, |device|) succeeds.
             - |descriptor|.{{GPUFragmentState/targets}}.[=list/size=] must be &le;
                 |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
+            - For each [=shader stage output=] |output|:
+                - |output|'s [=location=] must be &lt; |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
             - Let |entryPoint| be [$get the entry point$]({{GPUShaderStage/FRAGMENT}}, |descriptor|).
             - Let |usesDualSourceBlending| be `false`.
             - [=list/For each=] |index| of the [=list/indices=] of |descriptor|.{{GPUFragmentState/targets}}


### PR DESCRIPTION
Fixes #5341

Adds an additional check during render pipeline validation to ensure that all of the fragment shader output locations are < the maxColorAttachments limit. This check is needed in addition to the existing check that the targets list has less entries than the limit allows because the shader outputs are allowed to specify locations that don't have a corresponding target in the pipeline definition..