### PR TITLE
[editorial] Tweak requestAdapter step ordering, feature level definitions (again)

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2466,10 +2466,10 @@ interface GPU {
                     1. Set |adapter|.{{adapter/[[default feature level]]}} to
                         |options|.{{GPURequestAdapterOptions/featureLevel}}.
 
-                1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
+                1. Issue the |resolution steps| on <var data-timeline=content>contentTimeline</var>.
             </div>
             <div data-timeline=content>
-                [=Content timeline=] steps:
+                [=Content timeline=] |resolution steps|:
 
                 1. If |adapter| is not `null`:
                     1. [=Resolve=] |promise| with a new {{GPUAdapter}} encapsulating |adapter|.


### PR DESCRIPTION
Followup to #5443, just wanted to save it for after the merge.

Following other styles, validation should come first, then other stuff. Also tweak some wording to make clear what is implementation-defined, and that the [=adapter=] is always a new object (necessarily, because the expiry state is on it).

Make the feature level definitions more formal because they are depended on by the requestAdapter steps. Make the "new device" steps defer to those definitions instead of duplicating them.