### PR TITLE
Add subgroup_uniformity language extension

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11282,16 +11282,20 @@ The analysis is what actually defines these concepts, and when a program is vali
 
 For a given group of invocations:
 - If all invocations in a given scope execute as if they are executing in lockstep at a given
-    point in the program, that point is said to have <dfn noexport>uniform control flow</dfn>.
-    - For a [=compute shader stage=], the scope of uniform control flow is all invocations
-        in the same [=compute shader stage/workgroup=].
-    - For other shader stages, the scope of uniform control flow is all invocations for that
-        [=entry point=] in the same [=draw command=].
-    - If the [=language_extension/subgroup_uniformity=] feature is supported,
-        the scope of uniform control flow for
-        [[#subgroup-builtin-functions|subgroup]] and
+    point in the program, that point is said to have <dfn noexport>uniform control flow</dfn>
+    for the given <dfn noexport>uniformity scope</dfn>.
+    - <dfn noexport>Workgroup uniformity scope</dfn>: For a [=compute shader
+        stage=], the uniformity scope is all invocations in the same [=compute
+        shader stage/workgroup=].
+    - <dfn noexport>Draw uniformity scope</dfn>: For other shader stages, the
+        uniformity scope is all invocations for that [=entry point=] in the same
+        [=draw command=].
+    - <dfn noexport>Subgroup uniformity scope</dfn>: If the
+        [=language_extension/subgroup_uniformity=] feature is supported, the
+        uniformity scope for [[#subgroup-builtin-functions|subgroup]] and
         [[#quad-builtin-functions|quad]] built-in functions instead is all
         invocations in the same [=subgroup=].
+
 - If an expression is executed in uniform control flow, and all invocations compute the
     same value, it is said to be a <dfn noexport>uniform value</dfn>.
 - If invocations hold the same value for a local variable at every point where it is live,
@@ -11303,8 +11307,14 @@ The remaining subsections specify a static analysis that verifies that
 [[#collective-operations|collective operations]] are only executed in [=uniform
 control flow=].
 If the [=language_extension/subgroup_uniformity=] feature is supported then
-there are multiple scopes of uniformity.
+there are multiple [=uniformity scopes=].
 This analysis is performed once for each scope.
+
+Note: The analysis is described as being executed once per scope, but
+implementations may perform a single analysis that includes each scope.
+[=Workgroup uniformity scope|Workgroup=] and [=draw uniformity scope|draw=]
+uniformity scopes are effectively equivalent since they operate on different
+shader stages and represent the largest uniformity scope in a shader stage.
 
 The analysis assumes [=dynamic errors=] do not occur.
 A shader stage with a [=dynamic error=] is already non-portable, no matter the outcome
@@ -12000,11 +12010,11 @@ Here is the list of exceptions:
         - [=CallSiteRequiredToBeUniform.S|CallSiteRequiredToBeUniform.error=], with [=potential-trigger-set=]
             consisting of an unnamed [=diagnostic/triggering rule=]
             if [=language_extension/subgroup_uniformity=] is not supported or
-            the scope of [=uniform control flow=] is not subgroup.
+            the [=uniformity scope=] is not subgroup.
             - Note: The triggering rule has no name, and so it cannot be filtered.
         - [=CallSiteNoRestriction=] otherwise.
     - Additionally if [=language_extension/subgroup_uniformity=] is not
-        supported or the scope of [=uniform control flow=] is not subgroup, for a
+        supported or the [=uniformity scope=] is not subgroup, for a
         call to [[#workgroupUniformLoad-builtin|workgroupUniformLoad]],
         the parameter `p` has a [=parameter tag=] of [=ParameterRequiredToBeUniform.S|ParameterRequiredToBeUniform.error=],
         with [=potential-trigger-set=] consisting of an unnamed [=diagnostic/triggering rule=].
@@ -12012,7 +12022,7 @@ Here is the list of exceptions:
     [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]]:
     - Has a [=function tag=] of [=ReturnValueMayBeNonUniform=].
     - Has a [=call site tag=] as follows:
-        - If [=language_extension/subgroup_uniformity=] is not supported or the scope of [=uniform control flow=] is not subgroup
+        - If [=language_extension/subgroup_uniformity=] is not supported or the [=uniformity scope=] is not subgroup
             - Let *DF* be the [=nearest enclosing diagnostic filter=] for the call site location and triggering rule [=trigger/derivative_uniformity=]
             - If *DF* exists, then let *S* be the *DF*'s new severity parameter.
                 - If *S* is the severity [=severity/off=], the call site tag is [=CallSiteNoRestriction=].
@@ -12031,7 +12041,7 @@ Here is the list of exceptions:
 - A call to a function in
     [[#subgroup-builtin-functions]] or [[#quad-builtin-functions]]:
     - Has a [=function tag=] of:
-        - [=NoRestriction=] if the scope of [=uniform control flow=] is subgroup and the function is one of the following:
+        - [=NoRestriction=] if the [=uniformity scope=] is subgroup and the function is one of the following:
             - [[#subgroupadd-builtin|subgroupAdd]]
             - [[#subgroupall-builtin|subgroupAll]]
             - [[#subgroupand-builtin|subgroupAnd]]
@@ -12047,7 +12057,7 @@ Here is the list of exceptions:
         - [=ReturnValueMayBeNonUniform=] otherwise
     - Let *DF* be the [=nearest enclosing diagnostic filter=] for the call site location and triggering rule [=trigger/subgroup_uniformity=]
     - Has a [=call site tag=] as follows:
-        - If [=language_extension/subgroup_uniformity=] is not supported or the scope of [=uniform control flow=] is subgroup then:
+        - If [=language_extension/subgroup_uniformity=] is not supported or the [=uniformity scope=] is subgroup then:
             - If *DF* exists, then let *S* be the *DF*'s new severity parameter.
                 - If *S* is the severity [=severity/off=], the call site tag is [=CallSiteNoRestriction=].
                 - Otherwise, the call site tag is [=CallSiteRequiredToBeUniform.S=], with [=potential-trigger-set=]
@@ -12058,7 +12068,7 @@ Here is the list of exceptions:
         - [=CallSiteNoRestriction=] otherwise.
     - Additionally for the case of a call to [[#subgroupshuffleup-builtin|subgroupShuffleUp]] or [[#subgroupshuffledown-builtin|subgroupShuffleDown]],
         the parameter `delta` has a [=parameter tag=] of:
-        - If [=language_extension/subgroup_uniformity=] is not supported or the scope of [=uniform control flow=] is subgroup then:
+        - If [=language_extension/subgroup_uniformity=] is not supported or the [=uniformity scope=] is subgroup then:
             - If *DF* exists, then let *S* be *DF*'s new severity parameter.
                 - If *S* is the severity [=severity/off=], the parameter tag is [=NoRestriction=].
                 - Otherwise, the parameter tag is [=ParameterRequiredToBeUniform.S=] with [=potential-trigger-set=]
@@ -12069,7 +12079,7 @@ Here is the list of exceptions:
         - [=NoRestriction=] otherwise.
     - Additionally for the case of a call to [[#subgroupshufflexor-builtin|subgroupShuffleXor]],
         the parameter `mask` has a [=parameter tag=] of:
-        - If [=language_extension/subgroup_uniformity=] is not supported or the scope of [=uniform control flow=] is subgroup then:
+        - If [=language_extension/subgroup_uniformity=] is not supported or the [=uniformity scope=] is subgroup then:
             - If *DF* exists, then let *S* be *DF*'s new severity parameter.
                 - If *S* is the severity [=severity/off=], the parameter tag is [=NoRestriction=].
                 - Otherwise, the parameter tag is [=ParameterRequiredToBeUniform.S=] with [=potential-trigger-set=]
@@ -12080,8 +12090,8 @@ Here is the list of exceptions:
         - [=NoRestriction=] otherwise.
 
 Note: A WGSL implementation will ensure that if control flow prior to a
-function call is [=uniform control flow|uniform=], it will also be uniform
-after the function call.
+function call is [=uniform control flow|uniform=] for a particular scope, it
+will also be uniform after the function call.
 
 ### Uniformity Rules for Expressions ### {#uniformity-expressions}
 
@@ -12236,7 +12246,7 @@ The following built-in input variables are considered uniform:
 - [=built-in values/subgroup_size=] when used in a [=compute shader stage=]
 - [=built-in values/num_subgroups=]
 
-If the scope of [=uniform control flow=] is subgroup, the following built-in
+At [=subgroup uniformity scope=], the following built-in
 input variables are also considered uniform:
 - [=built-in values/subgroup_id=]
 


### PR DESCRIPTION
* Adds subgroup uniformity language
* When supported uniformity analysis is performed at twice (at different scopes)

See: #5368