### PR TITLE
Compat: fix check for compatible texture views

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11491,7 +11491,8 @@ It must only be included by interfaces which also include those mixins.
                                 - Let |bindGroup2| be |encoder|.{{GPUBindingCommandsMixin/[[bind_groups]]}}[|index2|].
                                 - For each {{GPUBindGroupEntry}} |bindGroupEntry2| in |bindGroup2|.{{GPUBindGroup/[[entries]]}}:
                                     - If |bindGroupEntry2|.{{GPUBindGroupEntry/resource}} is not a {{GPUTextureView}}, [=iteration/continue=].
-                                    - If |bindGroupEntry1|.{{GPUBindGroupEntry/resource}} is not equal to |bindGroupEntry2|.{{GPUBindGroupEntry/resource}}, [=iteration/continue=].
+                                    - If |bindGroupEntry1|.{{GPUBindGroupEntry/resource}}.{{GPUTextureView/[[texture]]}} is not equal to
+                                        |bindGroupEntry2|.{{GPUBindGroupEntry/resource}}.{{GPUTextureView/[[texture]]}}, [=iteration/continue=].
                                     - Let |descriptor2| be |bindGroupEntry2|.{{GPUBindGroupEntry/resource}}.{{GPUTextureView/[[descriptor]]}}.
                                     - |descriptor2|.{{GPUTextureViewDescriptor/baseMipLevel}} must be equal to |descriptor1|.{{GPUTextureViewDescriptor/baseMipLevel}}.
                                     - |descriptor2|.{{GPUTextureViewDescriptor/mipLevelCount}} must be equal to |descriptor1|.{{GPUTextureViewDescriptor/mipLevelCount}}.


### PR DESCRIPTION
This check didn't make sense, I think it was intending to check that the *texture* for the two texture views is equal.

Issue: https://github.com/gpuweb/gpuweb/pull/5402/files#r2450490632