### PR TITLE
wgsl: refine sample_mask definition for sample-rate shading

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -265,6 +265,7 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
         text: clip space coordinates; url: clip-space-coordinates
         text: clip position; url: clip-position
         text: viewport; url: dom-renderstate-viewport-slot
+        text: rasterizationpoint-coveragemask; url: rasterizationpoint-coveragemask
         text: rasterizationpoint-destination; url: rasterizationpoint-destination
         text: rasterizationpoint-depth; url: rasterizationpoint-depth
         text: rasterizationpoint-perspectivedivisor; url: rasterizationpoint-perspectivedivisor
@@ -10010,7 +10011,7 @@ Each is described in detail in subsequent sections.
   <tr><td style="width:10%">Description
       <td>
       Sample index for the current fragment.  The value is least 0 and at most
-      `sampleCount`-1, where `sampleCount` is the MSAA sample
+      `sampleCount`-1, where `sampleCount` is the sample
       {{GPUMultisampleState/count}} specified for the GPU render pipeline.
       When this attribute is applied, if the effects of the fragment shader would vary based
       on the value of [=built-in values/sample_index=], the [=fragment=] shader will be invoked
@@ -10032,11 +10033,28 @@ Each is described in detail in subsequent sections.
       <td>Input
   <tr><td style="width:10%">Description
       <td>
-      Sample coverage mask for the current fragment.  It contains a bitmask
-      indicating which samples in this fragment are covered by the primitive
-      being rendered.
+      Sample coverage bitmask for the current fragment.
 
-      See [[WebGPU#sample-masking]].
+      Bits are indexed by a sample index in the interval 0 through
+      `sampleCount`-1, where `sampleCount` is the sample
+      {{GPUMultisampleState/count}} specified for the GPU render pipeline.
+
+      A bit will be set to 1 *only if* the sample is covered by the primitive being rendered.
+      Bits with index `sampleCount` and above are always set to zero.
+
+      There are two possible values for the bitmask:
+      * The bitmask has a 1 bit set for every sample covered by the fragment.
+          In this case the bitmask equals the fragment's
+          [=RasterizationPoint=] [=rasterizationpoint-coveragemask|coverageMask=].
+      * The bitmask has only 1 bit set, corresponding to the sample being processed by the current fragment shader invocation.
+          That is, the bitmask is (1 `<<` [=built-in values/sample_index=]), as if using the `sample_index` built-in input.
+
+      Note: These two cases are the same when `sampleCount` &equals; 1.
+
+      Note: This is a known portability hazard when `sampleCount` &gt; 1.
+      Some devices yield the full coverage mask.  Other devices yield the single-bit mask.
+
+      See [[WebGPU#per-sample-shading]] and [[WebGPU#sample-masking]].
 </table>
 
 <table class='data'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10035,8 +10035,8 @@ Each is described in detail in subsequent sections.
       <td>
       Sample coverage bitmask for the current fragment.
 
-      Bits are indexed by a sample index in the interval 0 through
-      `sampleCount`-1, where `sampleCount` is the sample
+      Bits are indexed by a sample index in the half-open interval [0, `sampleCount`),
+      where `sampleCount` is the sample
       {{GPUMultisampleState/count}} specified for the GPU render pipeline.
 
       A bit will be set to 1 *only if* the sample is covered by the primitive being rendered.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9978,11 +9978,17 @@ Each is described in detail in subsequent sections.
       <td>Input
   <tr><td style="width:10%">Description
       <td>
-      Sample coverage mask for the current fragment.  It contains a bitmask
-      indicating which samples in this fragment are covered by the primitive
+      Sample coverage mask for the current fragment shader invocation.
+
+      If only one fragment shader invocation is executed for the fragment, the sample mask
+      contains a bitmask indicating which samples in this fragment are covered by the primitive
       being rendered.
 
-      See [[WebGPU#sample-masking]].
+      If there is one fragment shader invocation executed for each sample covered by the fragment,
+      the sample mask is a bitmask with 1 in the `sample_index` position, and zero elsewhere.
+      That is, the sample mask in this case is (1 `<<` `sample_index`).
+
+      See [[WebGPU#per-sample-shading]] and [[WebGPU#sample-masking]].
 </table>
 
 <table class='data'>


### PR DESCRIPTION
Fixes: #5457