### PR TITLE
Add `texture-compression-unaligned` feature to relax texture size block alignment requirement.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3063,6 +3063,7 @@ enum GPUFeatureName {
     "primitive-index",
     "texture-component-swizzle",
     "subgroup-size-control",
+    "texture-compression-unaligned",
 };
 </script>
 
@@ -4664,8 +4665,9 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
 
                     Note: this validation only applies to a user-specified textureBindingViewDimension. If no value is provided, the texture's textureBindingViewDimension is set as described in {{GPUDevice/createTexture()}}. That algorithm cannot produce invalid values, so the above validation is not required.
                 </div>
-            - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be multiple of [=texel block width=].
-            - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be multiple of [=texel block height=].
+            - If |this|.{{device/[[features]]}} does not [=list/contain=] {{GPUFeatureName/"texture-compression-unaligned"}}:
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] must be multiple of [=texel block width=].
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] must be multiple of [=texel block height=].
             - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
                 - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
                 - |descriptor|.{{GPUTextureDescriptor/size}}.[=GPUExtent3D/depthOrArrayLayers=] must be 1.
@@ -17579,6 +17581,13 @@ This feature adds no [=optional API surfaces=].
 
 - New WGSL extensions:
     - [=extension/subgroup_size_control=]
+
+<h3 id=dom-gpufeaturename-texture-compression-unaligned data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-unaligned"`
+</h3>
+
+Allows the creation of textures with block-based compressed {{GPUTextureFormat}}s whose {{GPUTextureDescriptor/size}} is not a multiple of the [=texel block width=] and [=texel block height=].
+
+This feature adds no [=optional API surfaces=].
 
 # Appendices # {#appendices}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17649,15 +17649,15 @@ New WGSL extensions:
 
 - [=extension/subgroup_size_control=]
 
-<!-- IMPORTANT: Follow the style of features above. Note this section is always non-normative.
-    When adding a new feature here, also update the GPUFeatureName definition. -->
-
 <h3 id=dom-gpufeaturename-texture-compression-unaligned data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-unaligned"`
 </h3>
 
-Allows the creation of textures with block-based compressed {{GPUTextureFormat}}s whose {{GPUTextureDescriptor/size}} is not a multiple of the [=texel block width=] and [=texel block height=].
+When enabled:
 
-This feature adds no [=optional API surfaces=].
+- Allows the creation of textures with block-based compressed {{GPUTextureFormat}}s whose {{GPUTextureDescriptor/size}} is not a multiple of the [=texel block width=] and [=texel block height=].
+
+<!-- IMPORTANT: Follow the style of features above. Note this section is always non-normative.
+    When adding a new feature here, also update the GPUFeatureName definition. -->
 
 # Appendices # {#appendices}
 


### PR DESCRIPTION
This PR updates the spec with the feature discussed in https://github.com/gpuweb/gpuweb/issues/2006

Update to the validation test suite is in the following PR: https://github.com/gpuweb/cts/pull/4676