### PR TITLE
uniformity: fix visit order for array accessor expressions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12477,7 +12477,7 @@ The rules for analyzing expressions take as argument both the expression itself 
           (*CF*, *e2*) => *V2*
       <td rowspan=2 class="nowrap">*Result*
       <td rowspan=2 class="nowrap">*Result* -> {*V1*, *V2*}
-   <tr><td class="nowrap">e1[e2]
+   <tr><td class="nowrap">e2[e1]
    <tr><td>*f*`()`<br>Function call expression without arguments
        <td>
        <td>Invoke [[#uniformity-function-calls|function call analysis]]:<br>
@@ -12539,12 +12539,12 @@ of a [=composite=] type separately.
       <td rowspan=3>
   <tr><td class="nowrap">**e*
   <tr><td class="nowrap">&*e*
-  <tr><td class="nowrap">*e1*[*e2*]
+  <tr><td class="nowrap">*e2*[*e1*]
       <td>
-      <td class="nowrap">[=LHSValue=]: (*CF*, *e1*) => *L1*<br>
-          (*CF*, *e2*) => *V2*
-      <td class="nowrap">*L1*
-      <td class="nowrap">*L1* -> *V2*
+      <td class="nowrap">(*CF*, *e1*) => *V1*<br>
+          [=LHSValue=]: (*CF*, *e2*) => *L2*
+      <td class="nowrap">*L2*
+      <td class="nowrap">*L2* -> *V1*
 </table>
 
 ### Annotating the Uniformity of Every Point in the Control-flow ### {#uniformity-optional-diagnosis-mode}


### PR DESCRIPTION
We need to visit the index expression before visiting the object expression to capture the potential for the index expression to modify the uniformity of the object itself (for example via a function call).