### PR TITLE
Add subgroup_id language extension

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12650,16 +12650,18 @@ Each subgroup may contain fewer invocations than the reported subgroup size
 An invocation's <dfn noexport>subgroup invocation ID</dfn> is a unique ID within the subgroup.
 This ID is accessible via the [=built-in values/subgroup_invocation_id=]
 built-in value and is in the range [0, `subgroup_size` - 1].
-There is no defined relationship between `subgroup_invocation_id` and
-[=built-in values/local_invocation_index=].
-To avoid non-portable code, shader authors should not assume a particular
-mapping between these two values.
 
 If the [=language_extension/subgroup_id=] feature is supported, within a
 compute shader the <dfn noexport>subgroup ID</dfn> is the unique ID for the
 subgroup within the workgroup.
 This ID is accessible via the [=built-in values/subgroup_id=] built-in value
 and is in the range [0, [=built-in values/num_subgroups=] - 1].
+
+There is no defined relationship between subgroup values (i.e.
+`subgroup_invocation_id` and `subgroup_id`) and [=built-in
+values/local_invocation_index=].
+To avoid non-portable code, shader authors should not assume a particular
+mapping between these two values.
 
 When invocations in the same subgroup execute different control flow paths, we
 say subgroup execution has diverged.


### PR DESCRIPTION
Refs #5365

* Adds two new built-in values under the subgroups enable extension
  * subgroup_id - ID of subgroup in the workgroup
  * num_subgroups - number of subgroups in the workgroup