### PR TITLE
[wgsl] Restrict f16 in immediates.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5219,7 +5219,12 @@ access mode; the default is read.
 A variable in the [=address spaces/immediate=] address space is an <dfn
 noexport>immediate data</dfn> variable.
 Its [=store type=] [=shader-creation error|must=] be a [=host-shareable=] [=constructible=] type,
-excluding arrays and structures that contain array members.
+excluding:
+ * arrays
+ * f16
+ * any type with an f16 component
+ * structures which include, or nest, any of the exclusions
+
 Each [=entry point=] [=shader-creation error|must=] [=statically access=] at most one immediate data variable.
 The value of an immediate variable is set via [=setImmediates=] commands recorded by the WebGPU API command encoder,
 and remains constant during shader execution.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4927,7 +4927,8 @@ effective-value-type.
 <tr><td>[=variable|var=]&lt;[=address spaces/immediate=]&gt;
     <td>Immutable
     <td>[=module scope|Module=]
-    <td>[=type/concrete|Concrete=] [=constructible=] [=host-shareable=], excluding arrays and structures containing array members
+    <td>[=type/concrete|Concrete=] [=constructible=] [=host-shareable=], excluding any type that is
+        or contains an [=array=] or [=f16=]
     <td>Disallowed
     <td>
     <td>Yes.<br>[=immediate data=]
@@ -5219,11 +5220,7 @@ access mode; the default is read.
 A variable in the [=address spaces/immediate=] address space is an <dfn
 noexport>immediate data</dfn> variable.
 Its [=store type=] [=shader-creation error|must=] be a [=host-shareable=] [=constructible=] type,
-excluding:
- * arrays
- * f16
- * any type with an f16 component
- * structures which include, or nest, any of the exclusions
+excluding any type that is or contains an [=array=] or [=f16=].
 
 Each [=entry point=] [=shader-creation error|must=] [=statically access=] at most one immediate data variable.
 The value of an immediate variable is set via [=setImmediates=] commands recorded by the WebGPU API command encoder,


### PR DESCRIPTION
The immediate spec should not permit f16 data at this point. Add the restriction into the WGSL spec text that f16 is not permitted.