### PR TITLE
Change ordering of alignment requirement conditionals

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1010,7 +1010,7 @@ When the scanner attempts to match the [=syntax_sym/_disambiguate_template=] tok
 Future token scanning steps will use the recorded template list delimiter positions to yield
 [=syntax_sym/_template_args_start=] and [=syntax_sym/_template_args_end=] tokens as indicated.
 
-This alternative approach is non-normative. 
+This alternative approach is non-normative.
 The normative grammar includes [=syntax_sym/_disambiguate_template=] tokens as a help to implementations
 using the alternative approach.
 A parser using the standard approach can either ignore the synthetic token, or equivalently, always successfully
@@ -11128,13 +11128,13 @@ used in address space |C|.
     <tr><th>Host-shareable or fixed footprint type |S|,
             assuming |S| can appear in |C|
         <th>[=RequiredAlignOf=](|S|, |C|),<br/>
-            |C| is not [=address spaces/uniform=] or
             [=language_extension/uniform_buffer_standard_layout=]
-            is supported
+            is supported or
+            |C| is not [=address spaces/uniform=]
         <th>[=RequiredAlignOf=](|S|, |C|),<br/>
-            |C| is [=address spaces/uniform=] and
             [=language_extension/uniform_buffer_standard_layout=]
-            is **not** supported
+            is **not** supported and
+            |C| is [=address spaces/uniform=]
   </thead>
   <tr><td>[=bool=], [=i32=], [=u32=], [=f32=], or [=f16=]
       <td>[=AlignOf=](|S|)
@@ -12028,7 +12028,7 @@ In analyzing loops, we use the following patterns:
     uniformity when first arriving at the loop.
 * Note: [[#behaviors|Statement behavior analysis]] implies that the
     behavior of a loop is one of {Next}, {Return}, or {Next,Return}.
-  
+
 <table class='data'>
   <caption>Uniformity rules for statements</caption>
   <thead>
@@ -12287,7 +12287,7 @@ Here is the list of exceptions:
             - If there is no such *DF*,
                 the call site tag is [=CallSiteRequiredToBeUniform.S|CallSiteRequiredToBeUniform.error=], with [=potential-trigger-set=]
                 consisting of a [=trigger/derivative_uniformity=] element.
-        - [=CallSiteNoRestriction=] otherwise. 
+        - [=CallSiteNoRestriction=] otherwise.
 - A call to [[#textureload]]:
     - Has a [=call site tag=] of [=CallSiteNoRestriction=]
     - Has a [=function tag=] as follows:


### PR DESCRIPTION
This Cl flips the conditional for the alignment requirement table to make it clear the `not` applies only to `uniform`.