### PR TITLE
wgsl: talk about feature support, rather than availability

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1818,7 +1818,7 @@ An <dfn noexport>enable-extension</dfn> is an [=extension=] whose functionality 
 * The shader explicitly requests it via an [=enable directive=], and
 * The corresponding WebGPU {{GPUFeatureName}} was one of the required features requested when creating the {{GPUDevice}}.
 
-[=Enable-extensions=] are intended to expose hardware functionality that is not universally available.
+[=Enable-extensions=] are intended to expose hardware functionality that is not universally supported.
 
 An <dfn noexport>enable directive</dfn> is a [=directive=] that turns on support for one or more enable-extensions.
 A [=shader-creation error=] results if the implementation does not support all the listed enable-extensions.
@@ -1895,7 +1895,7 @@ A <dfn noexport>language extension</dfn> is an [=extension=] which is automatica
 The program does not have to explicitly request it.
 
 [=Language extensions=] embody functionality which could reasonably be supported on any WebGPU implementation.
-If the feature is not universally available, that it is because some WebGPU implementation has not yet implemented it.
+If the feature is not universally supported, that it is because some WebGPU implementation has not yet implemented it.
 
 Note: For example, do-while loops could be a language extension.
 

--- a/wgsl/wgsl_spec_style_guide.md
+++ b/wgsl/wgsl_spec_style_guide.md
@@ -113,6 +113,9 @@ promote interoperability between developers using different input mechanisms.
 A developer intending to contribute can automatically normalize sources by
 passing `--fix` to `check-nfkc.py` in the tools directory.
 
+When talking about a feature, use phrasing like "if the BLAH feature is supported".
+Use "supported" instead of "available".
+
 ## Tagging conventions
 
 Several tools process the specification source, extracting things for further processing.


### PR DESCRIPTION
Most of the WGSL spec talks about a feature being "supported" rather than "available".  Change the last two instances of "available" to "supported".