### PR TITLE
Fix typo in WGSL spec

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3495,11 +3495,11 @@ If |N| is not greater than 0:
 * It is a [=shader-creation error=] if |N| is a [=const-expression=].
 * Otherwise, It is a [=pipeline-creation error=].
 
-If the [=extension/f16|f16 extension=] is enabled and |N| is not evenly divisble by 2:
+If the [=extension/f16|f16 extension=] is enabled and |N| is not evenly divisible by 2:
 * It is a [=shader-creation error=] if |N| is a [=const-expression=].
 * Otherwise, It is a [=pipeline-creation error=].
 
-If the [=extension/f16|f16 extension=] is not enabled and |N| is not evenly divisble by 4:
+If the [=extension/f16|f16 extension=] is not enabled and |N| is not evenly divisible by 4:
 * It is a [=shader-creation error=] if |N| is a [=const-expression=].
 * Otherwise, It is a [=pipeline-creation error=].
 
@@ -15043,9 +15043,10 @@ The internal layout rules are described in [[#internal-value-layout]].
 <table class='data builtin'>
   <tr><td style="width:10%">Overload
       <td>
-        <xmp highlight=wgsl>@const @must_use fn bitcast<u32>(e : AbstractInt) -> u32
-
-                            @const @must_use fn bitcast<vecN<u32>>(e : vecN<AbstractInt>) -> vecN<u32></xmp>
+        <xmp highlight=wgsl>
+          @const @must_use fn bitcast<u32>(e : AbstractInt) -> u32
+          @const @must_use fn bitcast<vecN<u32>>(e : vecN<AbstractInt>) -> vecN<u32>
+        </xmp>
   <tr><td>Parameterization
       <td>
   <tr><td>Description


### PR DESCRIPTION
Fix a typo (divisble) and fix formatting of an <xmp> block that had an indented newline (see img.)

<img width="722" height="217" alt="divsble typo" src="https://github.com/user-attachments/assets/786f5173-438b-45e7-aea3-063f83a1c7e2" />


<img width="1537" height="400" alt="incorrect indentation in bitcast overload" src="https://github.com/user-attachments/assets/ccc83ba7-abd6-4d1b-994c-6c9d46018283" />
