### PR TITLE
Update validation of bind groups usage

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10924,7 +10924,7 @@ command encoder can no longer be used.
                     1. Return an [$invalidated$] {{GPUCommandBuffer}}.
                 1. Set |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} to
                     |this|.{{GPUCommandsMixin/[[commands]]}}.
-                1. Set |commandBuffer|.{{GPUCommandsMixin/[[used_bind_groups]]}} to
+                1. Set |commandBuffer|.{{GPUCommandBuffer/[[used_bind_groups]]}} to
                     |this|.{{GPUCommandsMixin/[[used_bind_groups]]}}.
             </div>
         </div>


### PR DESCRIPTION
Fixes #5384

Requires that any resources used by any bind groups set during command encoding must be live/valid/not destroyed. This is a behavior change from the prior text, which suggested that only resources used by a "command" (presumably a draw/dispatch) were validated.

The updated validation described in this change matches the WebGPU CTS and the behavior of multiple implementations.