### PR TITLE
Fixes for transient attachment validation

### DIFF
--- a/proposals/transient-attachments.md
+++ b/proposals/transient-attachments.md
@@ -23,11 +23,11 @@ partial namespace GPUTextureUsage {
 
 ## Validation
 
-The `GPUCanvasContext/configure(configuration)` algorithm is extended with the following change:
+In `GPUCanvasContext/configure(configuration)`:
 
 - If `configuration.usage` includes the `TRANSIENT_ATTACHMENT` bit, throw a TypeError.
 
-The `validating GPUTextureDescriptor(this, descriptor)` algorithm is extended with the following change:
+In `validating GPUTextureDescriptor(this, descriptor)`:
 
 - If `descriptor.usage` includes the `TRANSIENT_ATTACHMENT` bit:
   - `descriptor.usage` must contain only and exactly `TRANSIENT_ATTACHMENT` and `RENDER_ATTACHMENT` bits.
@@ -35,21 +35,28 @@ The `validating GPUTextureDescriptor(this, descriptor)` algorithm is extended wi
   - `descriptor.mipLevelCount` must be 1.
   - `descriptor.size.depthOrArrayLayers` must be 1.
 
-The `GPURenderPassColorAttachment Valid Usage` algorithm is extended with the following change:
+In `GPUTexture/createView()`:
+
+- If the parent texture's usage includes `TRANSIENT_ATTACHMENT`, the view must
+  have the same usages as the parent texture.
+
+In `GPURenderPassColorAttachment Valid Usage`:
 
 - If `renderViewDescriptor.usage` includes the `TRANSIENT_ATTACHMENT` bit:
   - `this.loadOp` must be `"clear"`.
   - `this.storeOp` must be `"discard".`
+- If there is a `resolveTarget`:
+  - `resolveTarget.usage` must not include `TRANSIENT_ATTACHMENT`.
 
-The `GPURenderPassDepthStencilAttachment Valid Usage` algorithm is extended with the following change:
+In `GPURenderPassDepthStencilAttachment Valid Usage`:
 
 - If `this.view.[[descriptor]].usage` includes the `TRANSIENT_ATTACHMENT` bit:
   - If format has a depth aspect:
     - `this.depthLoadOp` must be `"clear"`.
     - `this.depthStoreOp` must be `"discard".`
   - If format has a stencil aspect:
-    - `this.stencilLoadOp ` must be `"clear"`.
-    - `this.stencilStoreOp ` must be `"discard".`
+    - `this.stencilLoadOp` must be `"clear"`.
+    - `this.stencilStoreOp` must be `"discard".`
 
 ## Javascript example
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5053,7 +5053,7 @@ enum GPUTextureAspect {
                         - If |descriptor|.{{GPUTextureViewDescriptor/swizzle}} is not `"rgba"`,
                             {{GPUFeatureName/"texture-component-swizzle"}} must be [=enabled for=] |this|.{{GPUObjectBase/[[device]]}}.
                         - |descriptor|.{{GPUTextureViewDescriptor/usage}} must be a subset of |this|.{{GPUTexture/usage}}.
-                        - If |descriptor|.{{GPUTextureViewDescriptor/usage}} includes the {{GPUTextureUsage/TRANSIENT_ATTACHMENT}} bit:
+                        - If |this|.{{GPUTexture/usage}} includes the {{GPUTextureUsage/TRANSIENT_ATTACHMENT}} bit:
                             - |descriptor|.{{GPUTextureViewDescriptor/usage}} must be exactly |this|.{{GPUTexture/usage}}.
                         - If |descriptor|.{{GPUTextureViewDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
                             - |descriptor|.{{GPUTextureViewDescriptor/format}} must be a [=renderable format=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5053,6 +5053,8 @@ enum GPUTextureAspect {
                         - If |descriptor|.{{GPUTextureViewDescriptor/swizzle}} is not `"rgba"`,
                             {{GPUFeatureName/"texture-component-swizzle"}} must be [=enabled for=] |this|.{{GPUObjectBase/[[device]]}}.
                         - |descriptor|.{{GPUTextureViewDescriptor/usage}} must be a subset of |this|.{{GPUTexture/usage}}.
+                        - If |descriptor|.{{GPUTextureViewDescriptor/usage}} includes the {{GPUTextureUsage/TRANSIENT_ATTACHMENT}} bit:
+                            - |descriptor|.{{GPUTextureViewDescriptor/usage}} must be exactly |this|.{{GPUTexture/usage}}.
                         - If |descriptor|.{{GPUTextureViewDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
                             - |descriptor|.{{GPUTextureViewDescriptor/format}} must be a [=renderable format=].
                         - If |descriptor|.{{GPUTextureViewDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit:
@@ -11921,7 +11923,7 @@ dictionary GPUComputePassDescriptor
                         - all of |workgroupCountX|, |workgroupCountY| and |workgroupCountZ| are &le;
                             |this|.device.limits.{{supported limits/maxComputeWorkgroupsPerDimension}}.
                         - let |workgroupSize| be the computed workgroup size for
-                            |bindingState|.{{GPUComputePassEncoder/[[pipeline]]}}. 
+                            |bindingState|.{{GPUComputePassEncoder/[[pipeline]]}}.
                         - the entry point uses the [=builtin/workgroup_index=]
                             built-in value and |workgroupCountX| &times; |workgroupCountY|
                             &times; |workgroupCountZ|
@@ -12426,6 +12428,8 @@ dictionary GPURenderPassColorAttachment {
                 1. |resolveTexture|.{{GPUTextureDescriptor/format}} |must| equal
                     |renderTexture|.{{GPUTextureDescriptor/format}}.
                 1. |resolveViewDescriptor|.{{GPUTextureViewDescriptor/format}} |must| support resolve according to [[#plain-color-formats]].
+                1. |resolveViewDescriptor|.{{GPUTextureViewDescriptor/usage}} |must| not include the
+                    {{GPUTextureUsage/TRANSIENT_ATTACHMENT}} bit.
         </div>
 </div>
 


### PR DESCRIPTION
Textures allocated with the TRANSIENT_ATTACHMENT bit may only ever be used as transient attachments.

- Disallow usage subsetting of TRANSIENT_ATTACHMENT textures
- Disallow using TRANSIENT_ATTACHMENT texture (views) as resolve target

CTS: https://github.com/gpuweb/cts/pull/4635