### PR TITLE
Sync extension anchors

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -140,8 +140,16 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
             text: f16; url: extension-f16
             text: clip_distances; url: extension-clip_distances
             text: dual_source_blending; url: extension-dual_source_blending
-            text: subgroup; url: extension-subgroups
+            text: subgroups; url: extension-subgroups
             text: primitive_index; url: extension-primitive_index
+        for: language-extension
+            text: readonly_and_readwrite_storage_textures; url: language_extension-readonly_and_readwrite_storage_textures
+            text: packed_4x8_integer_dot_product; url: language_extension-packed_4x8_integer_dot_product
+            text: unrestricted_pointer_parameters; url: language_extension-unrestricted_pointer_parameters
+            text: pointer_composite_access; url: language_extension-pointer_composite_access
+            text: uniform_buffer_standard_layout; url: language_extension-uniform_buffer_standard_layout
+            text: subgroup_id; url: language_extension-subgroup_id
+            text: subgroup_uniformity; url: language_extension-subgroup_uniformity
         for: type
             text: sampled texture; url: type-sampled-texture
             text: depth texture; url: type-depth-texture


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/issues/4440

PLMK if there is anything else to adjust for this (I also aligned subgroups since other plural extension names seem to inherit directly). Thank you!