### PR TITLE
Adds the `snorm10-10-10-2` vertex format to the WebGPU specification and WebIDL definition.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9921,6 +9921,7 @@ enum GPUVertexFormat {
     "sint32x4",
     "unorm10-10-10-2",
     "unorm8x4-bgra",
+    "snorm10-10-10-2",
 };
 </script>
 
@@ -10177,6 +10178,12 @@ enum GPUVertexFormat {
         <tr>
             <td><dfn>"unorm8x4-bgra"</dfn>
             <td>unsigned normalized
+            <td>4
+            <td>4
+            <td><code>vec4&lt;f32&gt;</code>
+        <tr>
+            <td><dfn>"snorm10-10-10-2"</dfn>
+            <td>signed normalized
             <td>4
             <td>4
             <td><code>vec4&lt;f32&gt;</code>


### PR DESCRIPTION
* Adds `"snorm10-10-10-2"` to `enum GPUVertexFormat`.
* Adds `snorm10-10-10-2` row to the Vertex Formats table (signed normalized, 4 components, 4 bytes,`vec4<f32>`).

Fixes [#6292](https://github.com/gpuweb/gpuweb/issues/6292)