### PR TITLE
Remove any from frag_depth proposal.

### DIFF
--- a/proposals/fragment-depth.md
+++ b/proposals/fragment-depth.md
@@ -6,7 +6,7 @@
 
 ## Motivation
 
-The ability for fragment shaders to explicitly write to the depth buffer via the `@builtin(frag_depth)`attribute is critical for many modern rendering techniques, including custom depth biasing for shadows, precise depth fog, and complex depth-based effects.
+The ability for fragment shaders to explicitly write to the depth buffer via the `@builtin(frag_depth)` attribute is critical for many modern rendering techniques, including custom depth biasing for shadows, precise depth fog, and complex depth-based effects.
 
 In the current WGSL specification, the mere act of writing to `@builtin(frag_depth)` often incurs a significant performance penalty because driver heuristics cannot guarantee that the fragment shader output will adhere to the depth written by the rasterizer's interpolated depth. Consequently, writing to `frag_depth` typically forces the GPU to disable crucial early-Z optimizations for the entire draw call.
 
@@ -59,17 +59,17 @@ providing a `depth_mode` the fragment depth is implicitly `any`.
 
 It can be either `@builtin(frag_depth)`, `@builtin(frag_depth, greater)`, or `@builtin(frag_depth, lesser)`
 
-   This applies `depth_mode` on the `frag_depth` built-in output value in a fragment shader.
+This applies `depth_mode` on the `frag_depth` built-in output value in a fragment shader.
 
 ### Example usage
 
-   ```wgsl
-   requires fragment_depth;
+```wgsl
+requires fragment_depth;
 
-   @fragment
-   fn main() -> @builtin(frag_depth, greater) f32 {
-       return 1.0f;
-   }
+@fragment
+fn main() -> @builtin(frag_depth, greater) f32 {
+    return 1.0f;
+}
 ```
 
 ### Built-in Value Mappings

--- a/proposals/fragment-depth.md
+++ b/proposals/fragment-depth.md
@@ -1,4 +1,4 @@
-# Fragment depth (less, greater, any)
+# Fragment depth (less, greater)
 
 * Status: [Draft](README.md#status-draft)
 * Created: 2025-10-08
@@ -6,13 +6,12 @@
 
 ## Motivation
 
-The ability for fragment shaders to explicitly write to the depth buffer via the `@builtin(frag_depth)` attribute is critical for many modern rendering techniques, including custom depth biasing for shadows, precise depth fog, and complex depth-based effects.
+The ability for fragment shaders to explicitly write to the depth buffer via the `@builtin(frag_depth)`attribute is critical for many modern rendering techniques, including custom depth biasing for shadows, precise depth fog, and complex depth-based effects.
 
 In the current WGSL specification, the mere act of writing to `@builtin(frag_depth)` often incurs a significant performance penalty because driver heuristics cannot guarantee that the fragment shader output will adhere to the depth written by the rasterizer's interpolated depth. Consequently, writing to `frag_depth` typically forces the GPU to disable crucial early-Z optimizations for the entire draw call.
 
-The introduction of a new `depth_mode` built-in parameter for the `@builtin(frag_depth)` with modes `less`, `greater`, and `any` directly addresses this performance limitation by letting the developer express their intent to the hardware.
+The introduction of a new `depth_mode` built-in parameter for the `@builtin(frag_depth)` with modes `less`, and `greater` directly addresses this performance limitation by letting the developer express their intent to the hardware.
 
-*   The `any` mode maintains the existing, unconditional behavior of `frag_depth`.
 *   The `less` and `greater` modes are used when a fragment shader declares it will only write depth values that are guaranteed to be less than (or greater than) the existing depth. The driver can be assured that any fragment whose interpolated depth already fails the declared comparison cannot possibly satisfy the conditional write, allowing it to be rejected early.
 
 ## HLSL
@@ -55,30 +54,29 @@ Source: https://usermanual.wiki/Document/Vulkan2BProgramming2BGuide2BThe2BOffici
 
 ### Built-in `depth_mode` parameter to `frag_depth`
 
-An optional `depth_mode` parameter declared after the built-in `frag_depth` name is allowed and
-defaults to `any`.
+An optional `depth_mode` parameter declared after the built-in `frag_depth` name is allowed. Without
+providing a `depth_mode` the fragment depth is implicitly `any`.
 
-It can be either `@builtin(frag_depth)`, `@builtin(frag_depth, greater)`,
-`@builtin(frag_depth, lesser)`, or `@builtin(frag_depth, any)`.
+It can be either `@builtin(frag_depth)`, `@builtin(frag_depth, greater)`, or `@builtin(frag_depth, lesser)`
 
-This applies `depth_mode` on the `frag_depth` built-in output value in a fragment shader.
+   This applies `depth_mode` on the `frag_depth` built-in output value in a fragment shader.
 
 ### Example usage
 
-```wgsl
-requires fragment_depth;
+   ```wgsl
+   requires fragment_depth;
 
-@fragment
-fn main() -> @builtin(frag_depth, greater) f32 {
-  return 1.0f;
-}
+   @fragment
+   fn main() -> @builtin(frag_depth, greater) f32 {
+       return 1.0f;
+   }
 ```
 
 ### Built-in Value Mappings
 
 | Built-in | SPIR-V | MSL | HLSL | GLSL |
 |----------|--------|-----|------|------|
-| frag_depth, any | SpvBuiltInFragDepth | depth(any) | SV_Depth | depth_any |
+| frag_depth | SpvBuiltInFragDepth | depth(any) | SV_Depth | depth_any |
 | frag_depth, greater | SpvBuiltInFragDepth + OpExecutionMode DepthGreater | depth(greater) | SV_DepthGreaterEqual | depth_greater |
 | frag_depth, less | SpvBuiltInFragDepth + OpExecutionMode DepthLess | depth(less) | SV_DepthLessEqual | depth_less |
 


### PR DESCRIPTION
Remove the `any` keyword from the frag_depth proposal. `frag_depth(any)`
is just another way to write `frag_depth`. The latter is shorter and we
have not been adding the 'default' value entries in for other optional
values in the spec.

Closes #6233