### PR TITLE
[editorial] Helper invocations have limited observable effects

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12784,8 +12784,9 @@ RasterizationPoints, fragment processing [=behavioral requirement|will=] create
 a <dfn noexport>helper invocation</dfn> for each unpopulated position in the
 quad.
 
-Helper invocations do not have observable effects, except that they help
-compute [[#derivatives|derivatives]].
+Helper invocations have limited observable effects.
+They help compute [[#derivatives|derivatives]] and may participate in
+[[#subgroup-ops|subgroup operations]].
 As such, helper invocations are subject to the following restrictions:
 * No [=write access|write accesses=] (see also [[#memory-operation]])
     [=behavioral requirement|will=] be performed on the [=address


### PR DESCRIPTION
* Update language from no observable (except derivatives) to limited observable and mention they may participate in subgroup operations