### PR TITLE
Rename immediate_data to immediate_address_space

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1507,7 +1507,7 @@ The [=language extension=] names are:
 * <a for=language_extension lt=texture_and_sampler_let>`'texture_and_sampler_let'`</a>
 * <a for=language_extension lt=texture_formats_tier1>`'texture_formats_tier1'`</a>
 * <a for=language_extension lt=linear_indexing>`'linear_indexing'`</a>
-* <a for=language_extension lt=immediate_data>`'immediate_data'`</a>
+* <a for=language_extension lt=immediate_address_space>`'immediate_address_space'`</a>
 
 ### Interpolation Type Names ### {#interpolation-type-names}
 
@@ -2007,7 +2007,7 @@ Extension names are not [=identifiers=]: they do not [=resolves|resolve=] to [=d
       <td>
       Supports the [=built-in values/global_invocation_index=] and
       [=built-in values/workgroup_index=] [=built-in values=].
-   <tr><td><dfn for="language_extension">immediate_data</dfn>
+   <tr><td><dfn for="language_extension">immediate_address_space</dfn>
       <td>
       Enables the [=address spaces/immediate=] address space, allowing variables
       to be declared with `var<immediate>` and bound to small amounts of frequently


### PR DESCRIPTION
This PR renames the `immediate_data` WGSL language extension name to `immediate_address_space` throughout the WGSL specification.