### PR TITLE
[editorial/bugfix] Dedup feature dependencies, fix missing auto-enablements

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1416,12 +1416,11 @@ implicitly [$valid to use with|unusable$].
 
     1. Let |features| be the [=set=] of values in
         |descriptor|.{{GPUDeviceDescriptor/requiredFeatures}}.
-    1. If |features| contains {{GPUFeatureName/"texture-formats-tier2"}}:
-        1. [=set/Append=] {{GPUFeatureName/"texture-formats-tier1"}} to |features|.
-    1. If |features| contains {{GPUFeatureName/"texture-formats-tier1"}}:
-        1. [=set/Append=] {{GPUFeatureName/"rg11b10ufloat-renderable"}} to |features|.
-    1. Append any default {{GPUFeatureName}}s to |features|
+    1. [=set/Extend=] |features| with any default {{GPUFeatureName}}s
         as defined by the |adapter|.{{adapter/[[default feature level]]}}.
+    1. For each |feature| in |features|:
+        1. [=set/Extend=] |features| with the set of features required (directly or indirectly)
+            by |feature|, as defined in [[#feature-dependencies]].
     1. Let |limits| be a new [=supported limits=] object with the default limits
         as defined by the |adapter|.{{adapter/[[default feature level]]}}.
     1. For each (|key|, |value|) pair in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}:
@@ -1538,6 +1537,72 @@ Note:
 Even where supported, enabling features is not necessarily desirable, as doing so may have a performance impact.
 Because of this, and to improve portability across devices and implementations,
 applications should generally only request features that they may actually require.
+
+<h5 id=gpufeaturename data-dfn-type=enum>`GPUFeatureName`
+<span id=enumdef-gpufeaturename></span>
+</h5>
+
+Each {{GPUFeatureName}} identifies a set of functionality which, if available,
+allows additional usages of WebGPU that would have otherwise been invalid.
+
+<script type=idl>
+enum GPUFeatureName {
+    "core-features-and-limits",
+    "depth-clip-control",
+    "depth32float-stencil8",
+    "texture-compression-bc",
+    "texture-compression-bc-sliced-3d",
+    "texture-compression-etc2",
+    "texture-compression-astc",
+    "texture-compression-astc-sliced-3d",
+    "timestamp-query",
+    "indirect-first-instance",
+    "shader-f16",
+    "rg11b10ufloat-renderable",
+    "bgra8unorm-storage",
+    "float32-filterable",
+    "float32-blendable",
+    "clip-distances",
+    "dual-source-blending",
+    "subgroups",
+    "texture-formats-tier1",
+    "texture-formats-tier2",
+    "primitive-index",
+    "texture-component-swizzle",
+    "subgroup-size-control",
+};
+</script>
+<!-- IMPORTANT: When adding a feature, also update the Feature Index,
+    and if needed the Feature Dependencies section below. -->
+
+#### Feature Dependencies #### {#feature-dependencies}
+
+A more-advanced feature `F2` may require a less-advanced feature `F1`.
+
+- In [[#adapter-capability-guarantees]], adapters with `F2` are guaranteed to also have `F1`.
+- In [=a new device=], devices created with `F2` will also implicitly enable `F1`.
+
+<table class=data dfn-type=attribute dfn-for="supported limits">
+    <thead>
+        <tr><th>This feature... <th>requires these features and their dependencies.
+    </thead>
+
+    <tr><td>{{GPUFeatureName/"texture-formats-tier2"}}
+        <td>
+            - {{GPUFeatureName/"texture-formats-tier1"}}
+    <tr><td>{{GPUFeatureName/"texture-formats-tier1"}}
+        <td>
+            - {{GPUFeatureName/"rg11b10ufloat-renderable"}}
+    <tr><td>{{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
+        <td>
+            - {{GPUFeatureName/"texture-compression-bc"}}
+    <tr><td>{{GPUFeatureName/"texture-compression-astc-sliced-3d"}}
+        <td>
+            - {{GPUFeatureName/"texture-compression-astc"}}
+    <tr><td>{{GPUFeatureName/"subgroup-size-control"}}
+        <td>
+            - {{GPUFeatureName/"subgroups"}}
+</table>
 
 ### Limits ### {#limits}
 
@@ -2572,10 +2637,9 @@ Any {{GPUAdapter}} returned by {{GPU/requestAdapter()}} must provide the followi
     - {{GPUFeatureName/"texture-compression-bc"}} is supported.
     - Both {{GPUFeatureName/"texture-compression-etc2"}} and
         {{GPUFeatureName/"texture-compression-astc"}} are supported.
-- If {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}
-    is supported, then {{GPUFeatureName/"texture-compression-bc"}} must be supported.
-- If {{GPUFeatureName/"texture-compression-astc-sliced-3d"}}
-    is supported, then {{GPUFeatureName/"texture-compression-astc"}} must be supported.
+- For each |feature| supported by the device:
+    - The adapter must also support all of the features required (directly or indirectly)
+        by |feature|, as defined in [[#feature-dependencies]].
 - All supported limits must be either the [=limit/default=] value or [=limit/better=].
 - All [=limit class/alignment|alignment-class=] limits must be powers of 2.
 - {{supported limits/maxBindingsPerBindGroup}} must be must be &ge;
@@ -3031,41 +3095,6 @@ dictionary GPUDeviceDescriptor
         });
     </pre>
 </div>
-
-<h5 id=gpufeaturename data-dfn-type=enum>`GPUFeatureName`
-<span id=enumdef-gpufeaturename></span>
-</h5>
-
-Each {{GPUFeatureName}} identifies a set of functionality which, if available,
-allows additional usages of WebGPU that would have otherwise been invalid.
-
-<script type=idl>
-enum GPUFeatureName {
-    "core-features-and-limits",
-    "depth-clip-control",
-    "depth32float-stencil8",
-    "texture-compression-bc",
-    "texture-compression-bc-sliced-3d",
-    "texture-compression-etc2",
-    "texture-compression-astc",
-    "texture-compression-astc-sliced-3d",
-    "timestamp-query",
-    "indirect-first-instance",
-    "shader-f16",
-    "rg11b10ufloat-renderable",
-    "bgra8unorm-storage",
-    "float32-filterable",
-    "float32-blendable",
-    "clip-distances",
-    "dual-source-blending",
-    "subgroups",
-    "texture-formats-tier1",
-    "texture-formats-tier2",
-    "primitive-index",
-    "texture-component-swizzle",
-    "subgroup-size-control",
-};
-</script>
 
 <h3 id=gpudevice data-dfn-type=interface>`GPUDevice`
 <span id=gpu-device></span>
@@ -17587,6 +17616,8 @@ This feature adds no [=optional API surfaces=].
 
 - New WGSL extensions:
     - [=extension/subgroup_size_control=]
+
+<!-- IMPORTANT: When adding a new feature here, also update the GPUFeatureName definition. -->
 
 # Appendices # {#appendices}
 


### PR DESCRIPTION
Previously this was defined separately in "Adapter Capability Guarantees", "a new device", and the "Feature Index".

This fixes a bunch of stuff that was missing:
- "a new device" missing:
  - `texture-compression-bc-sliced-3d`&rarr;`texture-compression-bc`
  - `texture-compression-astc-sliced-3d`&rarr;`texture-compression-astc`
- "Adapter Capability Guarantees" missing:
  - `texture-formats-tier2`&rarr;`texture-formats-tier1`&rarr;`rg11b10ufloat-renderable`

Also moves the definition of `GPUFeatureName` to the "Optional Capabilities" section to be consistent with limits.