### PR TITLE
Security: Fix Path Traversal in extract-grammar.py

### DIFF
--- a/wgsl/tools/extract-grammar.py
+++ b/wgsl/tools/extract-grammar.py
@@ -87,6 +87,15 @@ def read_lines_from_file(filename, exclusions):
     or files with ".syntax.bs.include" in their name.
     Skips empty lines.
     """
+    # Security: Validate path doesn't escape intended directory
+    def safe_path(base_dir, path):
+        """Validate that path is within base_dir to prevent path traversal"""
+        full = os.path.realpath(os.path.join(base_dir, path))
+        base = os.path.realpath(base_dir)
+        if not full.startswith(base):
+            raise ValueError(f"Path traversal detected: {path} resolves outside {base_dir}")
+        return full
+
     file = open(filename, "r")
     # Break up the input into lines, and skip empty lines.
     parts = [j for i in [i.split("\n") for i in file.readlines()]
@@ -97,6 +106,9 @@ def read_lines_from_file(filename, exclusions):
         m = include_re.match(line)
         if m:
             included_file = m.group(1)
+            # Security: Validate path is within expected directory
+            base_dir = os.path.dirname(filename)
+            included_file = safe_path(base_dir, included_file)
             if included_file not in exclusions:
                 result.extend(read_lines_from_file(included_file, exclusions))
                 continue


### PR DESCRIPTION
# Security: Fix Path Traversal in extract-grammar.py

## Summary

Fixes a path traversal vulnerability in `wgsl/tools/extract-grammar.py` that allows arbitrary file reads through the `path:` directive in `.bs` files.

## Vulnerability

The `read_lines_from_file()` function processes `path:` directives in Bikeshed source files but doesn't validate that the included path is within the expected directory. This allows an attacker who can add/modify `.bs` files to read arbitrary files on the system.

**CVSS Score:** 5.5 (MEDIUM) - AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N

## Proof of Concept

A malicious `.bs` file:
```bs
<div class='syntax'>
path: ../../../../../../../../etc/passwd
</div>
```

Would result in `/etc/passwd` being included in the generated grammar output.

## Impact

- Arbitrary file read on systems running `extract-grammar.py`
- CI/CD environments could leak secrets, tokens, SSH keys
- Sensitive data included in generated output files

## Fix

This PR adds a `safe_path()` validation function that:
1. Resolves both the base directory and the included path to absolute paths
2. Verifies the included path is within the base directory
3. Raises `ValueError` if path traversal is detected

## Testing

```python
# Before fix: Allows path traversal
path: ../../../../../etc/passwd  # ✗ Reads /etc/passwd

# After fix: Blocks path traversal
path: ../../../../../etc/passwd  # ✓ Raises ValueError
path: sections/file.bs           # ✓ Works normally
```

## Credit

Discovered and reported by security researcher.

## References

- CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
- OWASP Path Traversal: https://owasp.org/www-community/attacks/Path_Traversal