### PR TITLE
Clarify that subgroupMin/MaxSize bound the compiler's choice of size

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2016,12 +2016,14 @@ interface GPUAdapterInfo {
     : <dfn>subgroupMinSize</dfn>
     ::
         If the {{GPUFeatureName/"subgroups"}} feature is supported, the minimum
-        supported [=builtin-value/subgroup size=] for the [=adapter=].
+        [=builtin-value/subgroup size=] that may be chosen by the compiler when creating
+        {{GPUShaderModule}}s on devices created from this [=adapter=].
 
     : <dfn>subgroupMaxSize</dfn>
     ::
         If the {{GPUFeatureName/"subgroups"}} feature is supported, the maximum
-        supported [=builtin-value/subgroup size=] for the [=adapter=].
+        [=builtin-value/subgroup size=] that may be chosen by the compiler when creating
+        {{GPUShaderModule}}s on devices created from this [=adapter=].
 
     : <dfn>isFallbackAdapter</dfn>
     ::
@@ -2057,14 +2059,14 @@ interface GPUAdapterInfo {
         reasonable approximation of a description.
 
     1. If {{GPUFeatureName/"subgroups"}} is supported, set {{GPUAdapterInfo/subgroupMinSize}}
-        to the smallest supported subgroup size. Otherwise, set this value to 4.
+        to the adapter's smallest subgroup size. Otherwise, set this value to 4.
 
         Note: To preserve privacy, the user agent may choose to not support some features or provide values
         for the property which do not distinguish different devices, but are still usable
         (e.g. use the default value of 4 for all devices).
 
     1. If {{GPUFeatureName/"subgroups"}} is supported, set {{GPUAdapterInfo/subgroupMaxSize}}
-        to the largest supported subgroup size. Otherwise, set this value to 128.
+        to the adapter's largest subgroup size. Otherwise, set this value to 128.
 
         Note: To preserve privacy, the user agent may choose to not support some features or provide values
         for the property which do not distinguish different devices, but are still usable


### PR DESCRIPTION
There are a lot of minimums/maximums in the spec, and the subgroup size limits operate differently than most, which I thought might be worth clarifying here.

There is a [more verbose explanation in the WGSL spec](https://gpuweb.github.io/gpuweb/wgsl/#subgroup-size) that already captures things clearly, so I think this can be considered editorial.