### PR TITLE
Add linear_indexing language feature

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11922,11 +11922,11 @@ dictionary GPUComputePassDescriptor
                             |this|.device.limits.{{supported limits/maxComputeWorkgroupsPerDimension}}.
                         - let |workgroupSize| be the computed workgroup size for
                             |bindingState|.{{GPUComputePassEncoder/[[pipeline]]}}. 
-                        - the entry point uses [=builtin/workgroup_index=]
+                        - the entry point uses the [=builtin/workgroup_index=]
                             built-in value and |workgroupCountX| &times; |workgroupCountY|
                             &times; |workgroupCountZ|
                             is out of range of an unsigned 32-bit integer.
-                        - the entry point uses [=builtin/global_invocation_index=]
+                        - the entry point uses the [=builtin/global_invocation_index=]
                             built-in value and |workgroupCountX| &times; |workgroupCountY|
                             &times; |workgroupCountZ| &times; |workgroupSize|
                             is out of range of an unsigned 32-bit integer.
@@ -12021,11 +12021,11 @@ dictionary GPUComputePassDescriptor
                 1. If |workgroupCountX|, |workgroupCountY|, or |workgroupCountZ| is greater than
                     |this|.device.limits.{{supported limits/maxComputeWorkgroupsPerDimension}},
                     return.
-                1. If the entry point uses [=builtin/workgroup_index=]
+                1. If the entry point uses the [=builtin/workgroup_index=]
                     built-in value and |workgroupCountX| &times; |workgroupCountY| &times;
                     |workgroupCountZ| is out of range of an unsigned
                     32-bit integer return.
-                1. If the entry point uses [=builtin/global_invocation_index=]
+                1. If the entry point uses the [=builtin/global_invocation_index=]
                     built-in value and |workgroupCountX| &times; |workgroupCountY| &times;
                     |workgroupCountZ| &times; |workgroupSize| is out of range of an unsigned
                     32-bit integer return.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9725,6 +9725,14 @@ Each is described in detail in subsequent sections.
       [=built-in values/global_invocation_id=].x +<br>
       ([=built-in values/global_invocation_id=].y * [=attribute/workgroup_size=].x * [=built-in values/num_workgroups=].x) +<br>
       ([=built-in values/global_invocation_id=].z * [=attribute/workgroup_size=].x * [=built-in values/num_workgroups=].x * [=attribute/workgroup_size=].y * [=built-in values/num_workgroups=].y)
+
+      <div class=note>
+          <span class=marker>Note:</span> If the number of dispatched
+          workgroups would cause this value to exceed the range of the [=u32=]
+          type, then the dispatch will fail:
+          * For `dispatchWorkgroups`, the {{GPUComputePassEncoder}} will be invalidated.
+          * For `dispatchWorkgroupsIndirect`, the dispatch will not execute.
+      </div>
 </table>
 
 ##### `instance_index` ##### {#instance-index-builtin-value}
@@ -10018,6 +10026,14 @@ Each is described in detail in subsequent sections.
       workgroup in overall [=compute shader grid=].
 
       All invocations in the same workgroup have the same workgroup index.
+
+      <div class=note>
+          <span class=marker>Note:</span> If the number of dispatched
+          workgroups would cause this value to exceed the range of the [=u32=]
+          type, then the dispatch will fail:
+          * For `dispatchWorkgroups`, the {{GPUComputePassEncoder}} will be invalidated.
+          * For `dispatchWorkgroupsIndirect`, the dispatch will not execute.
+      </div>
 </table>
 
 ##### `subgroup_invocation_id` ##### {#subgroup-invocation-id-builtin-value}


### PR DESCRIPTION
* Two new builtins:
  * `global_invocation_index` - linearized `global_invocation_id`
  * `workgroup_index` - linearized `workgroup_id`

Fixes #5154