### PR TITLE
Add missing `Render target pixel byte cost` for `8snorm` formats

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17400,8 +17400,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=6>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
         <td><!-- Vulkan -->
-        <td>1
-        <td>1 (if {{GPUFeatureName/"texture-formats-tier1"}} is enabled)
+        <td colspan=2>1
     <tr>
         <td>{{GPUTextureFormat/r8uint}}
         <td>
@@ -17441,8 +17440,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=6>If {{GPUFeatureName/"texture-formats-tier1"}} is enabled
         <td><!-- Vulkan -->
-        <td>2
-        <td>2 (if {{GPUFeatureName/"texture-formats-tier1"}} is enabled)
+        <td colspan=2>2
     <tr>
         <td>{{GPUTextureFormat/rg8uint}}
         <td>
@@ -17500,7 +17498,7 @@ The [=texel block memory cost=] of each of these formats is the same as its
         <td>&checkmark;
         <td>
         <td>4
-        <td>8 (if {{GPUFeatureName/"texture-formats-tier1"}} is enabled)
+        <td>8
     <tr>
         <td>{{GPUTextureFormat/rgba8uint}}
         <td>


### PR DESCRIPTION
This patch adds missing `Render target pixel byte cost` for `r8snorm`, `rg8snorm` and `rgba8snorm` which get the `RENDER_ATTACHMENT` capability when the extension `"texture-format-tier-1"` is enabled.