### PR TITLE
[wgsl]: clarify where attributes can be used on function params and r…

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8614,11 +8614,12 @@ A <dfn noexport>function declaration</dfn> creates a <dfn noexport>user-defined 
 * An optional set of [=attributes=].
 * The name of the function.
 * The formal parameter list: an ordered sequence of zero
-    or more [=formal parameter=] declarations,
-    which may have attributes applied,
-    separated by commas, and
-    surrounded by parentheses.
-* An optional <dfn noexport>return type</dfn>, which may have attributes applied.
+    or more [=formal parameter=] declarations, separated by commas, and surrounded by parentheses.
+    * If the function is an [=entry point=], then the parameters may have attributes,
+        to specify the parameters as [=shader stage inputs=].
+* An optional <dfn noexport>return type</dfn>.
+    * If the function is an [=entry point=], then the return type may have attributes,
+        to specify [=shader stage outputs=].
 * The <dfn noexport>function body</dfn>.
     This is the set of statements to be executed when the function is [=function call|called=].
 
@@ -8629,7 +8630,7 @@ Note: Each [=user-defined function=] only has one [=overload=].
 
 A <dfn noexport>formal parameter</dfn> [=declaration=] specifies an [=identifier=] name and a type for a value that [=shader-creation error|must=] be
 provided when invoking the function.
-A formal parameter may have attributes.
+A formal parameter of an [=entry point=] function may have attributes.
 See [[#function-calls]].
 The [=scope=] of the identifier is the [=function body=].
 Two formal parameters for a given function [=shader-creation error|must not=] have the same name.
@@ -8644,14 +8645,6 @@ WGSL defines the following attributes that can be applied to function declaratio
  * the [=shader stage attributes=]: [=attribute/vertex=], [=attribute/fragment=], and [=attribute/compute=]
  * [=attribute/workgroup_size=]
  * [=attribute/subgroup_size=]
-
-WGSL defines the following attributes that can be applied to function
-parameters and return types:
- * [=attribute/builtin=]
- * [=attribute/location=]
- * [=attribute/blend_src=]
- * [=attribute/interpolate=]
- * [=attribute/invariant=]
 
 <pre class=include>
 path: syntax/function_decl.syntax.bs.include


### PR DESCRIPTION
…eturns

Avoid listing IO attributes in the user-declared function section. The IO attributes are already limited to being applied to entry point params, entry point return type specification, or members of structs. So in the user-defined section we don't need to list the IO attributes again.

Instead, mention that *entry point* params and return types may have attributes to specify them as shader stage inputs and outputs, then link to those terms and let the other section do the work of listing the IO attributes.

Fixed: #5552