### PR TITLE
[wgsl] Auto-enable dependent features

### DIFF
--- a/proposals/subgroup-matrix.md
+++ b/proposals/subgroup-matrix.md
@@ -167,7 +167,7 @@ and limited use of some scalar types (u8 and i8).
 Implicitly depends on subgroups.
 WGSL does not require any subgroups enable, but the API does.
 
-Automatically enabled `subgroups` extension.
+Automatically enables `subgroups` extension.
 
 
 #### Types

--- a/proposals/subgroup-matrix.md
+++ b/proposals/subgroup-matrix.md
@@ -167,6 +167,8 @@ and limited use of some scalar types (u8 and i8).
 Implicitly depends on subgroups.
 WGSL does not require any subgroups enable, but the API does.
 
+Automatically enabled `subgroups` extension.
+
 
 #### Types
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1877,8 +1877,8 @@ The valid [=enable-extensions=] are listed in the following table.
       <td>{{GPUFeatureName/"subgroup-size-control"}}
       <td>The attribute [=attribute/subgroup_size=] is valid to use in the WGSL module.
         Otherwise, using [=attribute/subgroup_size=] will result in a [=shader-creation error=].
-        [=shader-creation error|Must=] be enabled together with the [=extension/subgroups=] extension.
-        Otherwise, enabling [=extension/subgroup_size_control=] will result in a [=shader-creation error=].
+        The [=extension/subgroups=] [=behavioral requirement|will=] be automatically enabled when
+        `subgroup_size_control` is enabled.
 </table>
 
 <div class='example wgsl using extensions expect-error' heading="Using hypothetical enable-extensions">


### PR DESCRIPTION
Fixes #6347

* Auto-enable subgroups when subgroup_size_control is enabled
* Update subgroup_matrix proposal for similar enablement of subgroups