### PR TITLE
editorial: Reorder attributes in GPUPipelineError interface

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7551,7 +7551,7 @@ There are two ways to create pipelines:
 <dfn interface>GPUPipelineError</dfn> describes a pipeline creation failure.
 
 <script type=idl>
-[Exposed=(Window, Worker), SecureContext, Serializable]
+[Exposed=(Window, Worker), Serializable, SecureContext]
 interface GPUPipelineError : DOMException {
     constructor(optional DOMString message = "", GPUPipelineErrorInit options);
     readonly attribute GPUPipelineErrorReason reason;


### PR DESCRIPTION
All other interfaces have `Serializable, SecureContext`, except GPUPipelineError which has `SecureContext, Serializable`.

This is not alphabetical, so maybe we should revere this and change all others to be alphabetically ordered.