### PR TITLE
[process] New required functionality must be implementable on Compat

### DIFF
--- a/process/RequirementsForAdditionalFunctionality.md
+++ b/process/RequirementsForAdditionalFunctionality.md
@@ -33,7 +33,8 @@ In order for a proposal for additional functionality to be standardized in the W
 1. A proposal for new *optional* functionality must be implementable on at least 2 different browser engines. Rationale: One browser engine should not be able to unilaterally add functionality to the web platform.
 2. A proposal for new *optional* functionality must be implementable on at least 2 different Core-Mode native APIs. Rationale: The web is intended to be OS-independent, and there is a high correlation between the native APIs and the OSes they primarily run on.
 3. A proposal for new *optional* functionality must be implementable on devices created (designed? manufactured?) by at least 2 different device vendors. Rationale: The web is intended to be device-independent.
-4. A proposal for new *required* functionality must be implementable on all participating browser engines on all native APIs they target. (Note: This includes both Core-Mode and Compatibility-Mode native APIs. New functionality that isn't implementable on Compatibility-Mode native APIs will be a required part of an optional feature such as `"core-features-and-limits"`.)
+4. A proposal for new *required* functionality must be implementable on all participating browser engines on all native APIs they target.
+    - Note: This includes both Core-Mode and Compatibility-Mode native APIs. New functionality that isn't implementable on Compatibility-Mode native APIs will be a (required) part of an optional feature, such as `"core-features-and-limits"`.
 
 ## Non-requirements
 


### PR DESCRIPTION
Compatibility Mode means we now care about OpenGL/ES and D3D11 for any non-optional functionality (like immediates, `unrestricted_pointer_parameters`, etc.). Update the process doc accordingly.

Also clarify where we're talking about optional vs. required functionality, and expand on the meaning of "implementable".