### PR TITLE
Specify default value for mapAsync's `offset` argument.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3823,6 +3823,9 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             <div data-timeline=device>
                 [=Device timeline=] |validation steps|:
 
+                1. If |offset| is `undefined`:
+                    1. Let |offset| be 0.
+
                 1. If |size| is `undefined`:
                     1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/size}} - |offset|).
 


### PR DESCRIPTION
It seems like the spec doesn't actually specify the default value for the `offset` argument if it's omitted.