### PR TITLE
uniformity: remove exit control flow from expressions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12450,12 +12450,12 @@ of a [=composite=] type separately.
 <table class='data'>
   <caption>Uniformity rules for [=LHSValue=] expressions</caption>
   <thead>
-    <tr><th>Expression<th>New nodes<th>Recursive analyses<th>Resulting control flow node, variable node<th>New edges
+    <tr><th>Expression<th>New nodes<th>Recursive analyses<th>Resulting variable node<th>New edges
   </thead>
    <tr><td>identifier [=resolves|resolving=] to function-scope variable "x"
       <td>*Result*
       <td>*X* is the node corresponding to the value of "x" at the output of the statement containing this expression.
-      <td class="nowrap">*CF*, *Result*
+      <td class="nowrap">*Result*
       <td class>*Result* -> {*CF*, *X*}
 
       Note: *X* is equivalent to *Vin*(*next*) for "x"<br>
@@ -12464,26 +12464,25 @@ of a [=composite=] type separately.
           [=const-declaration=], [=override-declaration=], [=let-declaration=], or [=formal parameter=] "x"
       <td>
       <td>*X* is the node corresponding to "x"
-      <td class="nowrap">*CF*, *X*
+      <td class="nowrap">*X*
       <td>
   <tr><td>identifier [=resolves|resolving=] to module-scope variable "x"
       <td>
       <td>
-      <td class="nowrap">*CF*,<br>
-      [=MayBeNonUniform=]
+      <td class="nowrap">[=MayBeNonUniform=]
       <td>
   <tr><td class="nowrap">*e*.field
       <td rowspan=3>
-      <td class="nowrap" rowspan=3>[=LHSValue=]: (*CF*, *e*) => (*CF1*, *L1*)
-      <td class="nowrap" rowspan=3>*CF1*, *L1*
+      <td class="nowrap" rowspan=3>[=LHSValue=]: (*CF*, *e*) => *L1*
+      <td class="nowrap" rowspan=3>*L1*
       <td rowspan=3>
   <tr><td class="nowrap">**e*
   <tr><td class="nowrap">&*e*
   <tr><td class="nowrap">*e1*[*e2*]
       <td>
-      <td class="nowrap">[=LHSValue=]: (*CF*, *e1*) => (*CF1*, *L1*)<br>
-          (*CF1*, *e2*) => (*CF2*, *V2*)
-      <td class="nowrap">*CF2*, *L1*
+      <td class="nowrap">[=LHSValue=]: (*CF*, *e1*) => *L1*<br>
+          (*CF*, *e2*) => *V2*
+      <td class="nowrap">*L1*
       <td class="nowrap">*L1* -> *V2*
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11925,17 +11925,16 @@ The rules for analyzing statements take as argument both the statement itself an
 In the table below, `(CF1, S) => CF2` means "run the analysis on S starting
 with control flow CF1, apply the required changes to the graph, and name the
 resulting control flow CF2".
-Similarly, `(CF1, E) => (CF2, V)` means "run the analysis on expression E,
-starting with control flow CF1, apply the required changes to the graph, and
-name the resulting control flow node CF2 and the resulting value node V" (see
-next section for the analysis of expressions).
+Similarly, `(CF1, E) => V` means "run the analysis on expression E, starting
+with control flow CF1, apply the required changes to the graph, and name the
+resulting value node V" (see next section for the analysis of expressions).
 This evaluation of expressions is used for any expression that is not part of
 the [=left-hand side=] of an [=statement/assignment=] and is called an <dfn
 noexport>RHSValue</dfn>.
 
 There is a similar set of rules for expressions that are part of the
 [=left-hand side=] of an [=statement/assignment=], the <dfn noexport>LHSValue</dfn>,
-that we denote by `LHSValue: (CF, E) => (CF, L)`. Instead of computing the node
+that we denote by `LHSValue: (CF, E) => L`. Instead of computing the node
 which corresponds to the uniformity of the value, it computes the node which
 corresponds to the uniformity of the variable we are addressing.
 
@@ -12007,7 +12006,7 @@ In analyzing loops, we use the following patterns:
       <td>
   <tr><td class="nowrap">if *e* *s1* else *s2*<br> with behavior {Next}
       <td>
-      <td rowspan=2 class="nowrap">(*CF*, *e*) => (*CF'*, *V*)<br>
+      <td rowspan=2 class="nowrap">(*CF*, *e*) => *V*<br>
           (*V*, *s1*) => *CF1*<br>
           (*V*, *s2*) => *CF2*
       <td>*CF*
@@ -12066,7 +12065,7 @@ In analyzing loops, we use the following patterns:
 
   <tr><td class="nowrap">switch *e* case _: *s_1* .. case _: *s_n*<br> with behavior {Next}
       <td>
-      <td rowspan=2 class="nowrap">(*CF*, *e*) => (*CF'*, *V*)<br>
+      <td rowspan=2 class="nowrap">(*CF*, *e*) => *V*<br>
         (*V*, *s_1*) => *CF_1*<br>
         ...<br>
         (*V*, *s_n*) => *CF_n*
@@ -12089,9 +12088,9 @@ In analyzing loops, we use the following patterns:
   <tr><td class="nowrap">continue;
   <tr><td class="nowrap">break if *e*;
       <td>*CFend*
-      <td class="nowrap">(*CF*, *e*) => (*CF'*, *V*)
+      <td class="nowrap">(*CF*, *e*) => *V*
       <td>*CFend*
-      <td>*CFend* -> {*CF'*, *V*}
+      <td>*CFend* -> *V*
 
           Note: The edge from *CFend* to *V* captures the fact that when
           the condition value is non-uniform, then control flow resulting
@@ -12105,34 +12104,34 @@ In analyzing loops, we use the following patterns:
       [=Value_return_i_contents=] -> *Vin*(*prev*) (see [[#func-var-value-analysis]])
   <tr><td class="nowrap">return *e*;
       <td>
-      <td class="nowrap">(*CF*, *e*) => (*CF'*, *V*)
-      <td>*CF'*
+      <td class="nowrap">(*CF*, *e*) => *V*
+      <td>*CF*
       <td>[=Value_return=] -> *V*
 
       For each [=address spaces/function=] address space pointer parameter *i*,
       [=Value_return_i_contents=] -> *Vin*(*prev*) (see [[#func-var-value-analysis]])
   <tr><td class="nowrap">*e1* = *e2*;
       <td>
-      <td class="nowrap">[=LHSValue=]: (*CF*, *e1*) => (*CF1*, *LV*)<br>
-          (*CF1*, *e2*) => (*CF2*, *RV*)
-      <td>*CF2*
+      <td class="nowrap">[=LHSValue=]: (*CF*, *e1*) => *LV*<br>
+          (*CF*, *e2*) => *RV*
+      <td>*CF*
       <td>*LV* -> *RV*
 
       Note: *LV* is the result value from the [[#func-var-value-analysis|value analysis]].
   <tr><td class="nowrap">_ = *e*
       <td>
-      <td class="nowrap">(*CF*, *e*) => (*CF'*, *V*)
-      <td>*CF'*
+      <td class="nowrap">(*CF*, *e*) => *V*
+      <td>*CF*
       <td>
   <tr><td class="nowrap">let x = *e*;
       <td>
-      <td>(*CF*, *e*) => (*CF'*, *V*)
-      <td>*CF'*
+      <td>(*CF*, *e*) => *V*
+      <td>*CF*
       <td>
   <tr><td class="nowrap">var x = *e*;
       <td>
-      <td>(*CF*, *e*) => (*CF'*, *V*)
-      <td>*CF'*
+      <td>(*CF*, *e*) => *V*
+      <td>*CF*
       <td>
 
       Note: If x is a [=address spaces/function=] address space variable,
@@ -12140,14 +12139,14 @@ In analyzing loops, we use the following patterns:
   <tr><td>*f*`()`<br>Function call statement without arguments
       <td>
       <td>Invoke [[#uniformity-function-calls|function call analysis]]:
-                (*CF*, *f*()) => ([=CF_after=], [=Result=])
-      <td>*CF_after*
+                (*CF*, *f*()) => [=Result=]
+      <td>*CF*
       <td>
   <tr><td>*f*`(`*e1*,...,*eN*`)`<br>Function call statement with arguments
       <td>
       <td>Invoke [[#uniformity-function-calls|function call analysis]]:
-                (*CF*, *f*(*e1*,...,*eN*)) => ([=CF_after=], [=Result=])
-      <td>*CF_after*
+                (*CF*, *f*(*e1*,...,*eN*)) => [=Result=]
+      <td>*CF*
       <td>
 </table>
 
@@ -12172,14 +12171,14 @@ being the same as input control flow node.
 ### Uniformity Rules for Function Calls ### {#uniformity-function-calls}
 
 The most complex rule is for function calls:
-- For each argument, apply the corresponding expression rule, with the control flow at the exit of the previous argument (using the control flow at the beginning of the function call for the first argument). Name the corresponding value nodes <dfn noexport>arg_i</dfn> and the corresponding control flow nodes <dfn noexport>CF_i</dfn>
-- Create two new nodes, named <dfn noexport>Result</dfn> and <dfn noexport>CF_after</dfn>
+- Let *CF* be the control flow at the beginning of the function call expression.
+- For each argument, apply the corresponding expression rule with *CF*. Name the corresponding value nodes <dfn noexport>arg_i</dfn>
+- Create a new node named <dfn noexport>Result</dfn>
+    - Add an edge from [=Result=] to *CF*
 - If the [=call site tag=] of the function is [=CallSiteRequiredToBeUniform.S=], then:
-    - Add an edge from [=RequiredToBeUniform.S=] to the last [=CF_i=].
+    - Add an edge from [=RequiredToBeUniform.S=] to *CF*
     - Add the members of the [=potential-trigger-set=] of the [=call site tag=] to the potential-trigger-set associated with [=RequiredToBeUniform.S=].
-- Add an edge from [=CF_after=] to the last [=CF_i=]
 - If the [=function tag=] is [=ReturnValueMayBeNonUniform=], then add an edge from [=Result=] to [=MayBeNonUniform=]
-- Add an edge from [=Result=] to [=CF_after=]
 - For each argument *i*:
     - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform.S=], then:
         - Add an edge from [=RequiredToBeUniform.S=] to [=arg_i=].
@@ -12292,26 +12291,25 @@ will also be uniform after the function call.
 
 The rules for analyzing expressions take as argument both the expression itself and the node corresponding to control flow at the beginning of it (which we'll note "CF" below) and return the following:
 
-* A node corresponding to control flow at the exit of it
 * A node corresponding to its value
 * A set of new nodes and edges to add to the graph
 
 <table class='data'>
   <caption>Uniformity rules for [=RHSValue=] expressions</caption>
   <thead>
-    <tr><th>Expression<th>New nodes<th>Recursive analyses<th>Resulting control flow node, value node<th>New edges
+    <tr><th>Expression<th>New nodes<th>Recursive analyses<th>Resulting value node<th>New edges
   </thead>
   <tr><td class="nowrap">*e1* || *e2*
       <td rowspan=2>
-      <td rowspan=2 class="nowrap">(*CF*, *e1*) => (*CF1*, *V1*)<br>
-          (*V1*, *e2*) => (*CF2*, *V2*)
-      <td rowspan=2 class="nowrap">*CF*, *V2*
+      <td rowspan=2 class="nowrap">(*CF*, *e1*) => *V1*<br>
+          (*V1*, *e2*) => *V2*
+      <td rowspan=2 class="nowrap">*V2*
       <td rowspan=2>
   <tr><td class="nowrap">*e1* && *e2*
   <tr><td class="nowrap">Literal
       <td>
       <td>
-      <td class="nowrap">*CF*, *CF*
+      <td class="nowrap">*CF*
       <td>
    <tr><td>identifier [=resolves|resolving=] to function-scope variable "x",
       where the identifier appears as the [=root identifier=] of a [=memory view=]
@@ -12319,7 +12317,7 @@ The rules for analyzing expressions take as argument both the expression itself 
       [=type checking=]
       <td>*Result*
       <td class>*X* is the node corresponding to the value of "x" at the input to the statement containing this expression
-      <td class="nowrap">*CF*, *Result*
+      <td class="nowrap">*Result*
       <td class>*Result* -> {*CF*, *X*}
 
       Note: *X* is equivalent to *Vout*(*prev*) for "x"<br>
@@ -12331,7 +12329,7 @@ The rules for analyzing expressions take as argument both the expression itself 
       [=type checking=]
       <td>
       <td class>
-      <td class="nowrap">*CF*, [=param_i=]
+      <td class="nowrap">[=param_i=]
       <td class>
    <tr><td>identifier [=resolves|resolving=] to function-scope variable "x",
       where the identifier appears as the [=root identifier=] of a [=memory view=]
@@ -12339,13 +12337,13 @@ The rules for analyzing expressions take as argument both the expression itself 
       [=type checking=]
       <td>
       <td class>
-      <td class="nowrap">*CF*, *CF*
+      <td class="nowrap">*CF*
       <td class>
    <tr><td>identifier [=resolves|resolving=] to [=const-declaration=], [=override-declaration=],
       [=let-declaration=], or non-built-in [=formal parameter=] of [=pointer type|non-pointer type=] "x"
       <td>*Result*
       <td>*X* is the node corresponding to "x"
-      <td class="nowrap">*CF*, *Result*
+      <td class="nowrap">*Result*
       <td class="nowrap">*Result* -> {*CF*, *X*}
    <tr><td>identifier [=resolves|resolving=] to a [=formal parameter=] of
       [=pointer type=] in the [=address spaces/storage=], [=address spaces/workgroup=],
@@ -12355,7 +12353,7 @@ The rules for analyzing expressions take as argument both the expression itself 
       on *MVE* during [=type checking=]
       <td>
       <td>
-      <td>*CF*, [=MayBeNonUniform=]
+      <td>[=MayBeNonUniform=]
       <td>
    <tr><td>identifier [=resolves|resolving=] to a [=formal parameter=] of
       [=pointer type=] in the [=address spaces/storage=], [=address spaces/workgroup=],
@@ -12365,30 +12363,29 @@ The rules for analyzing expressions take as argument both the expression itself 
       invoked on *MVE* during [=type checking=]
       <td>
       <td>
-      <td>*CF*, *CF*
+      <td>*CF*
       <td>
    <tr><td>identifier [=resolves|resolving=] to a [=formal parameter=] of
       [=pointer type=] in an [=address space=] other than [=address
       spaces/function=] with a read-only [=access mode=]
       <td>
       <td>
-      <td>*CF*, *CF*
+      <td>*CF*
       <td>
    <tr><td>identifier [=resolves|resolving=] to uniform built-in value "x"
       <td>
       <td>
-      <td class="nowrap">*CF*, *CF*
+      <td class="nowrap">*CF*
       <td>
    <tr><td>identifier [=resolves|resolving=] to non-uniform built-in value "x"
       <td>
       <td>
-      <td class="nowrap">*CF*,<br>
-      [=MayBeNonUniform=]
+      <td class="nowrap">[=MayBeNonUniform=]
       <td>
    <tr><td>identifier [=resolves|resolving=] to read-only module-scope variable "x"
       <td>
       <td>
-      <td class="nowrap">*CF*, *CF*
+      <td class="nowrap">*CF*
       <td>
    <tr><td>identifier [=resolves|resolving=] to non-read-only module-scope
       variable "x" where the identifier appears as the [=root identifier=] of a [=memory view=]
@@ -12396,8 +12393,7 @@ The rules for analyzing expressions take as argument both the expression itself 
       [=type checking=]
       <td>
       <td>
-      <td class="nowrap">*CF*,<br>
-      [=MayBeNonUniform=]
+      <td class="nowrap">[=MayBeNonUniform=]
       <td>
    <tr><td>identifier [=resolves|resolving=] to non-read-only module-scope
       variable "x" where the identifier appears as the [=root identifier=] of a [=memory view=]
@@ -12405,33 +12401,33 @@ The rules for analyzing expressions take as argument both the expression itself 
       [=type checking=]
       <td>
       <td>
-      <td class="nowrap">*CF*,*CF*
+      <td class="nowrap">*CF*
       <td>
    <tr><td class="nowrap">( *e* )
       <td rowspan=3>
-      <td rowspan=3 class="nowrap">(*CF*, *e*) => (*CF'*, *V*)
-      <td rowspan=3 class="nowrap">*CF'*, *V*
+      <td rowspan=3 class="nowrap">(*CF*, *e*) => *V*
+      <td rowspan=3 class="nowrap">*V*
       <td rowspan=3>
    <tr><td class="nowrap">*op* *e*,<br> where *op* is a unary operator
    <tr><td class="nowrap">*e*.field
    <tr><td>*e1* *op* *e2*,<br> where *op* is a non-short-circuiting binary operator
       <td rowspan=2> *Result*
-      <td rowspan=2 class="nowrap">(*CF*, *e1*) => (*CF1*, *V1*)<br>
-          (*CF1*, *e2*) => (*CF2*, *V2*)
-      <td rowspan=2 class="nowrap">*CF2*, *Result*
+      <td rowspan=2 class="nowrap">(*CF*, *e1*) => *V1*<br>
+          (*CF1*, *e2*) => *V2*
+      <td rowspan=2 class="nowrap">*Result*
       <td rowspan=2 class="nowrap">*Result* -> {*V1*, *V2*}
    <tr><td class="nowrap">e1[e2]
    <tr><td>*f*`()`<br>Function call expression without arguments
        <td>
        <td>Invoke [[#uniformity-function-calls|function call analysis]]:<br>
-                (*CF*, *f*()) => ([=CF_after=], [=Result=])
-       <td>*CF_after*, *Result*
+                (*CF*, *f*()) => [=Result=]
+       <td>*Result*
        <td>
    <tr><td>*f*`(`*e1*,...,*eN*`)`<br>Function call expression with arguments
        <td>
        <td>Invoke [[#uniformity-function-calls|function call analysis]]:
-                (*CF*, *f*(*e1*,...,*eN*)) => ([=CF_after=], [=Result=])
-       <td>*CF_after*, *Result*
+                (*CF*, *f*(*e1*,...,*eN*)) => [=Result=]
+       <td>*Result*
        <td>
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12413,7 +12413,7 @@ The rules for analyzing expressions take as argument both the expression itself 
    <tr><td>*e1* *op* *e2*,<br> where *op* is a non-short-circuiting binary operator
       <td rowspan=2> *Result*
       <td rowspan=2 class="nowrap">(*CF*, *e1*) => *V1*<br>
-          (*CF1*, *e2*) => *V2*
+          (*CF*, *e2*) => *V2*
       <td rowspan=2 class="nowrap">*Result*
       <td rowspan=2 class="nowrap">*Result* -> {*V1*, *V2*}
    <tr><td class="nowrap">e1[e2]


### PR DESCRIPTION
Expressions cannot impact control flow since we guarantee reconvergence on return from a function call and after a short-circuiting operator, and because `discard` has demote-to-helper semantics.

This change removes the resulting control flow node from the uniformity rules for expressions and simplifies any relevant prose accordingly. This includes removing the `CF_after` node from function call expressions.