### PR TITLE
Refresh list of contacts in `w3c.json` file

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
 {
-  "group": [96877, 125519],
-  "contacts": ["tidoust", "Kangz", "kdashg"],
+  "group": ["cg/gpu", "wg/gpu"],
+  "contacts": ["tidoust", "Kangz", "jimblandy"],
   "repo-type": ["cg-report", "rec-track"]
 }


### PR DESCRIPTION
The list of contacts in the `w3c.json` file was outdated. This refreshes it to match list of chairs + team contact.

Also using this opportunity to make the list of groups more readable (the system used to require internal group IDs but now accepts more human-friendly shortnames)

@jimblandy, FYI, the IPR bot sends email notifications about PRs that need checking to this list (provided there's an email set on the GitHub profile, which seems to be the case for you).
