### PR TITLE
[Compat] Fixes for Compat initialization and more precise prose

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1323,9 +1323,9 @@ improved privacy. It is not required that a [=fallback adapter=] is available on
         If set to `true` indicates that the adapter was requested with compatibility with
         [=WebXR sessions=].
 
-    : <dfn>\[[default feature level]]</dfn>, of type {{DOMString}}, readonly
+    : <dfn>\[[default feature level]]</dfn>, of type [=feature level string=], readonly
     ::
-        Indicates the default [=feature level string|feature level=] of devices created from this adapter.
+        Indicates the default feature level of devices created from this adapter.
 </dl>
 
 [=adapter=] has the following [=device timeline properties=]:
@@ -2614,8 +2614,10 @@ enum GPUPowerPreference {
 <dl dfn-type=dict-member dfn-for=GPURequestAdapterOptions>
     : <dfn>featureLevel</dfn>
     ::
-        Requests an adapter with this {{adapter/[[default feature level]]}},
-        adherent to the rules defined in {{GPU/requestAdapter()}} and described below.
+        Requests an adapter that supports at least a particular set of [=capabilities=].
+        This influences the {{adapter/[[default feature level]]}} of devices created
+        from this adapter. The capabilities are described below, and the exact steps
+        are defined in the steps of {{GPU/requestAdapter()}}.
 
         If the implementation or system does not support all of the capabilities in the
         requested feature level, {{GPU/requestAdapter()}} will return `null`.
@@ -2630,22 +2632,26 @@ enum GPUPowerPreference {
         <dl dfn-type=dfn dfn-for="feature level string">
             : <dfn noexport>"core"</dfn>
             ::
-                "Core-defaulting" adapters always support a specific set of capabilities,
-                and enable those capabilities by default, including the
-                [=limit/Default=] limits and
+                A set of capabilities including the [=limit/Default=] limits and
                 the {{GPUFeatureName/"core-features-and-limits"}} feature.
                 See "[=a new device=]" for details.
+
+                Note:
+                Adapters with this {{adapter/[[default feature level]]}} may
+                conventionally be referred to as "Core-defaulting".
             : <dfn noexport>"compatibility"</dfn>
             ::
-                If the implementation does not support the stricter "Compatibility Mode"
-                validation rules, it will ignore this request and treat it as a request for
-                [=feature level string/"core"=].
-
-                "Compatibility-defaulting" adapters always support a specific set of capabilities,
-                and enable those capabilities by default, including the
-                [=limit/Compatibility Mode Default=] limits and
-                excluding the {{GPUFeatureName/"core-features-and-limits"}} feature.
+                A set of capabilities including the [=limit/Compatibility Mode Default=] limits and no features.
+                It excludes the {{GPUFeatureName/"core-features-and-limits"}} feature.
                 See "[=a new device=]" for details.
+
+                If the implementation cannot enforce the stricter "Compatibility Mode"
+                validation rules, {{GPU/requestAdapter()}} will ignore this request and
+                treat it as a request for [=feature level string/"core"=].
+
+                Note:
+                Adapters with this {{adapter/[[default feature level]]}} may
+                conventionally be referred to as "Compatibility-defaulting".
         </dl>
 
     : <dfn>powerPreference</dfn>


### PR DESCRIPTION
This started with addressing François's editorial comment to define "Compatibility Mode", but I determined that most of the references to "Compatibility Mode" should actually be more descriptive and point more precisely to relevant definitions, and that the definitions of the feature level strings should be more comprehensive.

Also removed definitions of "Core-defaulting" and
"Compatibility-defaulting" in favor of direct links (but kept those phrases in the prose as they're useful for understanding).

Additionally I noticed that were missing text to make `"core-features-and-limits"` increase the limits, and text to explicitly say we set the default limits depending on feature level. Fixed those.

Issue: https://github.com/gpuweb/gpuweb/pull/5402#pullrequestreview-3410836743