### PR TITLE
[wgsl] add third option for textureLoad OOB behavior

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -272,6 +272,7 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
         text: subgroupMinSize; url: dom-gpuadapterinfo-subgroupminsize
         text: subgroupMaxSize; url: dom-gpuadapterinfo-subgroupmaxsize
         text: primitive restart value; url: primitive-restart-value
+        text: texture view swizzle; url: dom-gputextureviewdescriptor-swizzle
         for: supported limits
             text: maxComputeWorkgroupStorageSize; url: dom-supported-limits-maxcomputeworkgroupstoragesize
     type: attribute
@@ -17410,9 +17411,11 @@ The [=logical texel address=] is invalid if:
 * `sample_index` is outside the range `[0, textureNumSamples(s))`
 
 If the logical texel address is invalid, the built-in function returns one of:
-* The data for some texel within bounds of the texture
-* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
-* 0.0 for depth textures
+* The data for some texel within bounds of the texture.
+* For non-depth textures, either:
+    * The vector (0,0,0,0) or (0,0,0,1) of the appropriate type, with the [=texture view swizzle=] applied, or
+    * The vector (0,0,0,0) or (0,0,0,1) of the appropriate type, without the [=texture view swizzle=] applied.
+* 0.0 for depth textures.
 
 ### `textureNumLayers` ### {#texturenumlayers}
 


### PR DESCRIPTION
If the textureLoad is out of bounds, allow the (0,0,0,1) result where that is either before or after the swizzle is applied.

Until now the spec was only allowing the unswizzled result.

Fixes: #5437