### PR TITLE
[editorial] Backport wording/formatting changes from Compat branch

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1548,7 +1548,7 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
 
 <table class=data dfn-type=attribute dfn-for="supported limits">
     <thead>
-        <tr><th>Limit name <th>Type <th>[=Limit class=] <th colspan=2>[=limit/Default=]
+        <tr><th>Limit name <th>Type <th>[=Limit class=] <th>[=limit/Default=] <th>
     </thead>
 
     <tr><td><dfn>maxTextureDimension1D</dfn>


### PR DESCRIPTION
This will minimize the Compat PR's diff (#5402), making it a bit easier to review.

I'll merge this back and handle the merge conflict once it lands.