### PR TITLE
wgsl: Define a "fragment" more carefully

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7968,20 +7968,20 @@ The type of the return value [=shader-creation error|must=] match the return typ
 ### Discard Statement ### {#discard-statement}
 
 A <dfn dfn-for="statement">discard</dfn> statement converts the invocation into
-a [=helper invocation=] and throws away the fragment.
+a [=helper invocation=] and throws away the fragment output.
 The `discard` statement [=shader-creation error|must=] only be used in a [=fragment=] shader stage.
 
 More precisely, executing a `discard` statement [=behavioral requirement|will=]:
 
 * convert the current invocation into a [=helper invocation=], and
-* prevent the current fragment from being processed downstream in the [=GPURenderPipeline=].
+* prevent the current fragment output from being processed downstream in the [=GPURenderPipeline=].
 
 Only statements executed prior to the `discard` statement [=behavioral
 requirement|will=] have observable effects.
 
 Note: A `discard` statement may be executed by any
 [=functions in a shader stage|function in a fragment stage=] and the effect is the same:
-the fragment will be thrown away.
+the fragment output will be thrown away.
 
 <div class='example wgsl' heading='Using the discard statement to throw away a fragment'>
   <xmp highlight=wgsl>
@@ -9368,9 +9368,17 @@ two programmable stages among other fixed-function stages:
 * A <dfn noexport>vertex shader stage</dfn> maps input attributes for a single vertex into
     output attributes for the vertex.
 * Fixed-function stages map vertices into graphic primitives (such as triangles)
-    which are then rasterized to produce fragments.
+    which are then rasterized to produce <dfn noexport>rasterization fragments</dfn>.
+    Each rasterization fragment represents the overlap between the primitive
+    being drawn, and a particular
+    pixel in the [=framebuffer=].
 * A <dfn noexport>fragment shader stage</dfn> processes each fragment,
     possibly producing a fragment output.
+    *   Typically, one fragment shader invocation is created for each [=rasterization fragment=].
+        More than one fragment invocation may be created if the rasterization fragment covers multiple
+        samples. See [[WebGPU#per-sample-shading]].
+    *   If the rasterization fragment is near the boundary of the primitive, then additional [=helper invocations=]
+        may also be created. See [[#fragment-shaders-helper-invocations]].
 * Fixed-function stages consume a fragment output, possibly updating external state
     such as color attachments and depth and stencil buffers.
 
@@ -9940,11 +9948,11 @@ Each is described in detail in subsequent sections.
   <tr><td style="width:10%">Description
       <td>
       <div algorithm="fragment position calculation">
-      Input position of the current fragment.
+      Input position of the current fragment rasterization point.
 
-      Let |fp| be the input position of the fragment.<br>
       Let |rp| be the [=RasterizationPoint=] for the fragment.<br>
-      Let |vp| be the {{RenderState/[[viewport]]}} in effect for the draw command.
+      Let |vp| be the {{RenderState/[[viewport]]}} in effect for the draw command.<br>
+      Then |fp| is the computed input position of the fragment rasterization point.
 
       Then schematically:
       <blockquote>
@@ -9955,7 +9963,7 @@ Each is described in detail in subsequent sections.
 
       In more detail:
       *  |fp|.x and |fp|.y are the interpolated x and y coordinates of the
-          position the current fragment in
+          position the current fragment rasterization point in
           the [=framebuffer=].
 
           The framebuffer is a two-dimensional grid of pixels with the top-left at (0.0,0.0)
@@ -9963,12 +9971,12 @@ Each is described in detail in subsequent sections.
           Each pixel has an extent of 1.0 unit in each of the x and y dimensions,
           and pixel centers are at (0.5,0.5) offset from integer coordinates.
 
-      * |fp|.z is the interpolated depth of the current fragment.
+      * |fp|.z is the interpolated depth of the current fragment rasterization point.
           For example:
           * depth 0 in [=normalized device coordinates=] maps to |fp|.z = |vp|.minDepth,
           * depth 1 in normalized device coordinates maps to |fp|.z = |vp|.maxDepth.
 
-      * |fp|.w is the perspective divisor for the fragment,
+      * |fp|.w is the perspective divisor for the fragment rasterization point,
           which is the interpolation of 1.0 &divide; |vertex_w|,
           where |vertex_w| is the w component
           of the [=built-in values/position=] output of the vertex shader.
@@ -10010,7 +10018,8 @@ Each is described in detail in subsequent sections.
       <td>Input
   <tr><td style="width:10%">Description
       <td>
-      Sample index for the current fragment.  The value is least 0 and at most
+      Sample index for the current fragment rasterization point.
+      The value is least 0 and at most
       `sampleCount`-1, where `sampleCount` is the sample
       {{GPUMultisampleState/count}} specified for the GPU render pipeline.
       When this attribute is applied, if the effects of the fragment shader would vary based


### PR DESCRIPTION
It is the overlap between the primitive being drawn and a particular pixel in the framebuffer.

Then mention the 1-1 or 1-to-many relation between fragment and fragment shader invocations.

The WGSL spec already has a 'fragment' as a defined term, referring to the fragment shader stage.  So in certain places this PR says "rasterization fragment" to denote the fragment-as-overlap concept.

Clarify definitions of `position` and `sample_index` to refer to the "fragment rasterization point" rather than just "fragment", so it accommodates sample-rate shading appropriately.

When talking about fragment output, say "fragment output". E.g. discussion of the discard statement.

Issue: #5499