### PR TITLE
check-nfkc.py: Don't try to scan deleted files

### DIFF
--- a/tools/check-nfkc.py
+++ b/tools/check-nfkc.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 
 files = subprocess.run(
-    ["git", "ls-files"], check=True, capture_output=True
+    ["git", "ls-files", "--no-deleted"], check=True, capture_output=True
 ).stdout.splitlines()
 
 fix = "--fix" in [unicodedata.normalize("NFKC", i) for i in sys.argv]


### PR DESCRIPTION
Before this change, the check-nfkc step will fail
if the git change includes a file deletion.