### PR TITLE
Keep depth/stencil aspect checks

### DIFF
--- a/proposals/transient-attachments.md
+++ b/proposals/transient-attachments.md
@@ -39,9 +39,11 @@ The `GPURenderPassColorAttachment Valid Usage` algorithm is extended with the fo
 The `GPURenderPassDepthStencilAttachment Valid Usage` algorithm is extended with the following change:
 
 - If `this.view.[[descriptor]].usage` includes the `TRANSIENT_ATTACHMENT` bit:
+  - If format has a depth aspect:
     - `this.depthLoadOp` must be `"clear"`.
-    - `this.stencilLoadOp ` must be `"clear"`.
     - `this.depthStoreOp` must be `"discard".`
+  - If format has a stencil aspect:
+    - `this.stencilLoadOp ` must be `"clear"`.
     - `this.stencilStoreOp ` must be `"discard".`
 
 ## Javascript example


### PR DESCRIPTION
Following https://github.com/gpuweb/gpuweb/pull/5450#discussion_r2556111189, I'm keeping depth/stencil aspect check in the transient attachments proposal. 

@Kangz Please review.