### PR TITLE
Compat: add validation for storage texture binding

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6776,6 +6776,13 @@ following members:
                                             includes {{GPUTextureUsage/STORAGE_BINDING}}.
                                         - |storageTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
                                         - |storageTextureView|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/swizzle}} must be `"rgba"`.
+                                        -
+                                            <div class=compatmode>
+                                                If |texture|.{{GPUTexture/textureBindingViewDimension}} is not `undefined`:
+
+                                                - [=Assert=] |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"core-features-and-limits"}}.
+                                                - |texture|.{{GPUTexture/textureBindingViewDimension}} must be equal to |storageTextureView|.{{GPUTextureViewDescriptor/dimension}}.
+                                            </div>
 
                                     :  {{GPUBindGroupLayoutEntry/buffer}}
                                     ::


### PR DESCRIPTION
Add validation for textureBindingViewDimension when the texture is specified as a storage binding (identical to the validation required for texture bindings).

---

EDIT: CTS issue: https://github.com/gpuweb/cts/issues/4668