### PR TITLE
wgsl: Don't repeat float literal rules in recursive grammar

### DIFF
--- a/wgsl/tools/analyze/Grammar.py
+++ b/wgsl/tools/analyze/Grammar.py
@@ -155,6 +155,7 @@ class PrintOption:
         self.inline_synthetic = True
         # Emit Bikeshed source
         self.bikeshed = False
+        self.treat_as_syntax_token = set()
 
         def MakeNone():
             return None
@@ -185,9 +186,10 @@ class PrintOption:
         result.print_terminals = self.print_terminals
         result.inline_synthetic = self.inline_synthetic
         result.bikeshed = self.bikeshed
-        result.replace_with_optional = self.replace_with_optional
-        result.replace_with_starred = self.replace_with_starred
-        result.replace_with_nested = self.replace_with_nested
+        result.treat_as_syntax_token = set(self.treat_as_syntax_token)
+        result.replace_with_optional = dict(self.replace_with_optional)
+        result.replace_with_starred = dict(self.replace_with_starred)
+        result.replace_with_nested = dict(self.replace_with_nested)
         result.grammar = self.grammar
         return result
 
@@ -343,7 +345,10 @@ class Rule(RegisterableObject):
                                               '_shift_right_assign']
                         if name in without_underscore:
                             name = name[1:]
-                return "[={}/{}=]".format(context,name)
+                if name in print_option.treat_as_syntax_token:
+                    return "[=syntax/{}=]".format(name)
+                else:
+                    return "[={}/{}=]".format(context,name)
             return name
         if isinstance(rule,Choice):
             parts = [i.pretty_str(print_option) for i in rule]
@@ -2014,6 +2019,8 @@ class Grammar:
         for key in sorted(self.rules):
             if key == LANGUAGE:
                 # This is synthetic, for analysis
+                continue
+            if key in po.treat_as_syntax_token:
                 continue
             rule_content = self.rules[key].pretty_str(po)
             if key in po.replace_with_optional:

--- a/wgsl/tools/analyze/lalr.py
+++ b/wgsl/tools/analyze/lalr.py
@@ -137,7 +137,15 @@ def main():
         g.compute_first()
         g.compute_follow()
 
-        print(g.pretty_str(po))
+        # The float literal rules are a choice over patterns.
+        # There is no point repeating them in the recursive grammar,
+        # and they would be sorted in a strange-looking order.
+        # https://github.com/gpuweb/gpuweb/issues/6307
+        po2 = po.clone()
+        po2.treat_as_syntax_token.add('hex_float_literal')
+        po2.treat_as_syntax_token.add('decimal_float_literal')
+
+        print(g.pretty_str(po2))
         printed = True
 
     else:

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -162,20 +162,6 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>decimal_float_literal</dfn>:
-
- | `/0[fh]/`
-
- | `/[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?[fh]?/`
-
- | `/[0-9]+[eE][+-]?[0-9]+[fh]?/`
-
- | `/[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?[fh]?/`
-
- | `/[1-9][0-9]*[fh]/`
-</div>
-
-<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>decimal_int_literal</dfn>:
 
  | `/0[iu]?/`
@@ -212,9 +198,9 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>float_literal</dfn>:
 
- | [=recursive descent syntax/decimal_float_literal=]
+ | [=syntax/decimal_float_literal=]
 
- | [=recursive descent syntax/hex_float_literal=]
+ | [=syntax/hex_float_literal=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -277,16 +263,6 @@
  | [=recursive descent syntax/attribute=] * `'override'` [=recursive descent syntax/optionally_typed_ident=] ( `'='` [=recursive descent syntax/expression=] )?
 
  | `'const'` [=recursive descent syntax/optionally_typed_ident=] `'='` [=recursive descent syntax/expression=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>hex_float_literal</dfn>:
-
- | `/0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP][+-]?[0-9]+[fh]?)?/`
-
- | `/0[xX][0-9a-fA-F]+[pP][+-]?[0-9]+[fh]?/`
-
- | `/0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*([pP][+-]?[0-9]+[fh]?)?/`
 </div>
 
 <div class='syntax' noexport='true'>


### PR DESCRIPTION
They don't need to be repeated, and they would sort strangely. So treat them as ordinary syntax tokens, and delegate their definitions to the LALR grammar.

Issue: #6307