### PR TITLE
Fix maxStorageTexturesIn*Stage defaults

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1700,14 +1700,14 @@ A <dfn dfn>supported limits</dfn> object has a value for every limit defined by 
         Note: This limit applies to all stages. At [=a new device|device initialization=], it is normalized with {{supported limits/maxStorageTexturesInVertexStage}} and {{supported limits/maxStorageTexturesInFragmentStage}} so that in the validation algorithm, each stage can be checked against just one of the three limits.
 
     <tr><td><dfn>maxStorageTexturesInVertexStage</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8 <td>0
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>4 <td>0
     <tr class=row-continuation><td colspan=5>
         For the vertex stage, the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
         which are storage textures.
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxStorageTexturesInFragmentStage</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8 <td>4
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td colspan=2>4
     <tr class=row-continuation><td colspan=5>
         For the fragment stage, the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
         which are storage textures.


### PR DESCRIPTION
The core defaults for maxStorageTexturesInVertexStage and maxStorageTexturesInFragmentStage should not exceed the core default for maxStorageTexturesPerShaderStage (4). (This was a typo in the Compat spec changes.)

Fixes #5488