### PR TITLE
Disallow viewFormats with TRANSIENT_ATTACHMENT

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4678,6 +4678,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                     with {{GPUTextureUsage/STORAGE_BINDING}} capability for at least one access mode.
             - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/TRANSIENT_ATTACHMENT}} bit:
                 - |descriptor|.{{GPUTextureDescriptor/usage}} must be equal to {{GPUTextureUsage/TRANSIENT_ATTACHMENT}} | {{GPUTextureUsage/RENDER_ATTACHMENT}}.
+                - |descriptor|.{{GPUTextureDescriptor/viewFormats}} must be equal to its default value of `[]`.
                 - |descriptor|.{{GPUTextureDescriptor/dimension}} must be equal to {{GPUTextureDimension/"2d"}}.
                 - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
                 - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be 1.


### PR DESCRIPTION
Alternate option would be: allow `viewFormats` to be used, but it can only be exactly `[format]`.

Tests: https://github.com/gpuweb/cts/pull/4647

Fixes #6263