### PR TITLE
Error scope doesn't necessarily store the first error

### DIFF
--- a/explainer/index.bs
+++ b/explainer/index.bs
@@ -447,7 +447,7 @@ Any device-timeline error from an operation is passed to the top-most error scop
 the time it was issued.
 
 - If an error scope captures an error, the error is not passed down the stack.
-    Each error scope stores only the **first** error it captures; any further errors it captures
+    Each error scope stores **only one** error it captures; any other errors it captures
     are **silently ignored**.
 - If not, the error is passed down the stack to the enclosing error scope.
 - If an error reaches the bottom of the stack, it **may**<sup>2</sup> fire the `uncapturederror`


### PR DESCRIPTION
From the spec:

> Let error be any one of the items in scope.[[errors]], or null if there are none.

https://www.w3.org/TR/webgpu/#dom-gpudevice-poperrorscope