### PR TITLE
Fix defaulting of textureBindingViewDimension

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4600,7 +4600,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                     1. If |descriptor|.{{GPUTextureDescriptor/textureBindingViewDimension}} is {{GPUTextureViewDimension/"2d"}}, |this|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be 1.
                     1. if |descriptor|.{{GPUTextureDescriptor/textureBindingViewDimension}} is {{GPUTextureViewDimension/"cube"}}, |this|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be 6.
 
-                Note: this validation only applies to a user-specified textureBindingViewDimension. If no value is provided, the texture's textureBindingViewDimension is set as described in {{GPUDevice/createTexture()}}. That algorithm cannot produce invalid values, so the above validation is not required.
+                    Note: this validation only applies to a user-specified textureBindingViewDimension. If no value is provided, the texture's textureBindingViewDimension is set as described in {{GPUDevice/createTexture()}}. That algorithm cannot produce invalid values, so the above validation is not required.
                 </div>
             - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be multiple of [=texel block width=].
             - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be multiple of [=texel block height=].
@@ -6691,7 +6691,7 @@ following members:
                                             &gt; `1`, Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
                                         -
                                             <div class=compatmode>
-                                                If |texture|.{{GPUTextureDescriptor/textureBindingViewDimension}} is not `undefined`:
+                                                If |texture|.{{GPUTexture/textureBindingViewDimension}} is not `undefined`:
 
                                                 - [=Assert=] |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}.
                                                 - |texture|.{{GPUTexture/textureBindingViewDimension}} must be equal to |textureView|.{{GPUTextureViewDescriptor/dimension}}.


### PR DESCRIPTION
When descriptor.textureBindingViewDimension is not provided,
set the texture's textureBindingViewDimension to the defaults, not
the descriptor's textureBindingViewDimension.

Add a Note: to explain that the validation of the textureBindingViewDimension in the descriptor is not applied to the defaulted value (which is ok).