### PR TITLE
git: ignore .python-version in every directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ correspondence/index.html
 tools/node_modules/
 .DS_Store
 **/__pycache__
+.python-version


### PR DESCRIPTION
pyenv uses the .python-version to specify the Python version
to use in this directory and its descendants.  This should
not be checked into the repo, since it might specify a version
that another person might not have.