### PR TITLE
wgsl: clarify compute subgroup_invocation_id's are dense starting at 0

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9974,6 +9974,16 @@ Each is described in detail in subsequent sections.
       The current invocation's [=subgroup invocation ID=].
 
       The ID is within the range [0, [=built-in values/subgroup_size=] - 1].
+
+      In a [=compute shader stage|compute=] shader, IDs begin at zero and are dense.
+      That is, when the compute shader begins execution, then within each subgroup:
+      * One invocation will have `subgroup_invocation_id` &equals; 0, and
+      * If the subgroup has an invocation with `subgroup_invocation_id` &equals; |k|,
+          then the subgroup has an invocation with `subgroup_invocation_id` &equals; |j|,
+          for all 0 &leq; |j| &lt; |k|.
+
+      Note: Subgroup invocation indexing in fragment shaders may not be dense. The implementation
+      may assign some lower-numbered IDs to [=helper invocations=].
 </table>
 
 ##### `subgroup_size` ##### {#subgroup-size-builtin-value}


### PR DESCRIPTION
Fixed: #5519