### PR TITLE
[subgroup-matrix] Relax load/store array requirements

### DIFF
--- a/proposals/subgroup-matrix.md
+++ b/proposals/subgroup-matrix.md
@@ -369,7 +369,7 @@ Define `MinorSize(T, Majorness)` as:
 For both load and store built-in functions the pointer `p` must encompass
 enough memory locations (i.e. point to a large enough amount of bytes) to
 access a minimally sized subgroupMatrix.
-For a subgroup matix with `M` rows, `N` columns, and a component type `C`, define `MinStorageSize(T)` as `M * N * Size(C)`.
+For a subgroup matix with `M` rows, `N` columns, and a component type `C`, define `MinStorageSize(T)` as `M * N * SizeOf(C)`.
 This requirement translates to a minimum required variable size.
 For workgroup variables it is the size of the variable.
 For storage variables it constrains the minimum binding size.
@@ -387,14 +387,13 @@ predicated control flow.
 **Overload**:
 ```rust
 @must_use fn
-subgroupMatrixLoad<T, Majorness>(p : ptr<AS, SA, AM>,
+subgroupMatrixLoad<T, Majorness>(p : ptr<AS, A, AM>,
                                  offset : u32,
                                  stride : u32) -> T
-```
 
 **Preconditions**:<br>
 T is a subgroup matrix type with component type C and shader scalar type S.<br>
-SA is an array with type S.<br>
+A is an array with a scalar or vector numeric type, SA.<br>
 AS is storage or workgroup.<br>
 AM is read or read_write.
 
@@ -405,24 +404,28 @@ Triggers a `subgroup_matrix_uniformity` diagnostic if
 uniformity analysis cannot prove p, offset, or stride are subgroup uniform
 values.
 
-stride counts elements of the array SA.
+stride counts elements of the array A.
 
-If `stride * SizeOf(S) < MinorSize(T, Majorness) * SizeOf(T)`, then:
+If `stride * SizeOf(SA) < MinorSize(T, Majorness) * SizeOf(C)`, then:
 * It is a shader-creation error if `stride` is a const-expression
 * It is a pipeline-creation error if `stride` is an override-expression
 * It is a dynamic error otherwise
 
-If SA is a fixed-size array with element count `N` and
-`offset + stride * (MajorSize(T, Majorness) - 1) + MinorSize(T, Majorness) > N * SizeOf(S) / SizeOf(C)` then:
+If A is a fixed-size array with element count `N` and
+`(offset + stride * (MajorSize(T, Majorness - 1)) * SizeOf(SA) + MinorSize(T, Majorness) * SizeOf(C) > N * SizeOf(SA)`, then:
 * It is a shader-creation error if `N` is a const-expression and
-    `offset` or `stride` is a const-expression (using 0 if either is not)
+    `offset` or `stride` is a const-expression.
+    * Use 0 for `offset` if it is not a const-expression
+    * Use `RoundUp(SizeOf(SA), MinorSize(T, Majorness) * SizeOf(C))` for `stride` if is not a const-expression
 * It is a pipeline-creation error if `N` is an override-expression and
-    `offset` or `stride` is an override-expression (using 0 if either is not)
+    `offset` or `stride` is an override-expression
+    * Use 0 for `offset` if it is not an override-expression
+    * Use `RoundUp(SizeOf(SA), MinorSize(T, Majorness) * SizeOf(C))` for `stride` if is not an override-expression
 * It is a dynamic error otherwise
 
 **Overload**:<br>
 ```rust
-fn subgroupMatrixStore<Majorness>(p : ptr<AS, SA, AM>,
+fn subgroupMatrixStore<Majorness>(p : ptr<AS, A, AM>,
                                   offset : u32,
                                   value : T,
                                   stride : u32)
@@ -430,7 +433,7 @@ fn subgroupMatrixStore<Majorness>(p : ptr<AS, SA, AM>,
 
 **Preconditions**:<br>
 T is a subgroup matrix type with component type C and scalar shader type S.<br>
-SA is an array with element type S.<br>
+A is an array with a scalar or vector numeric type, SA.<br>
 AS is storage or workgroup.<br>
 AM is write or read_write.
 
@@ -441,19 +444,23 @@ Triggers a `subgroup_matrix_uniformity` diagnostic if
 uniformity analysis cannot prove p, offset, value, or stride are subgroup
 uniform values.
 
-stride counts elements of the array SA.
+stride counts elements of the array A.
 
-If `stride * SizeOf(S) < MinorSize(T, Majorness) * SizeOf(T)`, then:
+If `stride * SizeOf(SA) < MinorSize(T, Majorness) * SizeOf(C)`, then:
 * It is a shader-creation error if `stride` is a const-expression
 * It is a pipeline-creation error if `stride` is an override-expression
 * It is a dynamic error otherwise
 
-If SA is a fixed-size array with element count `N` and
-`offset + stride * (MajorSize(T, Majorness) - 1) + MinorSize(T, Majorness) > N * SizeOf(S) / SizeOf(C)` then:
+If A is a fixed-size array with element count `N` and
+`(offset + stride * (MajorSize(T, Majorness - 1)) * SizeOf(SA) + MinorSize(T, Majorness) * SizeOf(C) > N * SizeOf(SA)`, then:
 * It is a shader-creation error if `N` is a const-expression and
-    `offset` or `stride` is a const-expression (using 0 if either is not)
+    `offset` or `stride` is a const-expression
+    * Use 0 for `offset` if it is not a const-expression
+    * Use `RoundUp(SizeOf(SA), MinorSize(T, Majorness) * SizeOf(C))` for `stride` if is not a const-expression
 * It is a pipeline-creation error if `N` is an override-expression and
-    `offset` or `stride` is an override-expression (using 0 if either is not)
+    `offset` or `stride` is an override-expression
+    * Use 0 for `offset` if it is not an override-expression
+    * Use `RoundUp(SizeOf(SA), MinorSize(T, Majorness) * SizeOf(C))` for `stride` if is not an override-expression
 * It is a dynamic error otherwise
 
 ##### Matrix arithmetic functions

--- a/proposals/subgroup-matrix.md
+++ b/proposals/subgroup-matrix.md
@@ -406,21 +406,21 @@ values.
 
 stride counts elements of the array A.
 
-If `stride * SizeOf(SA) < MinorSize(T, Majorness) * SizeOf(C)`, then:
+If `stride * StrideOf(A) < MinorSize(T, Majorness) * SizeOf(C)`, then:
 * It is a shader-creation error if `stride` is a const-expression
 * It is a pipeline-creation error if `stride` is an override-expression
 * It is a dynamic error otherwise
 
 If A is a fixed-size array with element count `N` and
-`(offset + stride * (MajorSize(T, Majorness - 1)) * SizeOf(SA) + MinorSize(T, Majorness) * SizeOf(C) > N * SizeOf(SA)`, then:
+`(offset + stride * (MajorSize(T, Majorness - 1)) * StrideOf(A) + MinorSize(T, Majorness) * SizeOf(C) > N * StrideOf(A)`, then:
 * It is a shader-creation error if `N` is a const-expression and
     `offset` or `stride` is a const-expression.
     * Use 0 for `offset` if it is not a const-expression
-    * Use `RoundUp(SizeOf(SA), MinorSize(T, Majorness) * SizeOf(C))` for `stride` if is not a const-expression
+    * Use `RoundUp(StrideOf(A), MinorSize(T, Majorness) * SizeOf(C))` for `stride` if is not a const-expression
 * It is a pipeline-creation error if `N` is an override-expression and
     `offset` or `stride` is an override-expression
     * Use 0 for `offset` if it is not an override-expression
-    * Use `RoundUp(SizeOf(SA), MinorSize(T, Majorness) * SizeOf(C))` for `stride` if is not an override-expression
+    * Use `RoundUp(StrideOf(A), MinorSize(T, Majorness) * SizeOf(C))` for `stride` if is not an override-expression
 * It is a dynamic error otherwise
 
 **Overload**:<br>
@@ -446,21 +446,21 @@ uniform values.
 
 stride counts elements of the array A.
 
-If `stride * SizeOf(SA) < MinorSize(T, Majorness) * SizeOf(C)`, then:
+If `stride * StrideOf(A) < MinorSize(T, Majorness) * SizeOf(C)`, then:
 * It is a shader-creation error if `stride` is a const-expression
 * It is a pipeline-creation error if `stride` is an override-expression
 * It is a dynamic error otherwise
 
 If A is a fixed-size array with element count `N` and
-`(offset + stride * (MajorSize(T, Majorness - 1)) * SizeOf(SA) + MinorSize(T, Majorness) * SizeOf(C) > N * SizeOf(SA)`, then:
+`(offset + stride * (MajorSize(T, Majorness - 1)) * StrideOf(A) + MinorSize(T, Majorness) * SizeOf(C) > N * StrideOf(A)`, then:
 * It is a shader-creation error if `N` is a const-expression and
     `offset` or `stride` is a const-expression
     * Use 0 for `offset` if it is not a const-expression
-    * Use `RoundUp(SizeOf(SA), MinorSize(T, Majorness) * SizeOf(C))` for `stride` if is not a const-expression
+    * Use `RoundUp(StrideOf(A), MinorSize(T, Majorness) * SizeOf(C))` for `stride` if is not a const-expression
 * It is a pipeline-creation error if `N` is an override-expression and
     `offset` or `stride` is an override-expression
     * Use 0 for `offset` if it is not an override-expression
-    * Use `RoundUp(SizeOf(SA), MinorSize(T, Majorness) * SizeOf(C))` for `stride` if is not an override-expression
+    * Use `RoundUp(StrideOf(A), MinorSize(T, Majorness) * SizeOf(C))` for `stride` if is not an override-expression
 * It is a dynamic error otherwise
 
 ##### Matrix arithmetic functions

--- a/proposals/subgroup-matrix.md
+++ b/proposals/subgroup-matrix.md
@@ -182,7 +182,7 @@ Add new types:
         *   The have matching row counts
         *   The have matching column counts
 *   T is the component type and must be one of the entries in the table
-    *   The scalar shader type is the associated type usable in the shader code for scalar operations and data representation in memory
+    *   The scalar shader type is the associated type usable in the shader code for scalar operations
     *   Can be expanded in the future to support more types (e.g. bfloat16) via new enables.
     *   The u8 and i8 cases are predeclared types that are not otherwise usable in WGSL. For layout calculations, they are of size 1 byte and have an alignment requirement of 1 byte.
 
@@ -250,17 +250,14 @@ The builtins do two things:
     where the [0,0]’th element of the matrix is stored.
     Then
     *   For row-major:
-        *   Matrix entry [r,c] maps to the SizeOf(T) bytes located at Base + Stride\*r\*Sizeof(S) + SizeOf(T)\*c,
-            where S is the shader scalar type of T
+        *   Matrix entry [r,c] maps to the SizeOf(T) bytes located at Base + Stride\*r\*StrideOf(A) + SizeOf(T)\*c,
+            where A is the array type in memory
         *   Stride >= number of matrix columns.
     *   For column-major:
-        *   Matrix entry [r,c] maps to the SizeOf(T) bytes located at Base + Stride\*c\*SizeOf(S) + SizeOf(T)\*r,
-            where S is the shader scalar type of T
+        *   Matrix entry [r,c] maps to the SizeOf(T) bytes located at Base + Stride\*c\*StrideOf(A) + SizeOf(T)\*r,
+            where A is the array type in memory
         *   Stride >= number of matrix rows.
-*   Reinterpret data values between the shader scalar type and the external
-    component type T, when those types differ.
-*   Note: `subgroupMatrixLoad` and `subgroupMatrixStore` describe Stride in terms of
-        the external memory array element type.
+*   Reinterpret data values between the matrix component type and memory array element type.
 
 #### Attributes
 
@@ -392,8 +389,9 @@ subgroupMatrixLoad<T, Majorness>(p : ptr<AS, A, AM>,
                                  stride : u32) -> T
 
 **Preconditions**:<br>
-T is a subgroup matrix type with component type C and shader scalar type S.<br>
-A is an array with a scalar or vector numeric type, SA.<br>
+T is a subgroup matrix type with component type C.<br>
+A is an array with an element type SA.<br>
+SA is scalar or vector numeric type.<br>
 AS is storage or workgroup.<br>
 AM is read or read_write.
 
@@ -432,8 +430,9 @@ fn subgroupMatrixStore<Majorness>(p : ptr<AS, A, AM>,
 ```
 
 **Preconditions**:<br>
-T is a subgroup matrix type with component type C and scalar shader type S.<br>
-A is an array with a scalar or vector numeric type, SA.<br>
+T is a subgroup matrix type with component type C.<br>
+A is an array with an element type SA.<br>
+SA is scalar or vector numeric type.<br>
 AS is storage or workgroup.<br>
 AM is write or read_write.
 


### PR DESCRIPTION
* Relax the allowed array types for use with subgroupMatrixLoad and subgroupMatrixStore
  * allow any numeric scalar or vector type as the array element type
* Fix some typos