### PR TITLE
Rename atomic 64 to atomic vec2u

### DIFF
--- a/proposals/atomic-64-min-max.md
+++ b/proposals/atomic-64-min-max.md
@@ -62,7 +62,7 @@ Add a single new enable extension:
 
 | Enable                  | Description                                          |
 | ----------------------- | ---------------------------------------------------- |
-| `atomic_vec2u_min_max`     | Adds functions for only min and max ops 64 bit atomics |
+| `atomic_vec2u_min_max`     | Adds functions for min and max atomic ops on a vec2u |
 
 > **NOTE**: The `atomic_vec2u_min_max` should be limited to storage buffers. This does not include textures/images.
 


### PR DESCRIPTION
Bikeshedding of name. 
We think that 'vec2u' is a better name since wgsl doesnt have 64 bit types and this feature is functionality built around key value pairs. The best known use case here is visibility buffers (depth/drawId).