### PR TITLE
Fix intra-spec links accidentally pointing to other specs

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1963,7 +1963,7 @@ Extension names are not [=identifiers=]: they do not [=resolves|resolve=] to [=d
       Each argument of pointer type to a [=user-defined function=]
       [=shader-creation error|must=] have the same [=memory view=] as its
       [=root identifier=].
-      * NOTE: This means no [=vector=], [=matrix=], [=array=], or [=struct=] access expressions
+      * NOTE: This means no [=vector=], [=matrix=], [=array=], or [=structure=] access expressions
           can be applied to produce a [=memory view=] into the [=root identifier=] when
           traced from the argument back through all the [=let-declarations=].
   <tr><td><dfn for="language_extension">pointer_composite_access</dfn>
@@ -11998,7 +11998,7 @@ notations:
           Note: Partial assignments include the previous value.
           The assignment either writes only a subset of the stored components,
           or the type of the written value differs from the [=store type=]
-          of the [=originating=] variable.
+          of the [=originating variable=].
   <tr><td>*s1* *s2*<br>
           where *Next* is in behavior of *s1*.
 


### PR DESCRIPTION
* Replace [=originating=] with [=originating variable=]

    Linking to [=originating=] errantly links to the CSS
    spec's concept of "orginate".

* Replace [=struct=] with [=structure=]

    [=struct=] errantly points to the INFRA spec.