### PR TITLE
WGSL grammar improvements

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1535,8 +1535,8 @@ Note: For example, the phrase `var<storage,read_write>` modifies the general `va
 </div>
 
 The `'<'` (U+003C) and `'>'` (U+003E) code points that delimit a template list are also used when spelling:
-* A comparison operator in a [=syntax/relational_expression=].
-* A shift operator in a [=syntax/shift_expression=].
+* A [=syntax/comparison_operator=] in a [=syntax/relational_expression=].
+* A [=syntax/shift_operator=] in a [=syntax/shift_expression=].
 * A [=syntax/compound_assignment_operator=] for performing a shift operation followed by an assignment.
 
 The syntactic ambiguity is resolved in favour of template lists:
@@ -1603,7 +1603,7 @@ Let |TemplateList| be a record type containing:
                 * Advance |CurrentPosition| past this code point, and start the next iteration of the loop.
             * If `'='` (U+003D) appears at |CurrentPosition|, then:
                 * Note: From assumption 1, no template parameter starts with `'='` (U+003C), so the previous code point cannot be the start of a template list.
-                    Assume the current and previous code point form a <a for=syntax_sym lt=less_than_equal>`'<='`</a> comparison operator.
+                    Assume the current and previous code point form a <a for=syntax_sym lt=less_than_equal>`'<='`</a> [=syntax/comparison_operator=].
                     Skip over the `'='` (U+003D) code point so a later step does not mistake it for an assignment.
                 * Pop the top entry from the |Pending| stack.
                 * Advance |CurrentPosition| past this code point, and start the next iteration of the loop.
@@ -1618,7 +1618,7 @@ Let |TemplateList| be a record type containing:
         * Otherwise, this code point does not end a template list:
             * Advance |CurrentPosition| past this code point.
             * If `'='` (U+003D) appears at |CurrentPosition| then:
-                * Note: Assume the current and previous code points form a <a for=syntax_sym lt=greater_than_equal>`'>='`</a> comparison operator.
+                * Note: Assume the current and previous code points form a <a for=syntax_sym lt=greater_than_equal>`'>='`</a> [=syntax/comparison_operator=].
                     Skip over the `'='` (U+003D) code point so a later step does not mistake it for an assignment.
                 * Advance |CurrentPosition| past this code point.
             * Start the next iteration of the loop.
@@ -1634,14 +1634,14 @@ Let |TemplateList| be a record type containing:
     * If `'!'` (U+0021) appears at |CurrentPosition| then:
         * Advance |CurrentPosition| past this code point.
         * If `'='` (U+003D) appears at |CurrentPosition| then:
-            * Note: Assume the current and previous code points form a <a for=syntax_sym lt=not_equal>`'!='`</a> comparison operator.
+            * Note: Assume the current and previous code points form a <a for=syntax_sym lt=not_equal>`'!='`</a> [=syntax/comparison_operator=].
                 Skip over the `'='` (U+003D) code point so a later step does not mistake it for an assignment.
             * Advance |CurrentPosition| past this code point.
         * Start the next iteration of the loop.
     * If `'='` (U+003D) appears at |CurrentPosition| then:
         * Advance |CurrentPosition| past this code point.
         * If `'='` (U+003D) appears at |CurrentPosition| then:
-            * Note: Assume the current and previous code points form a <a for=syntax_sym lt=equal_equal>`'=='`</a> comparison operator.
+            * Note: Assume the current and previous code points form a <a for=syntax_sym lt=equal_equal>`'=='`</a> [=syntax/comparison_operator=].
                 Skip over the `'='` (U+003D) code point so a later step does not mistake it for an assignment.
             * Advance |CurrentPosition| past this code point, and start the next iteration of the loop.
         * Note: Assume this code point is part of an assignment, which cannot appear as part of an expression, and therefore cannot appear in a template list.
@@ -6815,7 +6815,13 @@ path: syntax/additive_operator.syntax.bs.include
 path: syntax/shift_expression.syntax.bs.include
 </pre>
 <pre class=include>
+path: syntax/shift_operator.syntax.bs.include
+</pre>
+<pre class=include>
 path: syntax/relational_expression.syntax.bs.include
+</pre>
+<pre class=include>
+path: syntax/comparison_operator.syntax.bs.include
 </pre>
 <pre class=include>
 path: syntax/short_circuit_and_expression.syntax.bs.include

--- a/wgsl/syntax.bnf
+++ b/wgsl/syntax.bnf
@@ -92,7 +92,7 @@ diagnostic_rule_name :
 ;
 
 template_list :
-  _template_args_start template_arg_comma_list _template_args_end
+  template_args_start template_arg_comma_list template_args_end
 ;
 
 template_arg_comma_list :
@@ -339,18 +339,17 @@ additive_operator :
 
 shift_expression :
   additive_expression
-| unary_expression _shift_left unary_expression
-| unary_expression _shift_right unary_expression
+| unary_expression shift_operator unary_expression
+;
+
+shift_operator :
+  _shift_left
+| _shift_right
 ;
 
 relational_expression :
   shift_expression
-| shift_expression _less_than shift_expression
-| shift_expression _greater_than shift_expression
-| shift_expression _less_than_equal shift_expression
-| shift_expression _greater_than_equal shift_expression
-| shift_expression '==' shift_expression
-| shift_expression '!=' shift_expression
+| shift_expression comparison_operator shift_expression
 ;
 
 short_circuit_and_expression :
@@ -411,6 +410,15 @@ compound_assignment_operator :
 | '^='
 | _shift_right_assign
 | _shift_left_assign
+;
+
+comparison_operator :
+  '=='
+| '!='
+| _less_than
+| _less_than_equal
+| _greater_than
+| _greater_than_equal
 ;
 
 increment_statement :
@@ -559,7 +567,7 @@ function_decl :
 ;
 
 function_header :
-  'fn' ident '(' param_list ? ')' ( '->' attribute * template_elaborated_ident ) ?
+  'fn' ident '(' param_list ? ')' ( '->' attribute * type_specifier ) ?
 ;
 
 param_list :

--- a/wgsl/syntax.bnf
+++ b/wgsl/syntax.bnf
@@ -92,7 +92,7 @@ diagnostic_rule_name :
 ;
 
 template_list :
-  template_args_start template_arg_comma_list template_args_end
+  _template_args_start template_arg_comma_list _template_args_end
 ;
 
 template_arg_comma_list :

--- a/wgsl/syntax/comparison_operator.syntax.bs.include
+++ b/wgsl/syntax/comparison_operator.syntax.bs.include
@@ -1,0 +1,15 @@
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>comparison_operator</dfn> :
+
+    <span class="choice"></span> <a for=syntax_sym lt=equal_equal>`'=='`</a>
+
+    <span class="choice">|</span> <a for=syntax_sym lt=not_equal>`'!='`</a>
+
+    <span class="choice">|</span> [=syntax_sym/_less_than=]
+
+    <span class="choice">|</span> [=syntax_sym/_less_than_equal=]
+
+    <span class="choice">|</span> [=syntax_sym/_greater_than=]
+
+    <span class="choice">|</span> [=syntax_sym/_greater_than_equal=]
+</div>

--- a/wgsl/syntax/function_header.syntax.bs.include
+++ b/wgsl/syntax/function_header.syntax.bs.include
@@ -1,5 +1,5 @@
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_header</dfn> :
 
-    <span class="choice"></span> `'fn'` [=syntax/ident=] <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/param_list=] ? <a for=syntax_sym lt=paren_right>`')'`</a> ( <a for=syntax_sym lt=arrow>`'->'`</a> [=syntax/attribute=] * [=syntax/template_elaborated_ident=] ) ?
+    <span class="choice"></span> `'fn'` [=syntax/ident=] <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/param_list=] ? <a for=syntax_sym lt=paren_right>`')'`</a> ( <a for=syntax_sym lt=arrow>`'->'`</a> [=syntax/attribute=] * [=syntax/type_specifier=] ) ?
 </div>

--- a/wgsl/syntax/relational_expression.syntax.bs.include
+++ b/wgsl/syntax/relational_expression.syntax.bs.include
@@ -3,15 +3,5 @@
 
     <span class="choice"></span> [=syntax/shift_expression=]
 
-    <span class="choice">|</span> [=syntax/shift_expression=] [=syntax_sym/_less_than=] [=syntax/shift_expression=]
-
-    <span class="choice">|</span> [=syntax/shift_expression=] [=syntax_sym/_greater_than=] [=syntax/shift_expression=]
-
-    <span class="choice">|</span> [=syntax/shift_expression=] [=syntax_sym/_less_than_equal=] [=syntax/shift_expression=]
-
-    <span class="choice">|</span> [=syntax/shift_expression=] [=syntax_sym/_greater_than_equal=] [=syntax/shift_expression=]
-
-    <span class="choice">|</span> [=syntax/shift_expression=] <a for=syntax_sym lt=equal_equal>`'=='`</a> [=syntax/shift_expression=]
-
-    <span class="choice">|</span> [=syntax/shift_expression=] <a for=syntax_sym lt=not_equal>`'!='`</a> [=syntax/shift_expression=]
+    <span class="choice">|</span> [=syntax/shift_expression=] [=syntax/comparison_operator=] [=syntax/shift_expression=]
 </div>

--- a/wgsl/syntax/shift_expression.syntax.bs.include
+++ b/wgsl/syntax/shift_expression.syntax.bs.include
@@ -3,7 +3,5 @@
 
     <span class="choice"></span> [=syntax/additive_expression=]
 
-    <span class="choice">|</span> [=syntax/unary_expression=] [=syntax_sym/_shift_left=] [=syntax/unary_expression=]
-
-    <span class="choice">|</span> [=syntax/unary_expression=] [=syntax_sym/_shift_right=] [=syntax/unary_expression=]
+    <span class="choice">|</span> [=syntax/unary_expression=] [=syntax/shift_operator=] [=syntax/unary_expression=]
 </div>

--- a/wgsl/syntax/shift_operator.syntax.bs.include
+++ b/wgsl/syntax/shift_operator.syntax.bs.include
@@ -1,0 +1,7 @@
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>shift_operator</dfn> :
+
+    <span class="choice"></span> [=syntax_sym/_shift_left=]
+
+    <span class="choice">|</span> [=syntax_sym/_shift_right=]
+</div>

--- a/wgsl/syntax/template_list.syntax.bs.include
+++ b/wgsl/syntax/template_list.syntax.bs.include
@@ -1,5 +1,5 @@
 <div class='syntax' noexport='true'>
   <dfn for=syntax>template_list</dfn> :
 
-    <span class="choice"></span> [=syntax_sym/_template_args_start=] [=syntax/template_arg_comma_list=] [=syntax_sym/_template_args_end=]
+    <span class="choice"></span> [=syntax/template_args_start=] [=syntax/template_arg_comma_list=] [=syntax/template_args_end=]
 </div>

--- a/wgsl/syntax/template_list.syntax.bs.include
+++ b/wgsl/syntax/template_list.syntax.bs.include
@@ -1,5 +1,5 @@
 <div class='syntax' noexport='true'>
   <dfn for=syntax>template_list</dfn> :
 
-    <span class="choice"></span> [=syntax/template_args_start=] [=syntax/template_arg_comma_list=] [=syntax/template_args_end=]
+    <span class="choice"></span> [=syntax_sym/_template_args_start=] [=syntax/template_arg_comma_list=] [=syntax_sym/_template_args_end=]
 </div>

--- a/wgsl/tools/extract-grammar.py
+++ b/wgsl/tools/extract-grammar.py
@@ -986,10 +986,10 @@ def flow_extract(options, scan_result):
     name: 'wgsl',
 
     externals: $ => [
-        $.block_comment,
+        $._block_comment,
         $._disambiguate_template,
-        $.template_args_start,
-        $.template_args_end,
+        $._template_args_start,
+        $._template_args_end,
         $._less_than,
         $._less_than_equal,
         $._shift_left,
@@ -1003,7 +1003,7 @@ def flow_extract(options, scan_result):
 
     extras: $ => [
         $.line_comment,
-        $.block_comment,
+        $._block_comment,
         $._blankspace,
     ],
 

--- a/wgsl/tools/extract-grammar.py
+++ b/wgsl/tools/extract-grammar.py
@@ -17,7 +17,7 @@ from tree_sitter import Language, Parser
 
 # TODO: Source from spec
 derivative_patterns = {
-    "_comment": "/\\/\\/.*/",
+    "line_comment": "/\\/\\/.*/",
     "_blankspace": "/[\\u0020\\u0009\\u000a\\u000b\\u000c\\u000d\\u0085\\u200e\\u200f\\u2028\\u2029]/u"
 }
 
@@ -639,7 +639,7 @@ class ScanResult(dict):
          A dictionary mapping the name of an example to the
          WGSL source text for the example.
          The name is taken from the "heading" attriute of the <div> element.
-    self['_reserved']
+    self['reserved']
          A list of reserved words.
     """
     def __init__(self):
@@ -647,7 +647,7 @@ class ScanResult(dict):
         self[scanner_example.name()] = dict()
         self[scanner_token.name()] = dict()
         self['raw'] = []
-        self['_reserved'] = []
+        self['reserved'] = []
 
 
 def read_spec(options):
@@ -658,7 +658,7 @@ def read_spec(options):
 
     # Read reserved words
     with open('wgsl.reserved.plain', "r") as file:
-        result['_reserved'] = [s.strip() for s in file.readlines()]
+        result['reserved'] = [s.strip() for s in file.readlines()]
 
     # Get the input bikeshed text.
     scanner_lines = read_lines_from_file(
@@ -986,10 +986,10 @@ def flow_extract(options, scan_result):
     name: 'wgsl',
 
     externals: $ => [
-        $._block_comment,
+        $.block_comment,
         $._disambiguate_template,
-        $._template_args_start,
-        $._template_args_end,
+        $.template_args_start,
+        $.template_args_end,
         $._less_than,
         $._less_than_equal,
         $._shift_left,
@@ -1002,8 +1002,8 @@ def flow_extract(options, scan_result):
     ],
 
     extras: $ => [
-        $._comment,
-        $._block_comment,
+        $.line_comment,
+        $.block_comment,
         $._blankspace,
     ],
 
@@ -1067,7 +1067,7 @@ def flow_extract(options, scan_result):
 
 
         for key, value in rules.items():
-            if key.startswith("_") and key != "_comment" and key != "_blankspace" and key not in rule_skip:
+            if key.startswith("_") and key != "line_comment" and key != "_blankspace" and key not in rule_skip:
                 grammar_source += grammar_from_rule(key, value) + ",\n"
                 rule_skip.add(key)
 
@@ -1083,9 +1083,9 @@ def flow_extract(options, scan_result):
 
 
         grammar_source += grammar_from_rule(
-            "_comment", {'type': 'pattern',
-                               'value': derivative_patterns["_comment"]}) + ",\n"
-        rule_skip.add("_comment")
+            "line_comment", {'type': 'pattern',
+                               'value': derivative_patterns["line_comment"]}) + ",\n"
+        rule_skip.add("line_comment")
 
 
         # Extract space
@@ -1099,7 +1099,7 @@ def flow_extract(options, scan_result):
 
         # Reserved words
 
-        grammar_source += "\n        _reserved: $ => choice('" + "', '".join(scan_result['_reserved']) + "'),\n"
+        grammar_source += "\n        reserved: $ => choice('" + "', '".join(scan_result['reserved']) + "'),\n"
 
         grammar_source += r"""
     }

--- a/wgsl/tools/process-ts-grammar.py
+++ b/wgsl/tools/process-ts-grammar.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+Postprocessing grammar.js for tree-sitter-wgsl repository
+
+Exposes block_comment, template_args_start, and template_args_end as named nodes
+"""
+
+import argparse
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Postprocessing for grammar.js for tree-sitter-wgsl"
+    )
+    parser.add_argument("input", help="Input file path")
+    parser.add_argument("output", help="Output file path")
+
+    args = parser.parse_args()
+
+    try:
+        with open(args.input, "r", encoding="utf-8") as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f"Error: Input file '{args.input}' not found", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error reading input file: {e}", file=sys.stderr)
+        return 1
+
+    content = content.replace("_block_comment", "block_comment")
+    content = content.replace("_template_args_start", "template_args_start")
+    content = content.replace("_template_args_end", "template_args_end")
+
+    try:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(content)
+        print(f"Wrote processed file to '{args.output}'")
+    except Exception as e:
+        print(f"Error writing output file: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Some improvements to the wgsl grammar that enable better tree-sitter querying. 

See related PR in tree-sitter-wgsl: https://github.com/gpuweb/tree-sitter-wgsl/pull/5

Added a postprocessing script (wgsl/tools/process-ts-grammar.py) to expose _template_args_start, _template_args_end, and _block_comment as named nodes (replaces occurrences of those strings with leading underscores removed). Intended to be applied to the grammar.js to put in the tree-sitter-wgsl repo.

Changes in syntax.bnf:
- factor out shift_operator from _shift_left & _shift_right so it can be a named node
- factor out comparison_operator from all comparison operators including >, >=, <, <=, so it can be a named node
- replace generic identifier with type_specifier after `->` in function header (better highlighting)

Other changes in extract_grammar.py:
- rename _comment to line_comment, so it can be a named node
- rename _reserved to reserved, same reason