### PR TITLE
[wgsl] Integrate the fragment_depth proposal into the spec

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9794,18 +9794,18 @@ Each is described in detail in subsequent sections.
 
       * Specifying the [=depth mode name-token|depth_mode=]
         <dfn for="depth_mode" export>`less`</dfn> is a promise that if the [=fragment=] shader
-        writes to [=built-in values/frag_depth=] (i.e. doesn't `discard`), then the written value
+        returns [=built-in values/frag_depth=] (i.e. doesn't `discard`), then the returned value
         will be less than or equal to the original depth of the [=fragment=].
 
       * Specifying the [=depth mode name-token|depth_mode=]
         <dfn for="depth_mode" export>`greater`</dfn> is a promise that if the [=fragment=] shader
-        writes to [=built-in values/frag_depth=] (i.e. doesn't `discard`), then the written value
+        returns [=built-in values/frag_depth=] (i.e. doesn't `discard`), then the returned value
         will be greater than or equal to the original depth of the [=fragment=].
 
       The original depth of the [=fragment=] is the depth property of the fragment's
       [=RasterizationPoint=].
 
-      If the shader writes a depth value that violates the depth mode promise, then an
+      If the shader returns a depth value that violates the depth mode promise, then an
       indeterminate depth value may be used instead.
 
       ```wgsl

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1557,7 +1557,7 @@ path: syntax/swizzle_name.syntax.bs.include
 
 A <dfn noexport>depth mode name-token</dfn> is a [=token=] used in the [=built-in
 values/frag_depth|frag_depth=] builtin when the [=language_extension/fragment_depth=] feature is
-available.
+supported.
 
 * <a for=depth_mode lt=less>`'less'`</a>
 * <a for=depth_mode lt=greater>`'greater'`</a>
@@ -9805,8 +9805,8 @@ Each is described in detail in subsequent sections.
       The original depth of the [=fragment=] is the depth property of the fragment's
       [=RasterizationPoint=].
 
-      Violating the specified semantics may cause indeterminate values to be written to the depth
-      buffer.
+      If the shader writes a depth value that violates the depth mode promise, then an
+      indeterminate depth value may be used instead.
 
       ```wgsl
       @fragment

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9794,12 +9794,12 @@ Each is described in detail in subsequent sections.
 
       * Specifying the [=depth mode name-token|depth_mode=]
         <dfn for="depth_mode" export>`less`</dfn> is a promise that if the [=fragment=] shader
-        writes to [=built-in values/frag_depth=], then the written value well be less than the
+        writes to [=built-in values/frag_depth=], then the written value will be less than the
         original depth of the [=fragment=].
 
       * Specifying the [=depth mode name-token|depth_mode=]
         <dfn for="depth_mode" export>`greater`</dfn> is a promise that if the [=fragment=] shader
-        writes to [=built-in values/frag_depth=], then the written value well be greater than the
+        writes to [=built-in values/frag_depth=], then the written value will be greater than the
         original depth of the [=fragment=].
 
       The original depth of the [=fragment=] is the depth property of the fragment's

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9794,13 +9794,13 @@ Each is described in detail in subsequent sections.
 
       * Specifying the [=depth mode name-token|depth_mode=]
         <dfn for="depth_mode" export>`less`</dfn> is a promise that if the [=fragment=] shader
-        writes to [=built-in values/frag_depth=], then the written value will be less than the
-        original depth of the [=fragment=].
+        writes to [=built-in values/frag_depth=] (i.e. doesn't `discard`), then the written value
+        will be less than or equal to the original depth of the [=fragment=].
 
       * Specifying the [=depth mode name-token|depth_mode=]
         <dfn for="depth_mode" export>`greater`</dfn> is a promise that if the [=fragment=] shader
-        writes to [=built-in values/frag_depth=], then the written value will be greater than the
-        original depth of the [=fragment=].
+        writes to [=built-in values/frag_depth=] (i.e. doesn't `discard`), then the written value
+        will be greater than or equal to the original depth of the [=fragment=].
 
       The original depth of the [=fragment=] is the depth property of the fragment's
       [=RasterizationPoint=].

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1512,6 +1512,7 @@ The [=language extension=] names are:
 * <a for=language_extension lt=texture_formats_tier1>`'texture_formats_tier1'`</a>
 * <a for=language_extension lt=linear_indexing>`'linear_indexing'`</a>
 * <a for=language_extension lt=immediate_address_space>`'immediate_address_space'`</a>
+* <a for=language_extension lt=fragment_depth>`'fragment_depth'`</a>
 
 ### Interpolation Type Names ### {#interpolation-type-names}
 
@@ -1551,6 +1552,14 @@ The [=swizzle=] names are used in [[#vector-access-expr|vector access expression
 <pre class=include>
 path: syntax/swizzle_name.syntax.bs.include
 </pre>
+
+### Depth Mode Names ### {#depth-mode-names}
+
+A <dfn noexport>depth mode name-token</dfn> is a [=token=] used in the `frag_depth` builtin when the
+[=language_extension/fragment_depth=] is available.
+
+* <a for=depth_mode lt=less>`'less'`</a>
+* <a for=depth_mode lt=greater>`'greater'`</a>
 
 ## Template Lists ## {#template-lists-sec}
 
@@ -2022,6 +2031,12 @@ Extension names are not [=identifiers=]: they do not [=resolves|resolve=] to [=d
       Enables the [=address spaces/immediate=] address space, allowing variables
       to be declared with `var<immediate>` and bound to small amounts of frequently
       updated data passed directly from the command encoder via the WebGPU API.
+   <tr><td><dfn for="language_extension">fragment_depth</dfn>
+      <td>
+      Introduces a new `depth_mode` built-in parameter for the `@builtin(frag_depth)` with modes
+      <a for=depth_mode lt=less>`less`</a>, and <a for=depth_mode lt=greater>`greater`</a>
+      which are used when a fragment shader is declaring it will only write depth values that are
+      guaranteed to be less than (or greater than) the existing depth.
 
 </table>
 
@@ -9770,6 +9785,27 @@ Each is described in detail in subsequent sections.
       Updated depth of the fragment, in the viewport depth range.
 
       See [[WebGPU#coordinate-systems]].
+
+      If the [=language_extension/fragment_depth=] feature is present then an optional
+      [=depth mode name-token|depth_mode=] maybe applied to the `frag_depth` builtin.
+
+      Setting the [=depth mode name-token|depth_mode=] to <dfn for="depth_mode" export>`less`</dfn>
+      specifies that the fragment shader will only write depth values lesser than the one in the
+      depth buffer.
+
+      Setting the [=depth mode name-token|depth_mode=] to <dfn for="depth_mode"
+      export>`greater`</dfn> specifies that the fragment shader will only write depth values greater
+      than the one in the depth buffer.
+
+      Violating the specified semantics may cause undefined values to be written to the depth
+      buffer.
+
+      ```wgsl
+      @fragment
+      fn main() -> @builtin(frag_depth, greater) f32 {
+          return 1.0f;
+      }
+      ```
 </table>
 
 ##### `front_facing` ##### {#front-facing-builtin-value}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1555,8 +1555,9 @@ path: syntax/swizzle_name.syntax.bs.include
 
 ### Depth Mode Names ### {#depth-mode-names}
 
-A <dfn noexport>depth mode name-token</dfn> is a [=token=] used in the `frag_depth` builtin when the
-[=language_extension/fragment_depth=] is available.
+A <dfn noexport>depth mode name-token</dfn> is a [=token=] used in the [=built-in
+values/frag_depth|frag_depth=] builtin when the [=language_extension/fragment_depth=] feature is
+available.
 
 * <a for=depth_mode lt=less>`'less'`</a>
 * <a for=depth_mode lt=greater>`'greater'`</a>
@@ -2033,9 +2034,10 @@ Extension names are not [=identifiers=]: they do not [=resolves|resolve=] to [=d
       updated data passed directly from the command encoder via the WebGPU API.
    <tr><td><dfn for="language_extension">fragment_depth</dfn>
       <td>
-      Introduces a new `depth_mode` built-in parameter for the `@builtin(frag_depth)` with modes
+      Introduces a new [=depth mode name-token|depth_mode=] built-in parameter for the
+      [=built-in values/frag_depth|`frag-depth` builtin=] with modes
       <a for=depth_mode lt=less>`less`</a>, and <a for=depth_mode lt=greater>`greater`</a>
-      which are used when a fragment shader is declaring it will only write depth values that are
+      which are used when a [=fragment=] shader is declaring it will only write depth values that are
       guaranteed to be less than (or greater than) the existing depth.
 
 </table>
@@ -9786,18 +9788,24 @@ Each is described in detail in subsequent sections.
 
       See [[WebGPU#coordinate-systems]].
 
-      If the [=language_extension/fragment_depth=] feature is present then an optional
-      [=depth mode name-token|depth_mode=] maybe applied to the `frag_depth` builtin.
+      If the [=language_extension/fragment_depth=] feature is supported, then the
+      [=attribute/builtin=] attribute can have an optional second parameter to specify a
+      [=depth mode name-token|depth mode=]:
 
-      Setting the [=depth mode name-token|depth_mode=] to <dfn for="depth_mode" export>`less`</dfn>
-      specifies that the fragment shader will only write depth values lesser than the one in the
-      depth buffer.
+      * Specifying the [=depth mode name-token|depth_mode=]
+        <dfn for="depth_mode" export>`less`</dfn> is a promise that if the [=fragment=] shader
+        writes to [=built-in values/frag_depth=], then the written value well be less than the
+        original depth of the [=fragment=].
 
-      Setting the [=depth mode name-token|depth_mode=] to <dfn for="depth_mode"
-      export>`greater`</dfn> specifies that the fragment shader will only write depth values greater
-      than the one in the depth buffer.
+      * Specifying the [=depth mode name-token|depth_mode=]
+        <dfn for="depth_mode" export>`greater`</dfn> is a promise that if the [=fragment=] shader
+        writes to [=built-in values/frag_depth=], then the written value well be greater than the
+        original depth of the [=fragment=].
 
-      Violating the specified semantics may cause undefined values to be written to the depth
+      The original depth of the [=fragment=] is the depth property of the fragment's
+      [=RasterizationPoint=].
+
+      Violating the specified semantics may cause indeterminate values to be written to the depth
       buffer.
 
       ```wgsl


### PR DESCRIPTION
Update the WGSL spec to include the fragment_depth proposal text.

Closes #5342