### PR TITLE
[editorial] Editing on Feature Index

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1515,15 +1515,14 @@ All [=features=] are optional, but [=adapters=] make some guarantees about their
 (see [[#adapter-capability-guarantees]]).
 
 A [=device=] supports the exact set of features determined at creation (see [[#optional-capabilities]]).
-API calls perform validation according to these features (not the [=adapter=]'s features):
+API calls perform validation according to the device's features (not the [=adapter=]'s features):
 
-- Using existing API surfaces in a new way **typically** results in a [$validation error$].
-- There are several types of <dfn dfn>optional API surface</dfn>:
-    - Using a new method or enum value always throws a {{TypeError}}.
-    - Using a new dictionary member with a (correctly-typed) non-default value **typically**
-        results in a [$validation error$].
-    - Using a new WGSL `enable` directive always results in a {{GPUDevice/createShaderModule()}}
-        [$validation error$].
+- Using existing API surfaces in a non-enabled way **typically** results in a [$validation error$].
+- Using a non-enabled method or enum value always throws a {{TypeError}}.
+- Using a non-enabled dictionary member with a (correctly-typed) non-default value **typically**
+    results in a [$validation error$].
+- Using a non-enabled WGSL `enable` directive always results in a {{GPUDevice/createShaderModule()}}
+    [$validation error$].
 
 <div algorithm data-timeline=const>
     A {{GPUFeatureName}} |feature| is <dfn dfn>enabled for</dfn>
@@ -17249,10 +17248,18 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 
 # Feature Index # {#feature-index}
 
+*This section non-normative.*
+
+This section describes what is enabled by each feature in {{GPUFeatureName}}.
+Normative behavior is found in the relevant spec sections.
+
+Dependencies between features are described in [[#feature-dependencies]] and enforced in
+[[#adapter-capability-guarantees]] and [=a new device=].
+
 <h3 id=core-features-and-limits data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"core-features-and-limits"`
 </h3>
 
-Allows all Core WebGPU features and limits to be used.
+- Allows all Core WebGPU features and limits to be used.
 
 This is always available unless {{GPURequestAdapterOptions/featureLevel}} is set to [=feature level string/"compatibility"=],
 in which case it may or may not be available (see those definitions for information).
@@ -17261,361 +17268,321 @@ in which case it may or may not be available (see those definitions for informat
 <span id=dom-gpufeaturename-depth-clip-control></span>
 </h3>
 
-Allows [=depth clipping=] to be disabled.
+- Allows [=depth clipping=] to be disabled.
 
-This feature adds the following [=optional API surfaces=]:
+New {{GPUPrimitiveState}} dictionary members:
 
-- New {{GPUPrimitiveState}} dictionary members:
-    - {{GPUPrimitiveState/unclippedDepth}}
+- {{GPUPrimitiveState/unclippedDepth}}
 
 <h3 id=depth32float-stencil8 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"depth32float-stencil8"`
 <span id=dom-gpufeaturename-depth32float-stencil8></span>
 </h3>
 
-Allows for explicit creation of textures of format {{GPUTextureFormat/"depth32float-stencil8"}}.
+- Allows for explicit creation of textures of format {{GPUTextureFormat/"depth32float-stencil8"}}.
 
-This feature adds the following [=optional API surfaces=]:
+New {{GPUTextureFormat}} enum values:
 
-- New {{GPUTextureFormat}} enum values:
-    - {{GPUTextureFormat/"depth32float-stencil8"}}
+- {{GPUTextureFormat/"depth32float-stencil8"}}
 
 <h3 id=texture-compression-bc data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-bc"`
 <span id=dom-gpufeaturename-texture-compression-bc></span>
 </h3>
 
-Allows for explicit creation of textures of [=BC compressed formats=] which include the "S3TC",
-"RGTC", and "BPTC" formats. Only supports 2D textures.
+- Allows for explicit creation of textures of [=BC compressed formats=] which include the "S3TC",
+    "RGTC", and "BPTC" formats.
 
-Note: Adapters which support {{GPUFeatureName/"texture-compression-bc"}} do not
-always support {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}.
-To use {{GPUFeatureName/"texture-compression-bc-sliced-3d"}},
-{{GPUFeatureName/"texture-compression-bc"}} must be enabled explicitly as this feature
-does not enable the BC formats.
+This feature only supports 2D textures. If 3D textures are needed, use
+{{GPUFeatureName/"texture-compression-bc-sliced-3d"}}.
 
-This feature adds the following [=optional API surfaces=]:
+New {{GPUTextureFormat}} enum values:
 
-- New {{GPUTextureFormat}} enum values:
-    - {{GPUTextureFormat/"bc1-rgba-unorm"}}
-    - {{GPUTextureFormat/"bc1-rgba-unorm-srgb"}}
-    - {{GPUTextureFormat/"bc2-rgba-unorm"}}
-    - {{GPUTextureFormat/"bc2-rgba-unorm-srgb"}}
-    - {{GPUTextureFormat/"bc3-rgba-unorm"}}
-    - {{GPUTextureFormat/"bc3-rgba-unorm-srgb"}}
-    - {{GPUTextureFormat/"bc4-r-unorm"}}
-    - {{GPUTextureFormat/"bc4-r-snorm"}}
-    - {{GPUTextureFormat/"bc5-rg-unorm"}}
-    - {{GPUTextureFormat/"bc5-rg-snorm"}}
-    - {{GPUTextureFormat/"bc6h-rgb-ufloat"}}
-    - {{GPUTextureFormat/"bc6h-rgb-float"}}
-    - {{GPUTextureFormat/"bc7-rgba-unorm"}}
-    - {{GPUTextureFormat/"bc7-rgba-unorm-srgb"}}
+- {{GPUTextureFormat/"bc1-rgba-unorm"}}
+- {{GPUTextureFormat/"bc1-rgba-unorm-srgb"}}
+- {{GPUTextureFormat/"bc2-rgba-unorm"}}
+- {{GPUTextureFormat/"bc2-rgba-unorm-srgb"}}
+- {{GPUTextureFormat/"bc3-rgba-unorm"}}
+- {{GPUTextureFormat/"bc3-rgba-unorm-srgb"}}
+- {{GPUTextureFormat/"bc4-r-unorm"}}
+- {{GPUTextureFormat/"bc4-r-snorm"}}
+- {{GPUTextureFormat/"bc5-rg-unorm"}}
+- {{GPUTextureFormat/"bc5-rg-snorm"}}
+- {{GPUTextureFormat/"bc6h-rgb-ufloat"}}
+- {{GPUTextureFormat/"bc6h-rgb-float"}}
+- {{GPUTextureFormat/"bc7-rgba-unorm"}}
+- {{GPUTextureFormat/"bc7-rgba-unorm-srgb"}}
 
 <h3 id=texture-compression-bc-sliced-3d data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-bc-sliced-3d"`
 <span id=dom-gpufeaturename-texture-compression-bc-sliced-3d></span>
 </h3>
 
-Allows the {{GPUTextureDimension/3d}} dimension for textures with [=BC compressed formats=].
-
-Note: Adapters which support {{GPUFeatureName/"texture-compression-bc"}} do not
-always support {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}.
-To use {{GPUFeatureName/"texture-compression-bc-sliced-3d"}},
-{{GPUFeatureName/"texture-compression-bc"}} must be enabled explicitly as this feature
-does not enable the BC formats.
-
-This feature adds no [=optional API surfaces=].
+- Allows the {{GPUTextureDimension/3d}} dimension for textures with [=BC compressed formats=].
 
 <h3 id=texture-compression-etc2 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-etc2"`
 <span id=texture-compression-etc></span>
 <span id=dom-gpufeaturename-texture-compression-etc2></span>
 </h3>
 
-Allows for explicit creation of textures of [=ETC2 compressed formats=]. Only supports 2D textures.
+- Allows for explicit creation of textures of [=ETC2 compressed formats=].
 
-This feature adds the following [=optional API surfaces=]:
+This feature only supports 2D textures.
 
-- New {{GPUTextureFormat}} enum values:
-    - {{GPUTextureFormat/"etc2-rgb8unorm"}}
-    - {{GPUTextureFormat/"etc2-rgb8unorm-srgb"}}
-    - {{GPUTextureFormat/"etc2-rgb8a1unorm"}}
-    - {{GPUTextureFormat/"etc2-rgb8a1unorm-srgb"}}
-    - {{GPUTextureFormat/"etc2-rgba8unorm"}}
-    - {{GPUTextureFormat/"etc2-rgba8unorm-srgb"}}
-    - {{GPUTextureFormat/"eac-r11unorm"}}
-    - {{GPUTextureFormat/"eac-r11snorm"}}
-    - {{GPUTextureFormat/"eac-rg11unorm"}}
-    - {{GPUTextureFormat/"eac-rg11snorm"}}
+New {{GPUTextureFormat}} enum values:
+
+- {{GPUTextureFormat/"etc2-rgb8unorm"}}
+- {{GPUTextureFormat/"etc2-rgb8unorm-srgb"}}
+- {{GPUTextureFormat/"etc2-rgb8a1unorm"}}
+- {{GPUTextureFormat/"etc2-rgb8a1unorm-srgb"}}
+- {{GPUTextureFormat/"etc2-rgba8unorm"}}
+- {{GPUTextureFormat/"etc2-rgba8unorm-srgb"}}
+- {{GPUTextureFormat/"eac-r11unorm"}}
+- {{GPUTextureFormat/"eac-r11snorm"}}
+- {{GPUTextureFormat/"eac-rg11unorm"}}
+- {{GPUTextureFormat/"eac-rg11snorm"}}
 
 <h3 id=texture-compression-astc data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-astc"`
 <span id=dom-gpufeaturename-texture-compression-astc></span>
 </h3>
 
-Allows for explicit creation of textures of [=ASTC compressed formats=]. Only supports 2D textures.
+- Allows for explicit creation of textures of [=ASTC compressed formats=].
 
-This feature adds the following [=optional API surfaces=]:
+This feature only supports 2D textures. If 3D textures are needed, use
+{{GPUFeatureName/"texture-compression-astc-sliced-3d"}}.
 
-- New {{GPUTextureFormat}} enum values:
-    - {{GPUTextureFormat/"astc-4x4-unorm"}}
-    - {{GPUTextureFormat/"astc-4x4-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-5x4-unorm"}}
-    - {{GPUTextureFormat/"astc-5x4-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-5x5-unorm"}}
-    - {{GPUTextureFormat/"astc-5x5-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-6x5-unorm"}}
-    - {{GPUTextureFormat/"astc-6x5-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-6x6-unorm"}}
-    - {{GPUTextureFormat/"astc-6x6-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-8x5-unorm"}}
-    - {{GPUTextureFormat/"astc-8x5-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-8x6-unorm"}}
-    - {{GPUTextureFormat/"astc-8x6-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-8x8-unorm"}}
-    - {{GPUTextureFormat/"astc-8x8-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-10x5-unorm"}}
-    - {{GPUTextureFormat/"astc-10x5-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-10x6-unorm"}}
-    - {{GPUTextureFormat/"astc-10x6-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-10x8-unorm"}}
-    - {{GPUTextureFormat/"astc-10x8-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-10x10-unorm"}}
-    - {{GPUTextureFormat/"astc-10x10-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-12x10-unorm"}}
-    - {{GPUTextureFormat/"astc-12x10-unorm-srgb"}}
-    - {{GPUTextureFormat/"astc-12x12-unorm"}}
-    - {{GPUTextureFormat/"astc-12x12-unorm-srgb"}}
+New {{GPUTextureFormat}} enum values:
+
+- {{GPUTextureFormat/"astc-4x4-unorm"}}
+- {{GPUTextureFormat/"astc-4x4-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-5x4-unorm"}}
+- {{GPUTextureFormat/"astc-5x4-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-5x5-unorm"}}
+- {{GPUTextureFormat/"astc-5x5-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-6x5-unorm"}}
+- {{GPUTextureFormat/"astc-6x5-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-6x6-unorm"}}
+- {{GPUTextureFormat/"astc-6x6-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-8x5-unorm"}}
+- {{GPUTextureFormat/"astc-8x5-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-8x6-unorm"}}
+- {{GPUTextureFormat/"astc-8x6-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-8x8-unorm"}}
+- {{GPUTextureFormat/"astc-8x8-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-10x5-unorm"}}
+- {{GPUTextureFormat/"astc-10x5-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-10x6-unorm"}}
+- {{GPUTextureFormat/"astc-10x6-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-10x8-unorm"}}
+- {{GPUTextureFormat/"astc-10x8-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-10x10-unorm"}}
+- {{GPUTextureFormat/"astc-10x10-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-12x10-unorm"}}
+- {{GPUTextureFormat/"astc-12x10-unorm-srgb"}}
+- {{GPUTextureFormat/"astc-12x12-unorm"}}
+- {{GPUTextureFormat/"astc-12x12-unorm-srgb"}}
 
 <h3 id=texture-compression-astc-sliced-3d data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-astc-sliced-3d"`
 <span id=dom-gpufeaturename-texture-compression-astc-sliced-3d></span>
 </h3>
 
-Allows the {{GPUTextureDimension/3d}} dimension for textures with [=ASTC compressed formats=].
-
-Note: Adapters which support {{GPUFeatureName/"texture-compression-astc"}} do not
-always support {{GPUFeatureName/"texture-compression-astc-sliced-3d"}}.
-To use {{GPUFeatureName/"texture-compression-astc-sliced-3d"}},
-{{GPUFeatureName/"texture-compression-astc"}} must be enabled explicitly as this feature
-does not enable the ASTC formats.
-
-This feature adds no [=optional API surfaces=].
+- Allows the {{GPUTextureDimension/3d}} dimension for textures with [=ASTC compressed formats=].
 
 <h3 id=timestamp-query data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"timestamp-query"`
 <span id=dom-gpufeaturename-timestamp-query></span>
 </h3>
 
-Adds the ability to query timestamps from GPU command buffers. See [[#timestamp]].
+- Adds the ability to query timestamps from GPU command buffers. See [[#timestamp]].
 
-This feature adds the following [=optional API surfaces=]:
+New {{GPUQueryType}} values:
 
-- New {{GPUQueryType}} values:
-    - {{GPUQueryType/"timestamp"}}
-- New {{GPUComputePassDescriptor}} members:
-    - {{GPUComputePassDescriptor/timestampWrites}}
-- New {{GPURenderPassDescriptor}} members:
-    - {{GPURenderPassDescriptor/timestampWrites}}
+- {{GPUQueryType/"timestamp"}}
+
+New {{GPUComputePassDescriptor}} members:
+
+- {{GPUComputePassDescriptor/timestampWrites}}
+
+New {{GPURenderPassDescriptor}} members:
+
+- {{GPURenderPassDescriptor/timestampWrites}}
 
 <h3 id=indirect-first-instance data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"indirect-first-instance"`
 <span id=dom-gpufeaturename-indirect-first-instance></span>
 </h3>
 
-Allows the use of non-zero `firstInstance` values in [=indirect draw parameters=] and [=indirect drawIndexed parameters=].
-
-This feature adds no [=optional API surfaces=].
+- Allows the use of non-zero `firstInstance` values in [=indirect draw parameters=] and [=indirect drawIndexed parameters=].
 
 <h3 id=shader-f16 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"shader-f16"`
 <span id=dom-gpufeaturename-shader-f16></span>
 </h3>
 
-Allows the use of the half-precision floating-point type [=f16=] in WGSL.
+- Allows the use of the half-precision floating-point type [=f16=] in WGSL.
 
-This feature adds the following [=optional API surfaces=]:
+New WGSL extensions:
 
-- New WGSL extensions:
-    - [=extension/f16=]
+- [=extension/f16=]
 
 <h3 id=rg11b10ufloat-renderable data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"rg11b10ufloat-renderable"`
 <span id=dom-gpufeaturename-rg11b10ufloat-renderable></span>
 </h3>
 
-Allows the {{GPUTextureUsage/RENDER_ATTACHMENT}} usage on textures with format {{GPUTextureFormat/"rg11b10ufloat"}},
-and also allows textures of that format to be blended, multisampled, and resolved.
-
-Implicitly allows {{GPUTextureFormat/"rg11b10ufloat"}} as a destination format in {{GPUQueue/copyExternalImageToTexture()}}.
-
-This feature adds no [=optional API surfaces=].
-
-Note: This feature is automatically enabled by {{GPUFeatureName/"texture-formats-tier1"}},
-which is automatically enabled by {{GPUFeatureName/"texture-formats-tier2"}}.
+- Allows the {{GPUTextureUsage/RENDER_ATTACHMENT}} usage on textures with format {{GPUTextureFormat/"rg11b10ufloat"}},
+    and also allows textures of that format to be blended, multisampled, and resolved.
+- Implicitly, allows {{GPUTextureFormat/"rg11b10ufloat"}} as a destination format in {{GPUQueue/copyExternalImageToTexture()}}.
 
 <h3 id=bgra8unorm-storage data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"bgra8unorm-storage"`
 </h3>
 
-Allows the {{GPUTextureUsage/STORAGE_BINDING}} usage on textures with format {{GPUTextureFormat/"bgra8unorm"}}.
-
-This feature adds no [=optional API surfaces=].
+- Allows the {{GPUTextureUsage/STORAGE_BINDING}} usage on textures with format {{GPUTextureFormat/"bgra8unorm"}}.
 
 <h3 id=float32-filterable data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"float32-filterable"`
 </h3>
 
-Makes textures with formats {{GPUTextureFormat/"r32float"}}, {{GPUTextureFormat/"rg32float"}}, and
-{{GPUTextureFormat/"rgba32float"}} [=filterable=].
+- Makes textures with the following formats [=filterable=]:
+    - {{GPUTextureFormat/"r32float"}}
+    - {{GPUTextureFormat/"rg32float"}}
+    - {{GPUTextureFormat/"rgba32float"}}
 
 <h3 id=float32-blendable data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"float32-blendable"`
 </h3>
 
-Makes textures with formats {{GPUTextureFormat/"r32float"}}, {{GPUTextureFormat/"rg32float"}}, and
-{{GPUTextureFormat/"rgba32float"}} [=blendable=].
+- Makes textures with the following formats [=blendable=]:
+    - {{GPUTextureFormat/"r32float"}}
+    - {{GPUTextureFormat/"rg32float"}}
+    - {{GPUTextureFormat/"rgba32float"}}
 
 <h3 id=dom-gpufeaturename-clip-distances data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"clip-distances"`
 </h3>
 
-Allows the use of [=builtin/clip_distances=] in WGSL.
+- Allows the use of [=builtin/clip_distances=] in WGSL.
 
-This feature adds the following [=optional API surfaces=]:
+New WGSL extensions:
 
-- New WGSL extensions:
-    - [=extension/clip_distances=]
+- [=extension/clip_distances=]
 
 <h3 id=dom-gpufeaturename-dual-source-blending data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"dual-source-blending"`
 </h3>
 
-Allows the use of [=blend_src=] in WGSL and simultaneously using both pixel shader outputs
-(`@blend_src(0)` and `@blend_src(1)`) as inputs to a blending operation with the single color
-attachment at [=location=] `0`.
+- Allows the use of [=blend_src=] in WGSL and simultaneously using both pixel shader outputs
+    (`@blend_src(0)` and `@blend_src(1)`) as inputs to a blending operation with the single color
+    attachment at [=location=] `0`.
 
-This feature adds the following [=optional API surfaces=]:
-- Allows the use of the below {{GPUBlendFactor}}s:
-    - {{GPUBlendFactor/"src1"}}
-    - {{GPUBlendFactor/"one-minus-src1"}}
-    - {{GPUBlendFactor/"src1-alpha"}}
-    - {{GPUBlendFactor/"one-minus-src1-alpha"}}
+New {{GPUBlendFactor}} values:
 
-- New WGSL extensions:
-    - [=extension/dual_source_blending=]
+- {{GPUBlendFactor/"src1"}}
+- {{GPUBlendFactor/"one-minus-src1"}}
+- {{GPUBlendFactor/"src1-alpha"}}
+- {{GPUBlendFactor/"one-minus-src1-alpha"}}
+
+New WGSL extensions:
+
+- [=extension/dual_source_blending=]
 
 <h3 id=subgroups data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"subgroups"`
 <span id=dom-gpufeaturename-subgroups></span>
 </h3>
 
-Allows the use of the subgroup and quad operations in WGSL.
+- Allows the use of the subgroup and quad operations in WGSL.
+- The following entries of {{GPUAdapterInfo}}
+    expose real values whenever the feature is available on the adapter:
+    - {{GPUAdapterInfo/subgroupMinSize}}
+    - {{GPUAdapterInfo/subgroupMaxSize}}
 
-Note: This feature is automatically enabled by {{GPUFeatureName/"subgroup-size-control"}}.
+New WGSL extensions:
 
-This feature adds no [=optional API surfaces=], but the following entries of {{GPUAdapterInfo}}
-expose real values whenever the feature is available on the adapter:
-- {{GPUAdapterInfo/subgroupMinSize}}
-- {{GPUAdapterInfo/subgroupMaxSize}}
-
-- New WGSL extensions:
-    - [=extension/subgroups=]
+- [=extension/subgroups=]
 
 <h3 id=texture-formats-tier1 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-formats-tier1"`
 </h3>
 
-Enabling {{GPUFeatureName/"texture-formats-tier1"}} at device creation will enable
-{{GPUFeatureName/"rg11b10ufloat-renderable"}}. The following items are in addition to that.
-
-Supports the below new {{GPUTextureFormat}}s with the {{GPUTextureUsage/RENDER_ATTACHMENT}},
-[=blendable=], `multisampling` capabilities and the {{GPUTextureUsage/STORAGE_BINDING}} capability
-with the {{GPUStorageTextureAccess/"read-only"}} and {{GPUStorageTextureAccess/"write-only"}}
-{{GPUStorageTextureAccess}}es:
-- {{GPUTextureFormat/"r16unorm"}}
-- {{GPUTextureFormat/"r16snorm"}}
-- {{GPUTextureFormat/"rg16unorm"}}
-- {{GPUTextureFormat/"rg16snorm"}}
-- {{GPUTextureFormat/"rgba16unorm"}}
-- {{GPUTextureFormat/"rgba16snorm"}}
-
-Supports the {{GPUTextureUsage/RENDER_ATTACHMENT}}, [=blendable=], `multisampling` and `resolve`
-capabilities on below {{GPUTextureFormat}}s:
-- {{GPUTextureFormat/"r8snorm"}}
-- {{GPUTextureFormat/"rg8snorm"}}
-- {{GPUTextureFormat/"rgba8snorm"}}
-
-Supports the {{GPUTextureUsage/STORAGE_BINDING}} capability with the {{GPUStorageTextureAccess/"read-only"}} and
-{{GPUStorageTextureAccess/"write-only"}} {{GPUStorageTextureAccess}}es on below {{GPUTextureFormat}}s:
-- {{GPUTextureFormat/"r8unorm"}}
-- {{GPUTextureFormat/"r8snorm"}}
-- {{GPUTextureFormat/"r8uint"}}
-- {{GPUTextureFormat/"r8sint"}}
-- {{GPUTextureFormat/"rg8unorm"}}
-- {{GPUTextureFormat/"rg8snorm"}}
-- {{GPUTextureFormat/"rg8uint"}}
-- {{GPUTextureFormat/"rg8sint"}}
-- {{GPUTextureFormat/"r16uint"}}
-- {{GPUTextureFormat/"r16sint"}}
-- {{GPUTextureFormat/"r16float"}}
-- {{GPUTextureFormat/"rg16uint"}}
-- {{GPUTextureFormat/"rg16sint"}}
-- {{GPUTextureFormat/"rg16float"}}
-- {{GPUTextureFormat/"rgb10a2uint"}}
-- {{GPUTextureFormat/"rgb10a2unorm"}}
-- {{GPUTextureFormat/"rg11b10ufloat"}}
-
-Implicitly allows the following new destination formats in {{GPUQueue/copyExternalImageToTexture()}}:
-- {{GPUTextureFormat/"r16unorm"}}
-- {{GPUTextureFormat/"rg16unorm"}}
-- {{GPUTextureFormat/"rgba16unorm"}}
-
-Note: This feature is automatically enabled by {{GPUFeatureName/"texture-formats-tier2"}}.
+- Enables {{GPUFeatureName/"rg11b10ufloat-renderable"}}.
+- Supports the below new {{GPUTextureFormat}}s with the {{GPUTextureUsage/RENDER_ATTACHMENT}},
+    [=blendable=], `multisampling` capabilities and the {{GPUTextureUsage/STORAGE_BINDING}} capability
+    with the {{GPUStorageTextureAccess/"read-only"}} and {{GPUStorageTextureAccess/"write-only"}}
+    {{GPUStorageTextureAccess}} values:
+    - {{GPUTextureFormat/"r16unorm"}}
+    - {{GPUTextureFormat/"r16snorm"}}
+    - {{GPUTextureFormat/"rg16unorm"}}
+    - {{GPUTextureFormat/"rg16snorm"}}
+    - {{GPUTextureFormat/"rgba16unorm"}}
+    - {{GPUTextureFormat/"rgba16snorm"}}
+- Supports the {{GPUTextureUsage/RENDER_ATTACHMENT}}, [=blendable=], `multisampling` and `resolve`
+    capabilities on below {{GPUTextureFormat}}s:
+    - {{GPUTextureFormat/"r8snorm"}}
+    - {{GPUTextureFormat/"rg8snorm"}}
+    - {{GPUTextureFormat/"rgba8snorm"}}
+- Supports the {{GPUTextureUsage/STORAGE_BINDING}} capability with the {{GPUStorageTextureAccess/"read-only"}} and
+    {{GPUStorageTextureAccess/"write-only"}} {{GPUStorageTextureAccess}}es on below {{GPUTextureFormat}}s:
+    - {{GPUTextureFormat/"r8unorm"}}
+    - {{GPUTextureFormat/"r8snorm"}}
+    - {{GPUTextureFormat/"r8uint"}}
+    - {{GPUTextureFormat/"r8sint"}}
+    - {{GPUTextureFormat/"rg8unorm"}}
+    - {{GPUTextureFormat/"rg8snorm"}}
+    - {{GPUTextureFormat/"rg8uint"}}
+    - {{GPUTextureFormat/"rg8sint"}}
+    - {{GPUTextureFormat/"r16uint"}}
+    - {{GPUTextureFormat/"r16sint"}}
+    - {{GPUTextureFormat/"r16float"}}
+    - {{GPUTextureFormat/"rg16uint"}}
+    - {{GPUTextureFormat/"rg16sint"}}
+    - {{GPUTextureFormat/"rg16float"}}
+    - {{GPUTextureFormat/"rgb10a2uint"}}
+    - {{GPUTextureFormat/"rgb10a2unorm"}}
+    - {{GPUTextureFormat/"rg11b10ufloat"}}
+- Implicitly, allows the following new destination formats in {{GPUQueue/copyExternalImageToTexture()}}:
+    - {{GPUTextureFormat/"r16unorm"}}
+    - {{GPUTextureFormat/"rg16unorm"}}
+    - {{GPUTextureFormat/"rgba16unorm"}}
 
 <h3 id=texture-formats-tier2 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-formats-tier2"`
 </h3>
 
-Enabling {{GPUFeatureName/"texture-formats-tier2"}} at device creation will enable
-{{GPUFeatureName/"texture-formats-tier1"}}. The following items are in addition to that.
-
-Allows the {{GPUStorageTextureAccess/"read-write"}} {{GPUStorageTextureAccess}} on below
-{{GPUTextureFormat}}s:
-- {{GPUTextureFormat/"r8unorm"}}
-- {{GPUTextureFormat/"r8uint"}}
-- {{GPUTextureFormat/"r8sint"}}
-- {{GPUTextureFormat/"rgba8unorm"}}
-- {{GPUTextureFormat/"rgba8uint"}}
-- {{GPUTextureFormat/"rgba8sint"}}
-- {{GPUTextureFormat/"r16uint"}}
-- {{GPUTextureFormat/"r16sint"}}
-- {{GPUTextureFormat/"r16float"}}
-- {{GPUTextureFormat/"rgba16uint"}}
-- {{GPUTextureFormat/"rgba16sint"}}
-- {{GPUTextureFormat/"rgba16float"}}
-- {{GPUTextureFormat/"rgba32uint"}}
-- {{GPUTextureFormat/"rgba32sint"}}
-- {{GPUTextureFormat/"rgba32float"}}
+- Enables {{GPUFeatureName/"texture-formats-tier1"}}.
+- Allows the {{GPUStorageTextureAccess/"read-write"}} {{GPUStorageTextureAccess}} on below
+    {{GPUTextureFormat}}s:
+    - {{GPUTextureFormat/"r8unorm"}}
+    - {{GPUTextureFormat/"r8uint"}}
+    - {{GPUTextureFormat/"r8sint"}}
+    - {{GPUTextureFormat/"rgba8unorm"}}
+    - {{GPUTextureFormat/"rgba8uint"}}
+    - {{GPUTextureFormat/"rgba8sint"}}
+    - {{GPUTextureFormat/"r16uint"}}
+    - {{GPUTextureFormat/"r16sint"}}
+    - {{GPUTextureFormat/"r16float"}}
+    - {{GPUTextureFormat/"rgba16uint"}}
+    - {{GPUTextureFormat/"rgba16sint"}}
+    - {{GPUTextureFormat/"rgba16float"}}
+    - {{GPUTextureFormat/"rgba32uint"}}
+    - {{GPUTextureFormat/"rgba32sint"}}
+    - {{GPUTextureFormat/"rgba32float"}}
 
 <h3 id=dom-gpufeaturename-primitive-index data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"primitive-index"`
 </h3>
 
-Allows the use of [=builtin/primitive_index=] in WGSL.
+- Allows the use of [=builtin/primitive_index=] in WGSL.
 
-This feature adds the following [=optional API surfaces=]:
+New WGSL extensions:
 
-- New WGSL extensions:
-    - [=extension/primitive_index=]
+- [=extension/primitive_index=]
 
 <h3 id=dom-gpufeaturename-texture-component-swizzle data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-component-swizzle"`
 </h3>
 
-Allows {{GPUTextureView}}s to rearrange or replace the color components from texture's red/green/blue/alpha channels
-when used as a {{GPUTextureUsage/TEXTURE_BINDING}}.
+- Allows {{GPUTextureView}}s to rearrange or replace the color components from texture's red/green/blue/alpha channels
+    when used as a {{GPUTextureUsage/TEXTURE_BINDING}}.
+- Defines previously-implementation-defined behavior when [[#reading-depth-stencil]].
 
-Also defines previously-implementation-defined behavior when [[#reading-depth-stencil]].
+New {{GPUTextureViewDescriptor}} dictionary members:
 
-This feature adds the following [=optional API surfaces=]:
-
-- New {{GPUTextureViewDescriptor}} dictionary members:
-    - {{GPUTextureViewDescriptor/swizzle}}
+- {{GPUTextureViewDescriptor/swizzle}}
 
 <h3 id=dom-gpufeaturename-subgroup-size-control data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"subgroup-size-control"`
 </h3>
 
-Allows the use of the [=attribute/subgroup_size=] attribute in WGSL to control compute pipeline subgroup size.
+- Enables {{GPUFeatureName/"subgroups"}}.
+- Allows the use of the [=attribute/subgroup_size=] attribute in WGSL to control compute pipeline subgroup size.
 
-Enabling {{GPUFeatureName/"subgroup-size-control"}} at device creation will enable
-{{GPUFeatureName/"subgroups"}}.
+New WGSL extensions:
 
-This feature adds no [=optional API surfaces=].
-
-- New WGSL extensions:
-    - [=extension/subgroup_size_control=]
+- [=extension/subgroup_size_control=]
 
 <!-- IMPORTANT: When adding a new feature here, also update the GPUFeatureName definition. -->
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17261,7 +17261,10 @@ Dependencies between features are described in [[#feature-dependencies]] and enf
 
 When enabled:
 
-- Allows all Core WebGPU features and limits to be used.
+- Lifts extra validation rules that are specific to WebGPU [=feature level string/"compatibility"=] mode.
+    These are not enumerated here; see references to {{GPUFeatureName/"core-features-and-limits"}} throughout the spec.
+- Ensures all limits are set to their [=limit/default=] value
+    (rather than their [=limit/compatibility mode default=] value), or [=limit/better=] if requested.
 
 Note:
 This feature is always available when calling {{GPU/requestAdapter()}} with no arguments.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -17248,7 +17248,7 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 
 # Feature Index # {#feature-index}
 
-*This section non-normative.*
+*This section is non-normative.*
 
 This section describes what is enabled by each feature in {{GPUFeatureName}}.
 Normative behavior is found in the relevant spec sections.
@@ -17259,14 +17259,20 @@ Dependencies between features are described in [[#feature-dependencies]] and enf
 <h3 id=core-features-and-limits data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"core-features-and-limits"`
 </h3>
 
+When enabled:
+
 - Allows all Core WebGPU features and limits to be used.
 
-This is always available unless {{GPURequestAdapterOptions/featureLevel}} is set to [=feature level string/"compatibility"=],
-in which case it may or may not be available (see those definitions for information).
+Note:
+This feature is always available when calling {{GPU/requestAdapter()}} with no arguments.
+It may only be unavailable if {{GPURequestAdapterOptions/featureLevel}} is set to [=feature level string/"compatibility"=],
+in which case its availability depends on the system. See those definitions for details.
 
 <h3 id=depth-clip-control data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"depth-clip-control"`
 <span id=dom-gpufeaturename-depth-clip-control></span>
 </h3>
+
+When enabled:
 
 - Allows [=depth clipping=] to be disabled.
 
@@ -17278,6 +17284,8 @@ New {{GPUPrimitiveState}} dictionary members:
 <span id=dom-gpufeaturename-depth32float-stencil8></span>
 </h3>
 
+When enabled:
+
 - Allows for explicit creation of textures of format {{GPUTextureFormat/"depth32float-stencil8"}}.
 
 New {{GPUTextureFormat}} enum values:
@@ -17288,11 +17296,14 @@ New {{GPUTextureFormat}} enum values:
 <span id=dom-gpufeaturename-texture-compression-bc></span>
 </h3>
 
+When enabled:
+
 - Allows for explicit creation of textures of [=BC compressed formats=] which include the "S3TC",
     "RGTC", and "BPTC" formats.
 
-This feature only supports 2D textures. If 3D textures are needed, use
-{{GPUFeatureName/"texture-compression-bc-sliced-3d"}}.
+    Note:
+    This feature only supports 2D textures. If 3D textures are needed, use
+    {{GPUFeatureName/"texture-compression-bc-sliced-3d"}}.
 
 New {{GPUTextureFormat}} enum values:
 
@@ -17315,6 +17326,8 @@ New {{GPUTextureFormat}} enum values:
 <span id=dom-gpufeaturename-texture-compression-bc-sliced-3d></span>
 </h3>
 
+When enabled:
+
 - Allows the {{GPUTextureDimension/3d}} dimension for textures with [=BC compressed formats=].
 
 <h3 id=texture-compression-etc2 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-etc2"`
@@ -17322,9 +17335,12 @@ New {{GPUTextureFormat}} enum values:
 <span id=dom-gpufeaturename-texture-compression-etc2></span>
 </h3>
 
+When enabled:
+
 - Allows for explicit creation of textures of [=ETC2 compressed formats=].
 
-This feature only supports 2D textures.
+    Note:
+    This feature only supports 2D textures.
 
 New {{GPUTextureFormat}} enum values:
 
@@ -17343,10 +17359,13 @@ New {{GPUTextureFormat}} enum values:
 <span id=dom-gpufeaturename-texture-compression-astc></span>
 </h3>
 
+When enabled:
+
 - Allows for explicit creation of textures of [=ASTC compressed formats=].
 
-This feature only supports 2D textures. If 3D textures are needed, use
-{{GPUFeatureName/"texture-compression-astc-sliced-3d"}}.
+    Note:
+    This feature only supports 2D textures. If 3D textures are needed, use
+    {{GPUFeatureName/"texture-compression-astc-sliced-3d"}}.
 
 New {{GPUTextureFormat}} enum values:
 
@@ -17383,11 +17402,15 @@ New {{GPUTextureFormat}} enum values:
 <span id=dom-gpufeaturename-texture-compression-astc-sliced-3d></span>
 </h3>
 
+When enabled:
+
 - Allows the {{GPUTextureDimension/3d}} dimension for textures with [=ASTC compressed formats=].
 
 <h3 id=timestamp-query data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"timestamp-query"`
 <span id=dom-gpufeaturename-timestamp-query></span>
 </h3>
+
+When enabled:
 
 - Adds the ability to query timestamps from GPU command buffers. See [[#timestamp]].
 
@@ -17407,11 +17430,15 @@ New {{GPURenderPassDescriptor}} members:
 <span id=dom-gpufeaturename-indirect-first-instance></span>
 </h3>
 
+When enabled:
+
 - Allows the use of non-zero `firstInstance` values in [=indirect draw parameters=] and [=indirect drawIndexed parameters=].
 
 <h3 id=shader-f16 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"shader-f16"`
 <span id=dom-gpufeaturename-shader-f16></span>
 </h3>
+
+When enabled:
 
 - Allows the use of the half-precision floating-point type [=f16=] in WGSL.
 
@@ -17423,17 +17450,24 @@ New WGSL extensions:
 <span id=dom-gpufeaturename-rg11b10ufloat-renderable></span>
 </h3>
 
+When enabled:
+
 - Allows the {{GPUTextureUsage/RENDER_ATTACHMENT}} usage on textures with format {{GPUTextureFormat/"rg11b10ufloat"}},
     and also allows textures of that format to be blended, multisampled, and resolved.
-- Implicitly, allows {{GPUTextureFormat/"rg11b10ufloat"}} as a destination format in {{GPUQueue/copyExternalImageToTexture()}}.
+
+    Implicitly, this allows {{GPUTextureFormat/"rg11b10ufloat"}} as a destination format in {{GPUQueue/copyExternalImageToTexture()}}.
 
 <h3 id=bgra8unorm-storage data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"bgra8unorm-storage"`
 </h3>
+
+When enabled:
 
 - Allows the {{GPUTextureUsage/STORAGE_BINDING}} usage on textures with format {{GPUTextureFormat/"bgra8unorm"}}.
 
 <h3 id=float32-filterable data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"float32-filterable"`
 </h3>
+
+When enabled:
 
 - Makes textures with the following formats [=filterable=]:
     - {{GPUTextureFormat/"r32float"}}
@@ -17443,6 +17477,8 @@ New WGSL extensions:
 <h3 id=float32-blendable data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"float32-blendable"`
 </h3>
 
+When enabled:
+
 - Makes textures with the following formats [=blendable=]:
     - {{GPUTextureFormat/"r32float"}}
     - {{GPUTextureFormat/"rg32float"}}
@@ -17450,6 +17486,8 @@ New WGSL extensions:
 
 <h3 id=dom-gpufeaturename-clip-distances data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"clip-distances"`
 </h3>
+
+When enabled:
 
 - Allows the use of [=builtin/clip_distances=] in WGSL.
 
@@ -17459,6 +17497,8 @@ New WGSL extensions:
 
 <h3 id=dom-gpufeaturename-dual-source-blending data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"dual-source-blending"`
 </h3>
+
+When enabled:
 
 - Allows the use of [=blend_src=] in WGSL and simultaneously using both pixel shader outputs
     (`@blend_src(0)` and `@blend_src(1)`) as inputs to a blending operation with the single color
@@ -17479,6 +17519,8 @@ New WGSL extensions:
 <span id=dom-gpufeaturename-subgroups></span>
 </h3>
 
+When enabled:
+
 - Allows the use of the subgroup and quad operations in WGSL.
 - The following entries of {{GPUAdapterInfo}}
     expose real values whenever the feature is available on the adapter:
@@ -17492,6 +17534,8 @@ New WGSL extensions:
 <h3 id=texture-formats-tier1 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-formats-tier1"`
 </h3>
 
+When enabled:
+
 - Enables {{GPUFeatureName/"rg11b10ufloat-renderable"}}.
 - Supports the below new {{GPUTextureFormat}}s with the {{GPUTextureUsage/RENDER_ATTACHMENT}},
     [=blendable=], `multisampling` capabilities and the {{GPUTextureUsage/STORAGE_BINDING}} capability
@@ -17503,6 +17547,11 @@ New WGSL extensions:
     - {{GPUTextureFormat/"rg16snorm"}}
     - {{GPUTextureFormat/"rgba16unorm"}}
     - {{GPUTextureFormat/"rgba16snorm"}}
+
+    Implicitly, this allows the following new destination formats in {{GPUQueue/copyExternalImageToTexture()}}:
+    - {{GPUTextureFormat/"r16unorm"}}
+    - {{GPUTextureFormat/"rg16unorm"}}
+    - {{GPUTextureFormat/"rgba16unorm"}}
 - Supports the {{GPUTextureUsage/RENDER_ATTACHMENT}}, [=blendable=], `multisampling` and `resolve`
     capabilities on below {{GPUTextureFormat}}s:
     - {{GPUTextureFormat/"r8snorm"}}
@@ -17527,13 +17576,11 @@ New WGSL extensions:
     - {{GPUTextureFormat/"rgb10a2uint"}}
     - {{GPUTextureFormat/"rgb10a2unorm"}}
     - {{GPUTextureFormat/"rg11b10ufloat"}}
-- Implicitly, allows the following new destination formats in {{GPUQueue/copyExternalImageToTexture()}}:
-    - {{GPUTextureFormat/"r16unorm"}}
-    - {{GPUTextureFormat/"rg16unorm"}}
-    - {{GPUTextureFormat/"rgba16unorm"}}
 
 <h3 id=texture-formats-tier2 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-formats-tier2"`
 </h3>
+
+When enabled:
 
 - Enables {{GPUFeatureName/"texture-formats-tier1"}}.
 - Allows the {{GPUStorageTextureAccess/"read-write"}} {{GPUStorageTextureAccess}} on below
@@ -17557,6 +17604,8 @@ New WGSL extensions:
 <h3 id=dom-gpufeaturename-primitive-index data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"primitive-index"`
 </h3>
 
+When enabled:
+
 - Allows the use of [=builtin/primitive_index=] in WGSL.
 
 New WGSL extensions:
@@ -17565,6 +17614,8 @@ New WGSL extensions:
 
 <h3 id=dom-gpufeaturename-texture-component-swizzle data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-component-swizzle"`
 </h3>
+
+When enabled:
 
 - Allows {{GPUTextureView}}s to rearrange or replace the color components from texture's red/green/blue/alpha channels
     when used as a {{GPUTextureUsage/TEXTURE_BINDING}}.
@@ -17577,6 +17628,8 @@ New {{GPUTextureViewDescriptor}} dictionary members:
 <h3 id=dom-gpufeaturename-subgroup-size-control data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"subgroup-size-control"`
 </h3>
 
+When enabled:
+
 - Enables {{GPUFeatureName/"subgroups"}}.
 - Allows the use of the [=attribute/subgroup_size=] attribute in WGSL to control compute pipeline subgroup size.
 
@@ -17584,7 +17637,8 @@ New WGSL extensions:
 
 - [=extension/subgroup_size_control=]
 
-<!-- IMPORTANT: When adding a new feature here, also update the GPUFeatureName definition. -->
+<!-- IMPORTANT: Follow the style of features above. Note this section is always non-normative.
+    When adding a new feature here, also update the GPUFeatureName definition. -->
 
 # Appendices # {#appendices}
 


### PR DESCRIPTION
Editorial tangent to #6344

- Make the Feature Index non-normative - it's a summary of stuff in other parts of the spec.
- Make the list of API changes a list, so that other notes about the feature are visually distinct from them.
  - Note this still includes dependency info (but not reverse-dependency info) as otherwise it's hard to understand.