### PR TITLE
Update proposal statuses.

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -39,9 +39,11 @@ Always refer to the specifications as the source of truth.
 <!-- SECTION status-merged -->
 * [compatibility-mode](compatibility-mode.md)
 * [subgroups](subgroups.md)
+* [immediate-data](immediate-data.md)
 * [texture-component-swizzle](texture-component-swizzle.md)
 * [primitive-index](primitive-index.md)
 * [transient-attachments](transient-attachments.md)
+* [subgroup-size-control](subgroup-size-control.md)
 
 ### Status: Draft
 
@@ -55,7 +57,6 @@ Note however, an implementation might provide an option (e.g. command line flag)
 draft implementation, for developers who want to test this proposal.
 
 <!-- SECTION status-draft -->
-* [immediate-data](immediate-data.md)
 * [texel-buffers](texel-buffers.md)
 * [sized-binding-arrays](sized-binding-arrays.md)
 * [atomic-64-min-max](atomic-64-min-max.md)
@@ -64,7 +65,6 @@ draft implementation, for developers who want to test this proposal.
 * [fragment-depth](fragment-depth.md)
 * [bindless](bindless.md)
 * [buffer-view](buffer-view.md)
-* [subgroup-size-control](subgroup-size-control.md)
 * [bindless-filterability-validation](bindless-filterability-validation.md)
 * [view-instancing](view-instancing.md)
 * [multisampled-array-textures](multisampled-array-textures.md)

--- a/proposals/immediate-data.md
+++ b/proposals/immediate-data.md
@@ -1,6 +1,6 @@
 # ImmediateData
 
-* Status: [Draft](README.md#status-draft)
+* Status: [Merged](README.md#status-merged)
 * Created: 2024-04-29
 * Issue: [#75](https://github.com/gpuweb/gpuweb/issues/75)
 * Spec PR: [#5423](https://github.com/gpuweb/gpuweb/pull/5423)

--- a/proposals/subgroup-size-control.md
+++ b/proposals/subgroup-size-control.md
@@ -1,6 +1,6 @@
 # Subgroup Size Control
 
-* Status: [Draft](README.md#status-draft)
+* Status: [Merged](README.md#status-merged)
 * Created: 2026-01-28
 * Issue: [#5545](https://github.com/gpuweb/gpuweb/issues/5545)
 


### PR DESCRIPTION
Update the `immediate-data.md` and `subgroup-size-control.md` proposals to indicate that they have been merged into the specification.

Regenerate `proposals/README.md`.